### PR TITLE
🎨 Minor messaging improvements

### DIFF
--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -26,11 +26,12 @@ module.exports.Command = BaseCommand.extend({
     prompts: [{
         type: 'input',
         name: 'url',
-        message: 'What is your blog url?',
+        message: 'Enter your blog URL:',
+        default: 'http://localhost:2368',
         validate: function (value) {
             return validator.isURL(value, {
                 require_protocol: true
-            }) || 'Invalid url!';
+            }) || 'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com';
         }
     }],
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -61,7 +61,7 @@ module.exports.Command = BaseCommand.extend({
                 module: 'ghost',
                 version: version,
                 destination: installPath
-            }, 'Downloading and installing Ghost');
+            }, 'Downloading and installing Ghost v' + version);
         }).then(function moveCasper() {
             var move = Promise.promisify(fs.move);
 

--- a/test/acceptance/config-spec.js
+++ b/test/acceptance/config-spec.js
@@ -94,13 +94,13 @@ describe('Acceptance: Config', function () {
         it('prompts for host and saves correctly', function () {
             return run('config', {
                 stdin: [
-                    {when: /What is your blog url\?/gi, write: 'http://cli-test.com'}
+                    {when: /Enter your blog URL:/gi, write: 'http://cli-test.com'}
                 ]
             }).then(function afterConfig(result) {
                 var contents;
 
                 expect(result.stdout, 'output exists').to.be.ok;
-                expect(chalk.stripColor(result.stdout), 'value').to.match(/What is your blog url\?/);
+                expect(chalk.stripColor(result.stdout), 'value').to.match(/Enter your blog URL:/);
 
                 contents = fs.readJsonSync(env.path('config.production.json'));
                 expect(contents, 'config contents').to.be.ok;


### PR DESCRIPTION
- Output version information when install/downloading
- Include a default when prompting for URL

Note, locally when running the tests, even on master I get a failure:

```
  1) Unit: npm correctly captures the npm output and returns it when output is a string:
     TypeError: this is not a typed array.
      at Function.from (native)
      at Context.<anonymous> (test/unit/utils/npm-spec.js:155:43)
```

