### PR TITLE
Updates for Ghost alpha 8

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -53,17 +53,24 @@ module.exports.Command = BaseCommand.extend({
                     process.exit(1);
                 });
 
-                // TODO: once Ghost itself supports sending messages to parent
-                // process upon successful startup, change this to wait for Ghost
-                // to send a message
-                if (process.send) {
-                    process.send({started: true});
-                }
+                self.child.on('message', function (message) {
+                    console.log(message);
+                    if (message.started) {
+                        self.sendMessage(message);
+                        return;
+                    }
+
+                    self.sendMessage({started: false, error: message.error});
+                });
             }).catch(function (error) {
-                if (process.send) {
-                    process.send({error: true, message: error.message});
-                }
+                this.sendMessage({started: false, error: error.message});
             });
+    },
+
+    sendMessage: function sendMessage(message) {
+        if (process.send) {
+            process.send(message);
+        }
     },
 
     exit: function exit() {

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -20,11 +20,13 @@ module.exports.Command = BaseCommand.extend({
             'production' : 'development';
 
         var KnexMigrator = require('knex-migrator'),
-            merge = require('lodash/merge'),
             spawn = require('child_process').spawn,
             path = require('path'),
             self = this,
             knexMigrator;
+
+        // knex-migrator needs to know the content path
+        process.env.paths__contentPath = path.join(process.cwd(), 'content');
 
         knexMigrator = new KnexMigrator({
             knexMigratorFilePath: path.join(process.cwd(), 'current')
@@ -42,10 +44,7 @@ module.exports.Command = BaseCommand.extend({
             }).then(function () {
                 self.child = spawn(process.execPath, ['current/index.js'], {
                     cwd: process.cwd(),
-                    stdio: [0, 1, 2, 'ipc'],
-                    env: merge({
-                        paths__contentPath: path.join(process.cwd(), 'content')
-                    }, process.env)
+                    stdio: [0, 1, 2, 'ipc']
                 });
 
                 self.child.on('error', function (error) {
@@ -54,7 +53,6 @@ module.exports.Command = BaseCommand.extend({
                 });
 
                 self.child.on('message', function (message) {
-                    console.log(message);
                     if (message.started) {
                         self.sendMessage(message);
                         return;

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -18,15 +18,20 @@ module.exports.Command = BaseCommand.extend({
         this.checkValidInstall();
 
         var local = options.local || false,
-            self = this,
             Promise = require('bluebird'),
-            config;
+            path = require('path'),
+            self = this;
 
         delete options.local;
 
-        config = (local) ? Promise.resolve() : this.runCommand('config', null, null, options);
+        if (local) {
+            options.url = 'http://localhost:2368/',
+            options.db = 'sqlite3',
+            options.dbpath = path.join(process.cwd(), 'content/data/ghost-local.db');
+            options.environment = 'development';
+        }
 
-        return config.then(function afterConfig() {
+        return this.runCommand('config', null, null, options).then(function afterConfig() {
             // If 'local' is specified we will automatically start ghost
             if (local) {
                 return Promise.resolve({start: true});

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -40,7 +40,6 @@ module.exports.Command = BaseCommand.extend({
 
         pm = resolveProcessManager(config);
 
-        // TODO: rethink this
         return self.ui.run(
             Promise.resolve(pm.start(process.cwd(), environment)),
             'Starting Ghost instance'

--- a/lib/process/local.js
+++ b/lib/process/local.js
@@ -28,7 +28,7 @@ module.exports = BaseProcess.extend({
                 if (msg.error) {
                     fs.unlinkSync(path.join(cwd, PID_FILE));
 
-                    reject(msg.message);
+                    reject(msg.error);
                 }
 
                 if (msg.started) {

--- a/lib/utils/resolve-version.js
+++ b/lib/utils/resolve-version.js
@@ -1,7 +1,7 @@
 var semver = require('semver'),
     Promise = require('bluebird'),
     npm = require('./npm'),
-    MIN_RELEASE = '>= 1.0.0-alpha.5';
+    MIN_RELEASE = '>= 1.0.0-alpha.8';
 
 module.exports = function resolveVersion(version, update) {
     // If version contains a leading v, remove it

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "inquirer": "1.2.2",
     "lodash": "4.16.6",
     "log-symbols": "1.0.2",
-    "knex-migrator": "0.1.2",
+    "knex-migrator": "0.2.0",
     "npm": "2.15.11",
     "semver": "5.3.0",
     "symlink-or-copy": "1.1.6",


### PR DESCRIPTION
closes #66,#61
- breaking: won't work with any ghost versions < 1.0.0-alpha.8

Release once Ghost 1.0.0-alpha.8 has been released