### PR TITLE
Add ghost system stack checks to setup

### DIFF
--- a/lib/commands/doctor/checks/setup.js
+++ b/lib/commands/doctor/checks/setup.js
@@ -1,0 +1,40 @@
+module.exports = {
+    checks: [
+        function systemStack() {
+            var os = require('os'),
+                chalk = require('chalk'),
+                Promise = require('bluebird'),
+                symbols = require('log-symbols'),
+                exec = Promise.promisify(require('child_process').exec),
+                errors = [];
+
+            // Because we use `lsb_release` to determine the platform,
+            // platform is not linux we just return an error
+            if (os.platform() !== 'linux') {
+                return chalk.yellow(symbols.warning + ' Platform is not Linux');
+            }
+
+            return exec('lsb_release -a').then(function (stdout) {
+                if (!stdout.match(/Ubuntu 16/)) {
+                    errors.push(chalk.yellow(symbols.warning + ' Linux version is not Ubuntu 16'));
+                }
+
+                function checkPackage(name) {
+                    return exec('dpkg -l | grep ' + name).catch(function (error) {
+                        if (error.code === 1) {errors.push(chalk.yellow(symbols.warning + ' Missing package: ' + name));}
+                    });
+                }
+
+                return Promise.all([
+                    checkPackage('systemd'),
+                    checkPackage('nginx')
+                ]);
+            }).then(function () {
+                return errors.length ? errors.join(os.eol) : true;
+            });
+        }
+    ],
+    messages: {
+        systemStack: 'System is running Ghost recommended system stack'
+    }
+};

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -17,6 +17,10 @@ module.exports = {
         alias: 'N',
         description: 'Don\'t automatically run the setup command',
         flag: true
+    }, {
+        name: 'no-stack',
+        description: 'Don\'t check the system stack on setup',
+        flag: true
     }].concat(advancedOptions)
 };
 

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -6,6 +6,10 @@ module.exports = {
     description: 'setup an installation of Ghost (after it is installed)',
 
     options: [{
+        name: 'no-stack',
+        description: 'Don\'t check the system stack on setup',
+        flag: true
+    }, {
         name: 'local',
         alias: 'l',
         description: 'Quick setup for a local installation of Ghost',
@@ -32,7 +36,26 @@ module.exports.Command = BaseCommand.extend({
             options.environment = 'development';
         }
 
-        return this.runCommand('config', null, null, options).then(function afterConfig() {
+        return this.runCommand('config', null, null, options).then(function setupChecks() {
+            if (!options.stack) {
+                return Promise.resolve();
+            }
+
+            return self.runCommand('doctor', 'setup').catch(function sysStackError(error) {
+                if (error) {throw error;}
+
+                self.ui.log(
+                    'You are attempting to setup Ghost on a different system stack than is recommended\n' +
+                    'If you are simply missing items, please install them and run `ghost setup` again\n' +
+                    'However, if you wish to proceed on a different system stack, run `ghost setup --no-stack`\n' +
+                    'Note, however, that certain CLI features may not work as well, or at all\n',
+                    // TODO: add link to documentation
+                    'yellow'
+                );
+
+                return Promise.reject();
+            });
+        }).then(function afterConfig() {
             // If 'local' is specified we will automatically start ghost
             if (local) {
                 return Promise.resolve({start: true});


### PR DESCRIPTION
refs #64
- add `--no-stack` flag to install and setup commands to override system
checks
- add checks for ubuntu version, systemd, and nginx
- output helpful error message if stack is not recommended