### PR TITLE
Use `npm.cmd` instead of `npm` on Windows

### DIFF
--- a/lib/utils/npm.js
+++ b/lib/utils/npm.js
@@ -24,7 +24,8 @@ module.exports = function npm(npmArgs, npmConfig, options) {
     options.env = merge(options.env || {}, env);
 
     return new Promise(function runNpm(resolve, reject) {
-        var cp = spawn(path.resolve(__dirname, '../../node_modules/.bin/npm'), npmArgs, options),
+        var npmBinary = /^win*/.test(process.platform) ? 'npm.cmd' : 'npm',
+            cp = spawn(path.resolve(__dirname, '../../node_modules/.bin', npmBinary), npmArgs, options),
             output, ws, isString;
 
         if (captureOutput) {


### PR DESCRIPTION
Fixes #53.

It turns out the name of the binary on Windows platforms is different to *nix platforms.

Tested on Windows 7 (~~lame~~, I mean it's kind of old, I should update it 😅 ) with Node v6.9.1 and npm v3.10.8.

Would love to hear feedbacks on how this works on other Windows platforms.