### PR TITLE
🐛 don’t mutate process.env using lodash methods

### DIFF
--- a/lib/process/local.js
+++ b/lib/process/local.js
@@ -15,7 +15,7 @@ class LocalProcess extends BaseProcess {
                 cwd: cwd,
                 detached: true,
                 stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
-                env: assign({NODE_ENV: environment}, process.env)
+                env: assign({}, process.env, {NODE_ENV: environment})
             });
 
             fs.writeFileSync(path.join(cwd, PID_FILE), cp.pid);

--- a/lib/utils/yarn.js
+++ b/lib/utils/yarn.js
@@ -1,5 +1,5 @@
 'use strict';
-const merge = require('lodash/merge');
+const assign = require('lodash/assign');
 const execa = require('execa');
 const Observable = require('rxjs').Observable;
 
@@ -11,7 +11,7 @@ module.exports = function yarn(yarnArgs, options) {
     delete options.observe;
 
     yarnArgs = yarnArgs || [];
-    options.env = merge(env, options.env || {});
+    options.env = assign({}, env, options.env || {});
 
     let cp = execa('yarn', yarnArgs, options);
 

--- a/test/unit/utils/yarn-spec.js
+++ b/test/unit/utils/yarn-spec.js
@@ -56,4 +56,18 @@ describe('Unit: yarn', function () {
             expect(execa.args[0][2].cwd).to.equal('test');
         });
     });
+
+    it('respects process.env overrides but doesn\'t mutate process.env', function () {
+        process.env.TESTENV = 'test';
+
+        let promise = yarn([], {env: {TESTENV: 'override'}});
+
+        return promise.then(() => {
+            expect(execa.calledOnce).to.be.true;
+            expect(execa.args[0][2]).to.be.an('object');
+            expect(execa.args[0][2].env).to.be.an('object');
+            expect(execa.args[0][2].env.TESTENV).to.equal('override');
+            expect(process.env.TESTENV).to.equal('test');
+        });
+    });
 });


### PR DESCRIPTION
refs #104
- ensure usages of `assign` don’t overwrite existing objects

TODO:
- [ ] add a test to make sure this doesn't happen again 😛 