### PR TITLE
🎨 ✨ improve process manager handling on unsupported environments

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -19,7 +19,7 @@ module.exports.execute = function execute() {
     let knexMigrator = new KnexMigrator({
         knexMigratorFilePath: path.join(process.cwd(), 'current')
     });
-    let processManager = resolveProcessManager(config);
+    let processManager = resolveProcessManager(config, this.ui);
 
     return knexMigrator.isDatabaseOK().catch((error) => {
         if (error.code === 'DB_NOT_INITIALISED' ||

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -70,7 +70,7 @@ module.exports.execute = function execute(options) {
     }).then((answer) => {
         context.start = context.start || answer.start;
 
-        let processManager = resolveProcessManager(context.config);
+        let processManager = resolveProcessManager(context.config, this.ui);
 
         return this.ui.run(processManager.setup(this.environment), 'Finishing setup');
     }).then(() => {

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -15,7 +15,7 @@ module.exports.execute = function execute(options) {
         return Promise.reject(new Error('Ghost is already running.'));
     }
 
-    let processManager = resolveProcessManager(config);
+    let processManager = resolveProcessManager(config, this.ui);
     let start = Promise.resolve(processManager.start(process.cwd(), this.environment)).then(() => {
         cliConfig.set('running', this.environment).save();
         // TODO: add process info to global cli file so Ghost-CLI is aware of this instance

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -15,7 +15,7 @@ module.exports.execute = function execute(options) {
     }
 
     let config = Config.load(`config.${cliConfig.get('running')}.json`);
-    let processManager = resolveProcessManager(config);
+    let processManager = resolveProcessManager(config, this.ui);
     let stop = Promise.resolve(processManager.stop(process.cwd())).then(() => {
         cliConfig.set('running', null).save();
         return Promise.resolve();

--- a/lib/process/index.js
+++ b/lib/process/index.js
@@ -26,6 +26,16 @@ class BaseProcess {
     setup() {
         // Base implementation - noop
     }
+
+    /**
+     * This function checks if this process manager can be used on this system
+     *
+     * @return {Boolean} whether or not the process manager can be used
+     */
+    checkUsability() {
+        // Base implementation - return true
+        return true;
+    }
 };
 
 module.exports = BaseProcess;

--- a/lib/process/systemd/index.js
+++ b/lib/process/systemd/index.js
@@ -49,6 +49,15 @@ class SystemdProcess extends BaseProcess {
             stdio: ['inherit', 'inherit', 'inherit']
         });
     }
+
+    checkUsability() {
+        try {
+            execSync('which systemctl', {stdio: 'ignore'});
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
 };
 
 module.exports = SystemdProcess;

--- a/lib/utils/resolve-process.js
+++ b/lib/utils/resolve-process.js
@@ -24,7 +24,7 @@ function hasRequiredFns(pm) {
     return unimplementedMethods;
 }
 
-module.exports = function resolveProcessManager(config) {
+module.exports = function resolveProcessManager(config, ui) {
     let manager = config.get('process', 'systemd');
     let ProcessManager;
 
@@ -49,6 +49,16 @@ module.exports = function resolveProcessManager(config) {
 
     if (missingFns.length) {
         throw new Error(`Configured manager ${manager} is missing the following required methods: ${missingFns.join(', ')}`);
+    }
+
+    if (!pmInstance.checkUsability()) {
+        ui.log(`The '${manager}' process manager does not work on this system, defaulting to 'local'`, 'yellow');
+        // You may notice that we don't save the config here - this is in an effort to reduce duplicate error logs
+        // TODO: this is probably not the best practice, should likely fix.
+        config.set('process', 'local');
+        let LocalProcess = require(knownManagers.local);
+
+        return new LocalProcess(config);
     }
 
     return pmInstance;


### PR DESCRIPTION
no issue
- on non-systemd systems, the systemd process manager would still try to set itself up the normal way if the user said “Continue Anyways”
- this update allows process managers to check if they are usable on the system. If not, the process manager resolver logs a warning and defaults to the local process manager
- adds a #checkUsability function to the BaseProcess class (returns true by default)