### PR TITLE
Multi-install management improvements

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -87,6 +87,9 @@ function loadCommands(commands, program) {
             context.development = (process.env.NODE_ENV === 'development') || options.parent.development;
             context.environment = context.development ? 'development' : 'production';
 
+            // Set NODE_ENV so it's accessible everywhere
+            process.env.NODE_ENV = context.environment;
+
             if (command.exit && _.isFunction(command.exit)) {
                 // process.on('exit') is unreliable apparently, so we do this
                 process.removeAllListeners('SIGINT').on('SIGINT', command.exit)

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -51,6 +51,10 @@ module.exports = {
         }].concat(advancedOptions)
     },
 
+    ls: {
+        description: 'view running ghost processes'
+    },
+
     restart: {
         description: 'Restart the Ghost instance'
     },

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -83,7 +83,14 @@ module.exports = {
     },
 
     stop: {
-        description: 'stops a named instance of Ghost'
+        description: 'stops a named instance of Ghost',
+
+        options: [{
+            name: 'all',
+            alias: 'a',
+            description: 'option to stop all running Ghost blogs',
+            flag: true
+        }]
     },
 
     update: {

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -1,0 +1,18 @@
+'use strict';
+const each = require('lodash/each');
+const Config = require('../utils/config');
+
+module.exports.execute = function execute() {
+    let systemConfig = Config.load('system');
+    let rows = [];
+    let i = 1;
+
+    each(systemConfig.get('instances', {}), (instance, cwd) => {
+        rows.push([i, instance.url, instance.port, instance.mode, instance.process, cwd]);
+        i += 1;
+    });
+
+    this.ui.table(['#', 'Url', 'Port', 'Environment', 'Process Manager', 'Location'], rows, {
+        style: {head: ['cyan']}
+    });
+};

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -1,13 +1,13 @@
 'use strict';
 const path = require('path');
-const spawn = require('child_process').spawn;
 const KnexMigrator = require('knex-migrator');
 
 const Config = require('../utils/config');
+const Instance = require('../utils/instance');
 const checkValidInstall     = require('../utils/check-valid-install');
 const resolveProcessManager = require('../utils/resolve-process');
 
-let child;
+let instance;
 
 module.exports.execute = function execute() {
     checkValidInstall('run');
@@ -29,31 +29,14 @@ module.exports.execute = function execute() {
             return knexMigrator.migrate();
         }
     }).then(() => {
-        child = spawn(process.execPath, ['current/index.js'], {
-            cwd: process.cwd(),
-            stdio: [0, 1, 2, 'ipc']
-        });
-
-        child.on('error', (error) => {
-            this.ui.fail(error);
-            process.exit(1);
-        });
-
-        child.on('message', (message) => {
-            if (message.started) {
-                processManager.success();
-                return;
-            }
-
-            processManager.error(message.error);
-        });
+        instance = new Instance(this.ui, config, processManager);
     }).catch((error) => {
         processManager.error(error.message);
     });
 };
 
 module.exports.exit = function exit() {
-    if (child) {
-        child.kill();
+    if (instance) {
+        instance.kill();
     }
 };

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -29,7 +29,7 @@ module.exports.execute = function execute() {
             return knexMigrator.migrate();
         }
     }).then(() => {
-        instance = new Instance(this.ui, config, processManager);
+        instance = new Instance(this.ui, processManager);
     }).catch((error) => {
         processManager.error(error.message);
     });

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -3,6 +3,19 @@ const Config = require('../utils/config');
 const checkValidInstall     = require('../utils/check-valid-install');
 const resolveProcessManager = require('../utils/resolve-process');
 
+function register(config, environment) {
+    let systemConfig = Config.load('system');
+    let instances = systemConfig.get('instances', {});
+
+    instances[process.cwd()] = {
+        mode: environment,
+        url: config.get('url'),
+        port: config.get('server.port'),
+        process: config.get('process')
+    };
+    systemConfig.set('instances', instances).save();
+}
+
 module.exports.execute = function execute(options) {
     checkValidInstall('start');
 
@@ -17,6 +30,7 @@ module.exports.execute = function execute(options) {
 
     let processManager = resolveProcessManager(config);
     let start = Promise.resolve(processManager.start(process.cwd(), this.environment)).then(() => {
+        register(config, this.environment);
         cliConfig.set('running', this.environment).save();
         // TODO: add process info to global cli file so Ghost-CLI is aware of this instance
         return Promise.resolve();

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -1,7 +1,24 @@
 'use strict';
+const execa = require('execa');
+const Promise = require('bluebird');
+
 const Config = require('../utils/config');
 const checkValidInstall     = require('../utils/check-valid-install');
 const resolveProcessManager = require('../utils/resolve-process');
+
+function stopAll() {
+    let systemConfig = Config.load('system');
+    let instances = systemConfig.get('instances', {});
+
+    // Unlike lodash, bluebird doesn't support iterating over objects,
+    // so we have to iterate over the keys and then get the url later
+    return Promise.each(Object.keys(instances), (cwd) => {
+        return this.ui.run(execa('ghost', ['stop'], {
+            cwd: cwd,
+            stdio: 'ignore'
+        }), `Stopping Ghost: ${instances[cwd].url}`);
+    });
+}
 
 function deregister() {
     let systemConfig = Config.load('system');
@@ -11,6 +28,10 @@ function deregister() {
 }
 
 module.exports.execute = function execute(options) {
+    if (options.all) {
+        return stopAll.call(this);
+    }
+
     checkValidInstall('stop');
 
     options = options || {};

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -3,6 +3,13 @@ const Config = require('../utils/config');
 const checkValidInstall     = require('../utils/check-valid-install');
 const resolveProcessManager = require('../utils/resolve-process');
 
+function deregister() {
+    let systemConfig = Config.load('system');
+    let instances = systemConfig.get('instances', {});
+    delete instances[process.cwd()];
+    systemConfig.set('instances', instances).save();
+}
+
 module.exports.execute = function execute(options) {
     checkValidInstall('stop');
 
@@ -17,6 +24,7 @@ module.exports.execute = function execute(options) {
     let config = Config.load(`config.${cliConfig.get('running')}.json`);
     let processManager = resolveProcessManager(config);
     let stop = Promise.resolve(processManager.stop(process.cwd())).then(() => {
+        deregister();
         cliConfig.set('running', null).save();
         return Promise.resolve();
     });

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const ora       = require('ora');
 const chalk     = require('chalk');
+const Table     = require('cli-table2');
 const assign    = require('lodash/assign');
 const Promise   = require('bluebird');
 const inquirer  = require('inquirer');
@@ -47,6 +48,13 @@ class UI {
 
                 return Promise.reject(error);
             });
+    }
+
+    table(head, body, options) {
+        let table = new Table(assign({head: head}, options || {}));
+
+        table.push.apply(table, body);
+        this.log(table.toString());
     }
 
     log(message, color) {

--- a/lib/utils/Instance.js
+++ b/lib/utils/Instance.js
@@ -1,0 +1,59 @@
+'use strict';
+const spawn = require('child_process').spawn;
+const Config = require('./config');
+
+class Instance {
+    constructor(ui, config, processManager) {
+        this.ui = ui;
+        this.config = config;
+        this.processManager = processManager;
+
+        this.child = spawn(process.execPath, ['current/index.js'], {
+            cwd: process.cwd(),
+            stdio: [0, 1, 2, 'ipc']
+        });
+
+        this.child.on('error', (error) => {
+            this.ui.fail(error);
+            process.exit(1);
+        });
+
+        this.child.on('message', (message) => {
+            if (message.started) {
+                this.register();
+                this.processManager.success();
+                return;
+            }
+
+            this.processManager.error(message.error);
+        });
+    }
+
+    kill() {
+        this.deregister();
+        this.child.kill();
+    }
+
+    register() {
+        let systemConfig = Config.load('system');
+        let instances = systemConfig.get('instances', {});
+
+        instances[process.cwd()] = {
+            mode: process.env.NODE_ENV,
+            url: this.config.get('url'),
+            port: this.config.get('server.port'),
+            process: this.config.get('process')
+        };
+
+        systemConfig.set('instances', instances).save();
+    }
+
+    deregister() {
+        let systemConfig = Config.load('system');
+        let instances = systemConfig.get('instances', {});
+        delete instances[process.cwd()];
+        systemConfig.set('instances', instances).save();
+    }
+}
+
+module.exports = Instance;

--- a/lib/utils/Instance.js
+++ b/lib/utils/Instance.js
@@ -1,11 +1,9 @@
 'use strict';
 const spawn = require('child_process').spawn;
-const Config = require('./config');
 
 class Instance {
-    constructor(ui, config, processManager) {
+    constructor(ui, processManager) {
         this.ui = ui;
-        this.config = config;
         this.processManager = processManager;
 
         this.child = spawn(process.execPath, ['current/index.js'], {
@@ -20,7 +18,6 @@ class Instance {
 
         this.child.on('message', (message) => {
             if (message.started) {
-                this.register();
                 this.processManager.success();
                 return;
             }
@@ -30,29 +27,7 @@ class Instance {
     }
 
     kill() {
-        this.deregister();
         this.child.kill();
-    }
-
-    register() {
-        let systemConfig = Config.load('system');
-        let instances = systemConfig.get('instances', {});
-
-        instances[process.cwd()] = {
-            mode: process.env.NODE_ENV,
-            url: this.config.get('url'),
-            port: this.config.get('server.port'),
-            process: this.config.get('process')
-        };
-
-        systemConfig.set('instances', instances).save();
-    }
-
-    deregister() {
-        let systemConfig = Config.load('system');
-        let instances = systemConfig.get('instances', {});
-        delete instances[process.cwd()];
-        systemConfig.set('instances', instances).save();
     }
 }
 

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -7,6 +7,8 @@ const _set          = require('lodash/set');
 const _has          = require('lodash/has');
 const fs            = require('fs-extra');
 
+const SYSTEM_CONFIG_FOLDER = path.resolve(process.env.APPDATA || process.env.HOME, '.ghost');
+
 let singletonCache = {};
 
 class Config {
@@ -15,7 +17,7 @@ class Config {
             throw new Error('Config file not specified.');
         }
 
-        this.file = path.join(process.cwd(), filename);
+        this.file = path.isAbsolute(filename) ? filename : path.join(process.cwd(), filename);
         this.values = Config.exists(this.file) || {};
     }
 
@@ -58,6 +60,11 @@ class Config {
     }
 
     static load(filename) {
+        if (filename === 'system') {
+            fs.ensureDirSync(SYSTEM_CONFIG_FOLDER);
+            filename = path.join(SYSTEM_CONFIG_FOLDER, 'config');
+        }
+
         if (singletonCache[filename] && singletonCache[filename] instanceof Config) {
             return singletonCache[filename];
         }
@@ -70,3 +77,4 @@ class Config {
 };
 
 module.exports = Config;
+module.exports.system = SYSTEM_CONFIG_FOLDER;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "bluebird": "3.4.7",
     "chalk": "1.1.3",
+    "cli-table2": "0.2.0",
     "commander": "2.9.0",
     "decompress": "4.0.0",
     "download": "5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,15 @@ cli-spinners@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.0.0.tgz#ef987ed3d48391ac3dab9180b406a742180d6e6a"
 
+cli-table2@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/cli-table2/-/cli-table2-0.2.0.tgz#2d1ef7f218a0e786e214540562d4bd177fe32d97"
+  dependencies:
+    lodash "^3.10.1"
+    string-width "^1.0.1"
+  optionalDependencies:
+    colors "^1.1.2"
+
 cli-truncate@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
@@ -1825,6 +1834,10 @@ lodash@4.16.4:
 lodash@4.17.4, lodash@^4.0.0, lodash@^4.3.0, lodash@^4.6.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 log-driver@1.2.5:
   version "1.2.5"


### PR DESCRIPTION
Refs #65 

This PR refactors some of multi-process management handling of the CLI to better enable users to see multiple instances of Ghost running on the same system.

Additions:
- [x] `ghost ls` command - See all the running Ghost processes
~~- `ghost info <pname>` - View basic information about a running ghost process~~ punting on this one for a bit - need to figure out how to dedupe process names.
- [x] `ghost stop --all|-a` Stop all running ghost blogs at once

Screenshots!
`ghost ls`
<img width="778" alt="screen shot 2017-02-10 at 8 58 23 am" src="https://cloud.githubusercontent.com/assets/5167581/22831580/7a840428-ef70-11e6-80ec-5df6ee251226.png">

`ghost stop -a`
<img width="788" alt="screen shot 2017-02-10 at 9 46 58 am" src="https://cloud.githubusercontent.com/assets/5167581/22833314/07fe69f0-ef77-11e6-8b6c-bc77f0e4015a.png">