### PR TITLE
Make `ghost start` smarter with the node environment

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -1,4 +1,7 @@
 'use strict';
+const fs = require('fs');
+const path = require('path');
+
 const Config = require('../utils/config');
 const checkValidInstall     = require('../utils/check-valid-install');
 const resolveProcessManager = require('../utils/resolve-process');
@@ -20,6 +23,15 @@ module.exports.execute = function execute(options) {
     checkValidInstall('start');
 
     options = options || {};
+
+    // If we are starting in production mode but a development config exists and a production config doesn't,
+    // we want to start in development mode anyways.
+    if (!this.development && fs.existsSync(path.join(process.cwd(), 'config.development.json')) &&
+            !fs.existsSync(path.join(process.cwd(), 'config.production.json'))) {
+        this.ui.log('Found a development config but not a production config, starting in development mode instead.', 'yellow');
+        this.development = false;
+        process.NODE_ENV = this.environment = 'development';
+    }
 
     let config = Config.load(`config.${this.environment}.json`);
     let cliConfig = Config.load('.ghost-cli');


### PR DESCRIPTION
refs #152
- if a development config exists but not a production one, running ghost
start without the `-D` option will still run in development mode
- fixes issues when running `ghost start` in a local install