### PR TITLE
Various improvements around multi-install management

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -5,14 +5,12 @@ const Config = require('../utils/config');
 module.exports.execute = function execute() {
     let systemConfig = Config.load('system');
     let rows = [];
-    let i = 1;
 
-    each(systemConfig.get('instances', {}), (instance, cwd) => {
-        rows.push([i, instance.url, instance.port, instance.mode, instance.process, cwd]);
-        i += 1;
+    each(systemConfig.get('instances', {}), (instance, name) => {
+        rows.push([name, instance.url, instance.port, instance.mode, instance.process, instance.cwd]);
     });
 
-    this.ui.table(['#', 'Url', 'Port', 'Environment', 'Process Manager', 'Location'], rows, {
+    this.ui.table(['Name', 'Url', 'Port', 'Environment', 'Process Manager', 'Location'], rows, {
         style: {head: ['cyan']}
     });
 };

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -7,6 +7,7 @@ const Listr = require('listr');
 const setupChecks           = require('./doctor/checks/setup');
 const startCommand          = require('./start');
 const configCommand         = require('./config');
+const dedupeProcessName     = require('../utils/dedupe-process-name');
 const checkValidInstall     = require('../utils/check-valid-install');
 const resolveProcessManager = require('../utils/resolve-process');
 
@@ -24,8 +25,12 @@ module.exports.execute = function execute(options) {
         options.process = 'local';
         options.db = 'sqlite3';
         options.dbpath = path.join(process.cwd(), 'content/data/ghost-local.db');
-
         context.start = true;
+
+        // In the case that the user runs `ghost setup --local`, we want to make
+        // sure we're set up in development mode
+        this.development = true;
+        this.environment = 'development';
     }
 
     return configCommand.execute.call(this, null, null, options).then((config) => {
@@ -69,6 +74,9 @@ module.exports.execute = function execute(options) {
         });
     }).then((answer) => {
         context.start = context.start || answer.start;
+
+        // De-duplicate process name before setting up the process manager
+        dedupeProcessName(context.config);
 
         let processManager = resolveProcessManager(context.config, this.ui);
 

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -10,8 +10,9 @@ function register(config, environment) {
     let systemConfig = Config.load('system');
     let instances = systemConfig.get('instances', {});
 
-    instances[process.cwd()] = {
+    instances[config.get('pname')] = {
         mode: environment,
+        cwd: process.cwd(),
         url: config.get('url'),
         port: config.get('server.port'),
         process: config.get('process')

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -12,18 +12,19 @@ function stopAll() {
 
     // Unlike lodash, bluebird doesn't support iterating over objects,
     // so we have to iterate over the keys and then get the url later
-    return Promise.each(Object.keys(instances), (cwd) => {
+    return Promise.each(Object.keys(instances), (pname) => {
+        let instance = instances[pname];
         return this.ui.run(execa('ghost', ['stop'], {
-            cwd: cwd,
+            cwd: instance.cwd,
             stdio: 'ignore'
-        }), `Stopping Ghost: ${instances[cwd].url}`);
+        }), `Stopping Ghost: ${instance.url}`);
     });
 }
 
-function deregister() {
+function deregister(config) {
     let systemConfig = Config.load('system');
     let instances = systemConfig.get('instances', {});
-    delete instances[process.cwd()];
+    delete instances[config.get('pname')];
     systemConfig.set('instances', instances).save();
 }
 
@@ -45,7 +46,7 @@ module.exports.execute = function execute(options) {
     let config = Config.load(`config.${cliConfig.get('running')}.json`);
     let processManager = resolveProcessManager(config, this.ui);
     let stop = Promise.resolve(processManager.stop(process.cwd())).then(() => {
-        deregister();
+        deregister(config);
         cliConfig.set('running', null).save();
         return Promise.resolve();
     });

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -1,5 +1,4 @@
 'use strict';
-const execa = require('execa');
 const Promise = require('bluebird');
 
 const Config = require('../utils/config');
@@ -9,15 +8,16 @@ const resolveProcessManager = require('../utils/resolve-process');
 function stopAll() {
     let systemConfig = Config.load('system');
     let instances = systemConfig.get('instances', {});
+    let cwd = process.cwd();
 
     // Unlike lodash, bluebird doesn't support iterating over objects,
     // so we have to iterate over the keys and then get the url later
     return Promise.each(Object.keys(instances), (pname) => {
         let instance = instances[pname];
-        return this.ui.run(execa('ghost', ['stop'], {
-            cwd: instance.cwd,
-            stdio: 'ignore'
-        }), `Stopping Ghost: ${instance.url}`);
+        process.chdir(instance.cwd);
+        return this.ui.run(execute.call(this, {quiet: true}), `Stopping Ghost: ${instance.url}`);
+    }).then(() => {
+        process.chdir(cwd);
     });
 }
 
@@ -28,7 +28,7 @@ function deregister(config) {
     systemConfig.set('instances', instances).save();
 }
 
-module.exports.execute = function execute(options) {
+function execute(options) {
     options = options || {};
 
     if (options.all) {
@@ -57,3 +57,5 @@ module.exports.execute = function execute(options) {
 
     return this.ui.run(stop, 'Stopping Ghost');
 };
+
+module.exports.execute = execute;

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -17,7 +17,7 @@ class Config {
             throw new Error('Config file not specified.');
         }
 
-        this.file = path.isAbsolute(filename) ? filename : path.join(process.cwd(), filename);
+        this.file = filename;
         this.values = Config.exists(this.file) || {};
     }
 
@@ -63,6 +63,10 @@ class Config {
         if (filename === 'system') {
             fs.ensureDirSync(SYSTEM_CONFIG_FOLDER);
             filename = path.join(SYSTEM_CONFIG_FOLDER, 'config');
+        }
+
+        if (!path.isAbsolute(filename)) {
+            filename = path.join(process.cwd(), filename);
         }
 
         if (singletonCache[filename] && singletonCache[filename] instanceof Config) {

--- a/lib/utils/dedupe-process-name.js
+++ b/lib/utils/dedupe-process-name.js
@@ -1,0 +1,20 @@
+'use strict';
+const uniqueId = require('lodash/uniqueId');
+const includes = require('lodash/includes');
+const Config = require('./config');
+
+module.exports = function dedupeProcessName(config) {
+    let systemConfig = Config.load('system');
+    let existingProcessNames = Object.keys(systemConfig.get('instances'));
+    let pname = config.get('pname');
+
+    // Continue searching until we've found a new unique id
+    while (includes(existingProcessNames, pname)) {
+        pname = uniqueId(pname.endsWith('-') ? pname : `${pname}-`);
+    }
+
+    // If pname has changed, update the config
+    if (pname !== config.get('pname')) {
+        config.set('pname', pname).save();
+    }
+}


### PR DESCRIPTION
- de-duplicate process name on setup using lodash uniqueId()
- index process list by process name rather than cwd
- make Config cache files by absolute filename rather than local
- `ghost stop --all` stops all the processes in the same cli process, rather than executing subcommands.