### PR TITLE
Add server_name directive to nginx ssl block

### DIFF
--- a/lib/services/nginx/index.js
+++ b/lib/services/nginx/index.js
@@ -163,6 +163,7 @@ class NginxService extends BaseService {
             // add listen directives
             https._add('listen', '443 ssl http2');
             https._add('listen', '[::]:443 ssl http2');
+            https._add('server_name', this.parsedUrl.hostname);
             // add ssl cert directives
             https._add('ssl_certificate', `/etc/letsencrypt/live/${this.parsedUrl.hostname}/fullchain.pem`);
             https._add('ssl_certificate_key', `/etc/letsencrypt/live/${this.parsedUrl.hostname}/privkey.pem`);


### PR DESCRIPTION
Not sure if anything else is needed here (didn't see any related tests), but this fixes a particularly annoying bug that I'd like to get sorted in a release sometime soon 😁 

closes #186

- adds a single extra line to the ssl block
- allows multiple blogs to be installed on one server