### PR TITLE
✨ Allow SSL Email to be provided, skip prompts

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -84,6 +84,10 @@ module.exports = [{
     description: 'Database name',
     configPath: 'database.connection.database'
 }, {
+    name: 'sslemail',
+    description: 'SSL email address',
+    configPath: 'ssl.email'
+}, {
     name: 'auth',
     description: 'Type of authentication to use',
     configPath: 'auth.type',

--- a/lib/services/nginx/index.js
+++ b/lib/services/nginx/index.js
@@ -72,10 +72,20 @@ class NginxService extends BaseService {
             });
         }
 
-        let answers;
         let ghostExec = process.argv.slice(0,2).join(' ');
+        let answerPromise;
+        let answers;
 
-        return this.ui.prompt(prompts).then((_answers) => {
+        if (this.config.values.ssl && this.config.values.ssl.email) {
+            answerPromise = Promise.resolve({
+                ssl: true,
+                email: this.config.values.ssl.email
+            });
+        } else {
+            answerPromise = this.ui.prompt(prompts);
+        }
+
+        return answerPromise.then((_answers) => {
             answers = _answers;
 
             return this.ui.noSpin(execa.shell(`sudo ${ghostExec} service nginx-conf${!answers.ssl ? ' no-ssl' : ''}`, {stdio: 'inherit'})).catch((error) => {

--- a/lib/services/nginx/index.js
+++ b/lib/services/nginx/index.js
@@ -76,10 +76,10 @@ class NginxService extends BaseService {
         let answerPromise;
         let answers;
 
-        if (this.config.values.ssl && this.config.values.ssl.email) {
+        if (this.config.get('ssl.email', false)) {
             answerPromise = Promise.resolve({
                 ssl: true,
-                email: this.config.values.ssl.email
+                email: this.config.get('ssl.email')
             });
         } else {
             answerPromise = this.ui.prompt(prompts);


### PR DESCRIPTION
This is a proposal for how to introduce ssl config without requiring a prompt.
It is a little bit odd in that it causes the ssl email to be written to config. Not sure if that's useful/desired.

Note: I've not done particularly extensive testing of this.

refs #194

- If --sslemail is provided, use that instead of prompting
- Makes it easier to call ghost programmatically