### PR TITLE
✨ Allow start flag to be provided, skip prompts

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -101,6 +101,10 @@ module.exports = {
             alias: 'l',
             description: 'Quick setup for a local installation of Ghost',
             flag: true
+        }, {
+            name: 'start',
+            description: 'Automatically start Ghost without prompting',
+            flag: true
         }].concat(advancedOptions)
     },
 

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -32,6 +32,8 @@ module.exports.execute = function execute(options) {
         // sure we're set up in development mode
         this.development = true;
         process.env.NODE_ENV = this.environment = 'development';
+    } else {
+        context.start = options.start || false;
     }
 
     return configCommand.execute.call(this, null, null, options).then((config) => {


### PR DESCRIPTION
Again, this is a proposal more than anything & not particularly well tested 😁 

refs #194

- if --start is provided, use that instead of prompting
- makes it easier to call ghost install/ghost setup programmatically