### PR TITLE
fix(ls): don't allow dots in process name

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -31,10 +31,10 @@ module.exports = [{
 }, {
     name: 'pname',
     description: 'Name of the Ghost instance',
-    validate: value => !!value.match(/[A-Za-z0-9:\.\-_]+/) ||
-        'Invalid process name. Process name can contain alphanumeric characters,' +
-        'and the special characters \'.\', \'-\', and \'_\'',
-    default: config => url.parse(config.get('url')).hostname
+    validate: value => !!value.match(/^[A-Za-z0-9\-_]+$/) ||
+        'Invalid process name. Process name can contain alphanumeric characters ' +
+        'and the special characters \'-\' and \'_\'',
+    default: config => url.parse(config.get('url')).hostname.replace(/\./g, '-')
 }, {
     name: 'port',
     description: 'Port ghost should listen on',


### PR DESCRIPTION
closes #184
- tighten up pname validation regex
- replace dots with dashes in default pname