### PR TITLE
fix(run): make command descriptions clearer

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -3,7 +3,7 @@ const advancedOptions = require('./commands/config/advanced');
 
 module.exports = {
     config: {
-        description: 'configure a Ghost instance',
+        description: 'Configure a Ghost instance',
 
         arguments: [{
             name: 'key',
@@ -17,7 +17,7 @@ module.exports = {
     },
 
     doctor: {
-        description: 'check the system for any potential hiccups when installing/updating Ghost',
+        description: 'Check the system for any potential hiccups when installing/updating Ghost',
 
         arguments: [
             {name: 'category', optional: true}
@@ -25,12 +25,12 @@ module.exports = {
     },
 
     buster: {
-        description: 'who ya gonna call?'
+        description: 'Who ya gonna call?'
     },
 
     install: {
         alias: 'i',
-        description: 'install a brand new instance of Ghost',
+        description: 'Install a brand new instance of Ghost',
 
         arguments: [
             {name: 'version', optional: true}
@@ -52,7 +52,7 @@ module.exports = {
     },
 
     log: {
-        description: 'view logs of a running ghost process',
+        description: 'View logs of a running ghost process',
 
         arguments: ['name'],
         options: [{
@@ -69,7 +69,7 @@ module.exports = {
     },
 
     ls: {
-        description: 'view running ghost processes'
+        description: 'View running ghost processes'
     },
 
     restart: {
@@ -77,11 +77,11 @@ module.exports = {
     },
 
     run: {
-        description: 'start a managed ghost process'
+        description: 'Run a ghost instance directly (used by process managers and for debugging)'
     },
 
     service: {
-        description: 'run a service-defined command',
+        description: 'Run a service-defined command',
 
         arguments: [
             'command',
@@ -90,7 +90,7 @@ module.exports = {
     },
 
     setup: {
-        description: 'setup an installation of Ghost (after it is installed)',
+        description: 'Setup an installation of Ghost (after it is installed)',
 
         options: [{
             name: 'no-stack',
@@ -105,11 +105,11 @@ module.exports = {
     },
 
     start: {
-        description: 'starts an instance of Ghost'
+        description: 'Start an instance of Ghost'
     },
 
     stop: {
-        description: 'stops a named instance of Ghost',
+        description: 'Stops a named instance of Ghost',
 
         options: [{
             name: 'all',

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -10,6 +10,13 @@ let instance;
 module.exports.execute = function execute() {
     checkValidInstall('run');
 
+    // If the user is running this command directly, output a little note
+    // telling them they're likely looking for `ghost start`
+    if (process.stdin.isTTY) {
+        this.ui.log('The `ghost run` command is used by the configured Ghost process manager and for debugging. ' +
+            'If you\'re not running this to debug something, you should run `ghost start` instead.', 'yellow');
+    }
+
     process.env.paths__contentPath = path.join(process.cwd(), 'content');
 
     this.service.setConfig(Config.load(this.environment));


### PR DESCRIPTION
closes #185
- fix command descriptions
- output help note on `ghost run` if it is being run directly