### PR TITLE
Fix: IP address not configured when specified as option

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -16,7 +16,8 @@ const BASE_PORT = '2368';
  */
 module.exports = [{
     name: 'ip',
-    description: 'IP ghost should listen on'
+    description: 'IP ghost should listen on',
+    configPath: 'server.ip'
 }, {
     name: 'url',
     description: 'Blog url protocol required ex http://loveghost.com ',


### PR DESCRIPTION
Ghost-cli does not consider the IP address given in the '--ip' option
on the command line. Adding this line fixes the issue.

Thanks to @acburdine who responded on Slack with this solution and asked
me to submit a PR.