### PR TITLE
🎨  X-Frame-Options SAMEORIGIN

### DIFF
--- a/lib/services/nginx/files/ssl-params.conf
+++ b/lib/services/nginx/files/ssl-params.conf
@@ -9,7 +9,7 @@ ssl_stapling_verify on; # Requires nginx => 1.3.7
 resolver 8.8.8.8 8.8.4.4 valid=300s;
 resolver_timeout 5s;
 add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-add_header X-Frame-Options DENY;
+add_header X-Frame-Options SAMEORIGIN;
 add_header X-Content-Type-Options nosniff;
 
 ssl_dhparam /etc/ssl/certs/dhparam.pem;


### PR DESCRIPTION
refs #230

*Using refs, because i would like to wait for feedback on ssl ciphers.*

- change x-frame-options from DENY to SAMEORIGIN
- SAMEORIGIN: This setting will allow the page to be displayed in a frame on the same origin as the page itself.
- background: if we deny x-frame-options, we can't export content/database

@ErisDS I have talked to @acburdine quickly, we can merge this already into master and @acburdine will rebase his [extension PR](https://github.com/TryGhost/Ghost-CLI/pull/238) against master.