### PR TITLE
✨ Accept mail configuration options

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -7,6 +7,11 @@ const validator = require('validator');
 const url = require('url');
 
 const BASE_PORT = '2368';
+const knownMailServices = [
+    'AOL', 'DynectEmail', 'Gmail', 'hot.ee', 'Hotmail', 'iCloud', 'mail.ee', 'Mail.Ru', 'Mailgun',
+    'Mailjet', 'Mandrill', 'Postmark', 'QQ', 'QQex (Tencent Business Email)', 'SendGrid',
+    'SendCloud', 'SES', 'Yahoo', 'yandex', 'Zoho'
+];
 
 /*
     Note: these options are handled serially, i.e. one after the other.
@@ -58,6 +63,8 @@ module.exports = {
         defaultValue: (c, env) => env === 'production' ? 'systemd' : 'local',
         type: 'string'
     },
+
+    // Database options
     db: {
         description: 'Type of database Ghost should use',
         validate: value => includes(['sqlite3', 'mysql'], value),
@@ -89,6 +96,45 @@ module.exports = {
         configPath: 'database.connection.database',
         type: 'string'
     },
+
+    // Mail options:
+    // Designed to support the most common mail configs, more advanced configs will require editing the config file
+    mail: {
+        description: 'Mail transport, E.g SMTP, Sendmail or Direct',
+        validate: value => includes(['SMTP', 'Sendmail', 'Direct'], value),
+        configPath: 'mail.transport',
+        type: 'string',
+        default: 'Direct'
+    },
+    mailservice: {
+        description: 'Mail service (used with SMTP transport), E.g. Mailgun, Sendgrid, Gmail, SES...',
+        configPath: 'mail.options.service',
+        validate: value => includes(knownMailServices, value),
+        type: 'string'
+    },
+    mailuser: {
+        description: 'Mail auth user (used with SMTP transport)',
+        configPath: 'mail.options.auth.user',
+        type: 'string',
+        implies: 'mailpass'
+    },
+    mailpass: {
+        description: 'Mail auth pass (used with SMTP transport)',
+        configPath: 'mail.options.auth.pass',
+        type: 'string',
+        implies: 'mailuser'
+    },
+    mailhost: {
+        description: 'Mail host (used with SMTP transport)',
+        configPath: 'mail.options.host',
+        type: 'string'
+    },
+    mailport: {
+        description: 'Mail port (used with SMTP transport)',
+        configPath: 'mail.options.port',
+        type: 'number'
+    },
+
     sslemail: {
         description: 'SSL email address',
         configPath: 'ssl.email',


### PR DESCRIPTION
refs #232, #216

- this is the most straight forward pass through adding mail config options
- there is loads of small tweaks possible here, but they are not required
E.g.
- auto-set transport to smtp if any other argument is supplied
- use grouping to make the output better
- stronger use of implies?

---- 

## Documentation notes

This makes it possible to configure SMTP & Sendmail transports via the CLI using `--mail`. [SES and Pickup](https://github.com/nodemailer/nodemailer/tree/0.7#possible-transport-methods) are not supported as transports. Direct doesn't require further config.

This then makes it possible to provide the most common other options for SMTP. Sendmail options are all optional, so we don't support these via the cli.

Any more advanced SMTP or optional Sendmail config can be provided by editing the file.

There are man "known" mail services, and we allow them all to be set using `--mailservice`, but list only the very common ones in the description.

Note that SES is one of the services, and so SES can be configured through the CLI via the SMTP transport.

Along side "service", we support the host, port, auth.user and auth.pass configuration options via the CLI as `--mailhost`, `--mailport`, `--mailuser` and `--mailpass`. This covers most of the setups I know of using mailgun, gmail, SES, etc.

This is not complete, but should be enough for most people.