### PR TITLE
🔥 fix(config): remove unused auth option

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -140,12 +140,6 @@ module.exports = {
         configPath: 'ssl.email',
         type: 'string'
     },
-    auth: {
-        description: 'Type of authentication to use',
-        configPath: 'auth.type',
-        validate: value => value === 'password',
-        type: 'string'
-    },
     log: {
         description: 'Transport to send Ghost log output to',
         configPath: 'logging.transports',


### PR DESCRIPTION
Don't think we should keep this around?

no issue

- auth is no longer going to be used
- as we don't want anyone to use it, we shouldn't output it in help :)