### PR TITLE
✨ feat(setup): enable systemd service during setup

### DIFF
--- a/lib/services/process/systemd/ghost.service.template
+++ b/lib/services/process/systemd/ghost.service.template
@@ -1,6 +1,6 @@
 [Unit]
 Description=Ghost systemd service for blog: <%= name %>
-# Documentation=add documentation link here
+Documentation=https://docs.ghost.org
 
 [Service]
 Type=simple

--- a/lib/services/process/systemd/index.js
+++ b/lib/services/process/systemd/index.js
@@ -32,9 +32,18 @@ class SystemdProcess extends BaseProcess {
             ghost_exec_path: process.argv.slice(0,2).join(' ')
         }), 'utf8');
 
-        return this.ui.sudo(`mv ${serviceFilename} /lib/systemd/system`).catch(() => {
-            return Promise.reject(new errors.SystemError('Ghost service file could not be put in place, ensure you have proper sudo permissions and systemd is installed.'));
-        });
+        return this
+            .config()
+            .then(() => this.enable());
+    }
+
+    config() {
+        return this.ui
+            // moving our written template to the correct location
+            .sudo(`mv ${this.systemdName}.service /lib/systemd/system`)
+            .catch(() => {
+                return Promise.reject(new errors.SystemError('Ghost service file could not be put in place, ensure you have proper sudo permissions and systemd is installed.'));
+            });
     }
 
     uninstall() {
@@ -47,15 +56,25 @@ class SystemdProcess extends BaseProcess {
         }
     }
 
+    enable() {
+        return this.ui
+            // systemctl enable tells a service to start on server boot
+            .sudo(`systemctl enable ${this.systemdName}`)
+            .catch((error) => Promise.reject(new errors.ProcessError(error)));
+    }
+
     start() {
-        return this.ui.sudo(`systemctl start ${this.systemdName}`)
+        return this.ui
+            .sudo(`systemctl start ${this.systemdName}`)
             .catch((error) => Promise.reject(new errors.ProcessError(error)));
     }
 
     stop() {
-        return this.ui.sudo(`systemctl stop ${this.systemdName}`)
+        return this.ui
+            .sudo(`systemctl stop ${this.systemdName}`)
             .catch((error) => Promise.reject(new errors.ProcessError(error)));
     }
+
 
     static willRun() {
         try {


### PR DESCRIPTION
This is a quick version for now, to ensure that enable is called and Ghost doesn't fail to start on reboot of servers.

I will try to revisit the better plan in #248 next week,

refs #216, #248

- add an extra step to enable systemd on setup
   - this is what tells systemd to start the service on server restart
- Update the template to contain docs link