### PR TITLE
refactor(migrate): move migrations step into setup & update commands

### DIFF
--- a/extensions/systemd/index.js
+++ b/extensions/systemd/index.js
@@ -20,25 +20,22 @@ class SystemdExtension extends cli.Extension {
         }
     }
 
-    _setup() {
+    _setup(argv, ctx) {
         let service = template(fs.readFileSync(path.join(__dirname, 'ghost.service.template'), 'utf8'));
         let serviceFilename = `${this.systemdName}.service`;
-        let instance = this.system.getInstance();
 
-        return instance.template(service({
-            name: instance.name,
+        return ctx.instance.template(service({
+            name: ctx.instance.name,
             dir: process.cwd(),
             user: process.getuid(),
             environment: this.system.environment,
             ghost_exec_path: process.argv.slice(0,2).join(' ')
         }), 'systemd service file', serviceFilename, '/lib/systemd/system').then(() => {
-            instance.cliConfig.set('extension.systemd', true).save();
+            ctx.instance.cliConfig.set('extension.systemd', true).save();
         });
     }
 
-    uninstall() {
-        let instance = this.system.getInstance();
-
+    uninstall(instance) {
         if (!instance.cliConfig.get('extension.systemd', false)) {
             return;
         }

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -6,6 +6,7 @@ const omit           = require('lodash/omit');
 
 const errors         = require('../errors');
 const Command        = require('../command');
+const migrate        = require('../tasks/migrate');
 const setupChecks    = require('./doctor/checks/setup');
 const StartCommand   = require('./start');
 const ConfigCommand  = require('./config');
@@ -64,14 +65,26 @@ class SetupCommand extends Command {
             task: () => this.ui.listr(setupChecks, false)
         }, {
             title: 'Setting up instance',
-            task: () => {
-                let instance = this.system.getInstance();
-                instance.name = argv.pname || url.parse(instance.config.get('url')).hostname.replace(/\./g, '-');
-                this.system.addInstance(instance);
+            task: (ctx) => {
+                ctx.instance = this.system.getInstance();
+                ctx.instance.name = argv.pname || url.parse(ctx.instance.config.get('url')).hostname.replace(/\./g, '-');
+                this.system.addInstance(ctx.instance);
             }
         }];
 
         if (argv.stage) {
+            let instance = this.system.getInstance();
+
+            // If a user is running a specific setup stage, we want to run the env check here.
+            // That way, if they haven't run setup at all for the particular environment that they're running
+            // this stage for, then it will use the other one
+            instance.checkEnvironment();
+
+            // Special-case migrations
+            if (argv.stage === 'migrate') {
+                return this.ui.run(migrate({instance: instance}), 'Running database migrations');
+            }
+
             return this.system.hook('setup', this, argv).then(() => {
                 let stage = this.stages.find(stage => stage.name === argv.stage);
 
@@ -81,8 +94,8 @@ class SetupCommand extends Command {
 
                 return this.ui.listr([{
                     title: `Setting up ${stage.name}`,
-                    task: (ctx, task) => stage.fn(argv, Object.assign(ctx, {single: true}), task)
-                }]);
+                    task: (ctx, task) => stage.fn(argv, ctx, task)
+                }], {single: true, instance: instance});
             });
         }
 
@@ -113,6 +126,14 @@ class SetupCommand extends Command {
                     }
                 };
             }));
+
+            if (argv.migrate !== false) {
+                // Tack on db migration task to the end
+                tasks.push({
+                    title: 'Running database migrations',
+                    task: migrate
+                });
+            }
 
             return this.ui.listr(tasks, {setup: true}).then(() => {
                 if (!argv.prompt || argv.start) {

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -4,7 +4,6 @@ const omit = require('lodash/omit');
 
 const Command = require('../command');
 const startupChecks = require('./doctor/checks/startup');
-const runMigrations = require('../tasks/migrate');
 
 class StartCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {
@@ -29,10 +28,7 @@ class StartCommand extends Command {
 
         instance.checkEnvironment();
 
-        return this.ui.listr(startupChecks.concat({
-            title: 'Running database migrations',
-            task: runMigrations
-        }), {environment: this.system.environment, config: instance.config}).then(() => {
+        return this.ui.listr(startupChecks, {environment: this.system.environment, config: instance.config}).then(() => {
             let start = () => Promise.resolve(instance.process.start(process.cwd(), this.system.environment)).then(() => {
                 instance.running = this.system.environment;
             });

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -39,7 +39,7 @@ class UninstallCommand extends Command {
         }).then(() => {
             this.system.setEnvironment(!fs.existsSync('config.production.json'));
 
-            return this.ui.run(this.system.hook('uninstall'), 'Removing related configuration');
+            return this.ui.run(this.system.hook('uninstall', instance), 'Removing related configuration');
         }).then(() => this.ui.run(() => {
             this.system.removeInstance(instance);
             return Promise.all(fs.readdirSync('.').map(file => fs.remove(file)));

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -10,6 +10,7 @@ const resolveVersion = require('../utils/resolve-version');
 
 // Tasks/Commands
 // TODO: update checks
+const migrate = require('../tasks/migrate');
 const yarnInstall = require('../tasks/yarn-install');
 const StopCommand = require('./stop');
 const StartCommand = require('./start');
@@ -86,6 +87,10 @@ class UpdateCommand extends Command {
                     casperPath
                 ));
             }
+        }, {
+            title: 'Running database migrations',
+            skip: (ctx) => ctx.rollback,
+            task: migrate
         }, {
             title: 'Restarting Ghost',
             task: () => {

--- a/lib/tasks/migrate.js
+++ b/lib/tasks/migrate.js
@@ -6,7 +6,7 @@ const errors = require('../errors');
 
 module.exports = function runMigrations(context) {
     process.env.paths__contentPath = path.join(process.cwd(), 'content');
-    let config = context.config;
+    let config = context.instance.config;
 
     let transports = config.get('logging.transports', null);
     config.set('logging.transports', ['file']).save();

--- a/test/unit/tasks/migrate-spec.js
+++ b/test/unit/tasks/migrate-spec.js
@@ -1,0 +1,171 @@
+'use strict';
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+const errors = require('../../../lib/errors');
+
+const migratePath = '../../../lib/tasks/migrate';
+
+// Used for testing
+class TestError extends Error {
+    constructor(code) {
+        super('an error');
+        this.code = code;
+    }
+}
+
+describe('Unit: Tasks > Migrate', function () {
+    it('disables stdout log in config and re-enables it after completion', function () {
+        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
+        let setStub = sinon.stub().returnsThis();
+        let saveStub = sinon.stub().returnsThis();
+        let dbOkStub = sinon.stub().resolves();
+
+        let migrate = proxyquire(migratePath, {
+            'knex-migrator': class KnexMigrator {
+                isDatabaseOK() { return dbOkStub(); }
+            }
+        });
+
+        return migrate({ instance: { config: {
+            get: getStub,
+            set: setStub,
+            save: saveStub
+        } } }).then(() => {
+            expect(dbOkStub.calledOnce).to.be.true;
+            expect(getStub.calledOnce).to.be.true;
+            expect(setStub.calledTwice).to.be.true;
+            expect(setStub.args[0]).to.deep.equal(['logging.transports', ['file']]);
+            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+            expect(saveStub.calledTwice).to.be.true;
+        });
+    });
+
+    it('runs init if database is not initialized', function () {
+        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
+        let setStub = sinon.stub().returnsThis();
+        let saveStub = sinon.stub().returnsThis();
+        let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('DB_NOT_INITIALISED')));
+        let initStub = sinon.stub().resolves();
+
+        let migrate = proxyquire(migratePath, {
+            'knex-migrator': class KnexMigrator {
+                isDatabaseOK() { return dbOkStub() }
+                init() { return initStub() }
+            }
+        });
+
+        return migrate({ instance: { config: {
+            get: getStub, set: setStub, save: saveStub
+        } } }).then(() => {
+            expect(dbOkStub.calledOnce).to.be.true;
+            expect(initStub.calledOnce).to.be.true;
+            expect(setStub.calledTwice).to.be.true;
+            expect(setStub.args[0]).to.deep.equal(['logging.transports', ['file']]);
+            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+        });
+    });
+
+    it('runs init if migration table is missing', function () {
+        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
+        let setStub = sinon.stub().returnsThis();
+        let saveStub = sinon.stub().returnsThis();
+        let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('MIGRATION_TABLE_IS_MISSING')));
+        let initStub = sinon.stub().resolves();
+
+        let migrate = proxyquire(migratePath, {
+            'knex-migrator': class KnexMigrator {
+                isDatabaseOK() { return dbOkStub() }
+                init() { return initStub() }
+            }
+        });
+
+        return migrate({ instance: { config: {
+            get: getStub, set: setStub, save: saveStub
+        } } }).then(() => {
+            expect(dbOkStub.calledOnce).to.be.true;
+            expect(initStub.calledOnce).to.be.true;
+            expect(setStub.calledTwice).to.be.true;
+            expect(setStub.args[0]).to.deep.equal(['logging.transports', ['file']]);
+            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+        });
+    });
+
+    it('runs migrate if db needs migration', function () {
+        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
+        let setStub = sinon.stub().returnsThis();
+        let saveStub = sinon.stub().returnsThis();
+        let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('DB_NEEDS_MIGRATION')));
+        let migrateStub = sinon.stub().resolves();
+
+        let migrate = proxyquire(migratePath, {
+            'knex-migrator': class KnexMigrator {
+                isDatabaseOK() { return dbOkStub() }
+                migrate() { return migrateStub() }
+            }
+        });
+
+        return migrate({ instance: { config: {
+            get: getStub, set: setStub, save: saveStub
+        } } }).then(() => {
+            expect(dbOkStub.calledOnce).to.be.true;
+            expect(migrateStub.calledOnce).to.be.true;
+            expect(setStub.calledTwice).to.be.true;
+            expect(setStub.args[0]).to.deep.equal(['logging.transports', ['file']]);
+            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+        });
+    });
+
+    it('throws config error with db host if database not found', function () {
+        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
+        let setStub = sinon.stub().returnsThis();
+        let saveStub = sinon.stub().returnsThis();
+        let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('ENOTFOUND')));
+
+        let migrate = proxyquire(migratePath, {
+            'knex-migrator': class KnexMigrator {
+                isDatabaseOK() { return dbOkStub() }
+            }
+        });
+
+        return migrate({ instance: { config: {
+            get: getStub, set: setStub, save: saveStub
+        } } }).then(() => {
+            expect(false, 'error should have been thrown').to.be.true;
+        }).catch((error) => {
+            expect(error).to.be.an.instanceof(errors.ConfigError);
+            expect(error.options.configKey).to.equal('database.connection.host');
+            expect(dbOkStub.calledOnce).to.be.true;
+            expect(setStub.calledTwice).to.be.true;
+            expect(setStub.args[0]).to.deep.equal(['logging.transports', ['file']]);
+            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+        });
+    });
+
+    it('throws config error with db user if access denied error', function () {
+        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
+        let setStub = sinon.stub().returnsThis();
+        let saveStub = sinon.stub().returnsThis();
+        let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('ER_ACCESS_DENIED_ERROR')));
+
+        let migrate = proxyquire(migratePath, {
+            'knex-migrator': class KnexMigrator {
+                isDatabaseOK() { return dbOkStub() }
+            }
+        });
+
+        return migrate({ instance: { config: {
+            get: getStub, set: setStub, save: saveStub
+        } } }).then(() => {
+            expect(false, 'error should have been thrown').to.be.true;
+        }).catch((error) => {
+            expect(error).to.be.an.instanceof(errors.ConfigError);
+            expect(error.options.configKey).to.equal('database.connection.user');
+            expect(dbOkStub.calledOnce).to.be.true;
+            expect(setStub.calledTwice).to.be.true;
+            expect(setStub.args[0]).to.deep.equal(['logging.transports', ['file']]);
+            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+        });
+    });
+});


### PR DESCRIPTION
closes #250
- clean up contextual instance behavior in setup tasks
- move migrate task into setup & update commands rather than start commands