### PR TITLE
feat(process): add enable/disable support

### DIFF
--- a/extensions/systemd/systemd.js
+++ b/extensions/systemd/systemd.js
@@ -23,6 +23,29 @@ class SystemdProcessManager extends cli.ProcessManager {
             .catch((error) => Promise.reject(new cli.errors.ProcessError(error)));
     }
 
+    isEnabled() {
+        try {
+            execa.shellSync(`systemctl is-enabled ${this.systemdName}`);
+            return true;
+        } catch (e) {
+            if (!e.message.match(/disabled/)) {
+                throw e;
+            }
+
+            return false;
+        }
+    }
+
+    enable() {
+        return this.ui.sudo(`systemctl enable ${this.systemdName} --quiet`)
+            .catch((error) => Promise.reject(new cli.errors.ProcessError(error)));
+    }
+
+    disable() {
+        return this.ui.sudo(`systemctl disable ${this.systemdName} --quiet`)
+            .catch((error) => Promise.reject(new cli.errors.ProcessError(error)));
+    }
+
     isRunning() {
         try {
             execa.shellSync(`systemctl is-active ${this.systemdName}`);

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -23,7 +23,8 @@ class SetupCommand extends Command {
         });
 
         yargs = super.configureOptions(commandName, yargs, extensions);
-        return ConfigCommand.configureOptions('config', yargs, extensions);
+        yargs = ConfigCommand.configureOptions('config', yargs, extensions);
+        yargs = StartCommand.configureOptions('start', yargs, extensions);
     }
 
     constructor(ui, system) {
@@ -157,7 +158,6 @@ SetupCommand.options = {
         default: true
     },
     start: {
-        name: 'start',
         description: 'Automatically start Ghost without prompting',
         type: 'boolean',
         default: false

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -4,6 +4,7 @@ const omit = require('lodash/omit');
 
 const Command = require('../command');
 const startupChecks = require('./doctor/checks/startup');
+const ProcessManager = require('../process-manager');
 
 class StartCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {
@@ -29,7 +30,8 @@ class StartCommand extends Command {
         instance.checkEnvironment();
 
         return this.ui.listr(startupChecks, {environment: this.system.environment, config: instance.config}).then(() => {
-            let start = () => Promise.resolve(instance.process.start(process.cwd(), this.system.environment)).then(() => {
+            let processInstance = instance.process;
+            let start = () => Promise.resolve(processInstance.start(process.cwd(), this.system.environment)).then(() => {
                 instance.running = this.system.environment;
             });
 
@@ -38,6 +40,26 @@ class StartCommand extends Command {
             }
 
             return this.ui.run(start, 'Starting Ghost').then(() => {
+                // If process manager doesn't support enable behavior OR
+                // it's already enabled, then skip prompt
+                if (!ProcessManager.supportsEnableBehavior(processInstance) || processInstance.isEnabled()) {
+                    return Promise.resolve({yes: false});
+                }
+
+                // If prompts are disabled or enable is passed,
+                // skip prompt
+                if (argv.enable || !argv.prompt) {
+                    return Promise.resolve({yes: argv.enable});
+                }
+
+                return this.ui.confirm('Do you wish to enable the Ghost instance to start on reboot?')
+            }).then((answer) => {
+                if (!answer.yes) {
+                    return Promise.resolve();
+                }
+
+                return this.ui.run(processInstance.enable(), 'Enabling instance startup on server boot');
+            }).then(() => {
                 this.ui.log(`You can access your blog at ${instance.config.get('url')}`, 'cyan');
             });
         });
@@ -45,5 +67,11 @@ class StartCommand extends Command {
 }
 
 StartCommand.description = 'Start an instance of Ghost';
+StartCommand.options = {
+    enable: {
+        description: 'Enable the instance to restart on server reboot (if the process manager supports it)',
+        type: 'boolean'
+    }
+}
 
 module.exports = StartCommand;

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -5,6 +5,7 @@ const Promise = require('bluebird');
 
 const errors = require('../errors');
 const Command = require('../command');
+const ProcessManager = require('../process-manager');
 
 class StopCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {
@@ -51,7 +52,11 @@ class StopCommand extends Command {
             return stop();
         }
 
-        return this.ui.run(stop, 'Stopping Ghost');
+        return this.ui.run(stop, 'Stopping Ghost').then(() => {
+            if (argv.disable && ProcessManager.supportsEnableBehavior(instance.process) && instance.process.isEnabled()) {
+                return this.ui.run(instance.process.disable(), 'Disabling instance startup on server boot');
+            }
+        });
     }
 
     stopAll() {
@@ -73,6 +78,10 @@ StopCommand.options = {
     all: {
         alias: 'a',
         description: 'option to stop all running Ghost blogs',
+        type: 'boolean'
+    },
+    disable: {
+        description: 'Disable restarting Ghost on server reboot (if the process manager supports it)',
         type: 'boolean'
     }
 };

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -1,8 +1,14 @@
 'use strict';
+const every = require('lodash/every');
 const requiredMethods = [
     'start',
     'stop',
     'isRunning'
+];
+const enableMethods = [
+    'isEnabled',
+    'enable',
+    'disable'
 ];
 
 class ProcessManager {
@@ -79,5 +85,10 @@ function isValid(SubClass) {
     return missing;
 }
 
+function supportsEnableBehavior(processInstance) {
+    return every(enableMethods, (method) => processInstance[method]);
+}
+
 module.exports = ProcessManager
 module.exports.isValid = isValid;
+module.exports.supportsEnableBehavior = supportsEnableBehavior;

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -29,6 +29,23 @@ describe('Unit: Process Manager', function () {
         });
     });
 
+    describe('supportsEnableBehavior', function () {
+        it('returns false if the class does not implement all of the methods for enable behavior', function () {
+            let instance = new ProcessManager({}, {}, {});
+            expect(ProcessManager.supportsEnableBehavior(instance)).to.be.false;
+        });
+
+        it('returns true if all the methods for enable behavior are implemented', function () {
+            class TestProcess extends ProcessManager {
+                isEnabled() { }
+                enable() { }
+                disable() { }
+            }
+            let instance = new TestProcess({}, {}, {});
+            expect(ProcessManager.supportsEnableBehavior(instance)).to.be.true;
+        });
+    });
+
     it('restart base implementation calls start and stop methods', function () {
         let instance = new ProcessManager({}, {}, {});
         let startStub = sinon.stub(instance, 'start').resolves();
@@ -39,5 +56,35 @@ describe('Unit: Process Manager', function () {
             expect(startStub.calledOnce).to.be.true;
             expect(stopStub.calledBefore(startStub)).to.be.true;
         })
+    });
+
+    it('base start implementation returns a promise', function () {
+        let instance = new ProcessManager({}, {}, {});
+        let start = instance.start();
+
+        expect(start).to.be.an.instanceof(Promise);
+        return start;
+    });
+
+    it('base stop implementation returns a promise', function () {
+        let instance = new ProcessManager({}, {}, {});
+        let stop = instance.stop();
+
+        expect(stop).to.be.an.instanceof(Promise);
+        return stop;
+    });
+
+    it('base willRun method returns true', function () {
+        expect(ProcessManager.willRun()).to.be.true;
+    });
+
+    it('base error method re-throws the error', function () {
+        let instance = new ProcessManager({}, {}, {});
+        try {
+            instance.error({error: true});
+            expect(false, 'error should have been thrown').to.be.true;
+        } catch (e) {
+            expect(e).to.deep.equal({error: true});
+        }
     });
 });


### PR DESCRIPTION
closes #248
- add isEnabled, enable, disable methods to process manager
- add support for enable/disable to start and stop commands

TODO:
- [x] test on droplet to verify this actually works
- [x] add tests