### PR TITLE
More work on setup stages

### DIFF
--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -20,8 +20,8 @@ class NginxExtension extends cli.Extension {
         }
 
         cmd.addStage('nginx', this.setupNginx.bind(this));
-        cmd.addStage('ssl', this.setupSSL.bind(this));
-        cmd.addStage('ssl-renew', this.setupRenew.bind(this), 'automatic ssl renewal');
+        cmd.addStage('ssl', this.setupSSL.bind(this), 'nginx');
+        cmd.addStage('ssl-renew', this.setupRenew.bind(this), 'ssl', 'automatic ssl renewal');
     }
 
     setupNginx(argv, ctx, task) {

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -33,10 +33,11 @@ class SetupCommand extends Command {
         this.stages = [];
     }
 
-    addStage(name, fn, description) {
+    addStage(name, fn, dependencies, description) {
         this.stages.push({
             name: name,
             description: description || name,
+            dependencies: dependencies && (Array.isArray(dependencies) ? dependencies : [dependencies]),
             fn: fn
         });
     }
@@ -60,19 +61,6 @@ class SetupCommand extends Command {
             // sure we're set up in development mode
             this.system.setEnvironment(true, true);
         }
-
-        let initialStages = [{
-            title: 'Running setup checks',
-            skip: () => !argv.stack,
-            task: () => this.ui.listr(setupChecks, false)
-        }, {
-            title: 'Setting up instance',
-            task: (ctx) => {
-                ctx.instance = this.system.getInstance();
-                ctx.instance.name = argv.pname || url.parse(ctx.instance.config.get('url')).hostname.replace(/\./g, '-');
-                this.system.addInstance(ctx.instance);
-            }
-        }];
 
         if (argv.stages && argv.stages.length) {
             let instance = this.system.getInstance();
@@ -99,13 +87,41 @@ class SetupCommand extends Command {
             });
         }
 
+        let initialStages = [{
+            title: 'Running setup checks',
+            skip: () => !argv.stack,
+            task: () => this.ui.listr(setupChecks, false)
+        }, {
+            title: 'Setting up instance',
+            task: (ctx) => {
+                ctx.instance = this.system.getInstance();
+                ctx.instance.name = argv.pname || url.parse(ctx.instance.config.get('url')).hostname.replace(/\./g, '-');
+                this.system.addInstance(ctx.instance);
+            }
+        }];
+
         return this.ui.run(() => this.runCommand(ConfigCommand, argv), 'Configuring Ghost').then(
             () => this.system.hook('setup', this, argv)
         ).then(() => {
+            let taskMap = {};
+
             let tasks = initialStages.concat(this.stages.map((stage) => {
                 return {
                     title: `Setting up ${stage.name}`,
                     task: (ctx, task) => {
+                        taskMap[stage.name] = task;
+
+                        if (stage.dependencies) {
+                            // TODO: this depends on Listr private API, probably should find a better way
+                            let skipped = stage.dependencies.filter(dep => !taskMap[dep] || taskMap[dep]._task.isSkipped());
+
+                            if (skipped) {
+                                let plural = skipped.length > 1;
+                                this.ui.log(`Task ${stage.name} depends on the '${skipped.join('\', \'')}' ${plural ? 'stages' : 'stage'}, which ${plural ? 'were' : 'was'} skipped.`, 'gray');
+                                return task.skip();
+                            }
+                        }
+
                         if (argv[`setup-${stage.name}`] === false) {
                             return task.skip();
                         }

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -3,8 +3,8 @@ const url            = require('url');
 const path           = require('path');
 const get            = require('lodash/get');
 const omit           = require('lodash/omit');
+const includes       = require('lodash/includes');
 
-const errors         = require('../errors');
 const Command        = require('../command');
 const migrate        = require('../tasks/migrate');
 const setupChecks    = require('./doctor/checks/setup');
@@ -74,30 +74,28 @@ class SetupCommand extends Command {
             }
         }];
 
-        if (argv.stage) {
+        if (argv.stages && argv.stages.length) {
             let instance = this.system.getInstance();
 
-            // If a user is running a specific setup stage, we want to run the env check here.
+            // If a user is running a specific setup stage (or stages), we want to run the env check here.
             // That way, if they haven't run setup at all for the particular environment that they're running
             // this stage for, then it will use the other one
             instance.checkEnvironment();
 
-            // Special-case migrations
-            if (argv.stage === 'migrate') {
-                return this.ui.run(migrate({instance: instance}), 'Running database migrations');
-            }
-
             return this.system.hook('setup', this, argv).then(() => {
-                let stage = this.stages.find(stage => stage.name === argv.stage);
+                let tasks = this.stages.filter((stage) => includes(argv.stages, stage.name)).map((stage) => {
+                    return {
+                        title: `Setting up ${stage.description}`,
+                        task: (ctx, task) => stage.fn(argv, ctx, task)
+                    };
+                });
 
-                if (!stage) {
-                    throw new errors.SystemError(`No setup stage '${argv.stage} exists`);
+                // Special-case migrations
+                if (includes(argv.stages, 'migrate')) {
+                    tasks.push({title: 'Running database migrations', task: migrate})
                 }
 
-                return this.ui.listr([{
-                    title: `Setting up ${stage.description}`,
-                    task: (ctx, task) => stage.fn(argv, ctx, task)
-                }], {single: true, instance: instance});
+                return this.ui.listr(tasks, {single: true, instance: instance});
             });
         }
 
@@ -151,7 +149,7 @@ class SetupCommand extends Command {
 }
 
 SetupCommand.description = 'Setup an installation of Ghost (after it is installed)';
-SetupCommand.params = '[stage]';
+SetupCommand.params = '[stages..]';
 SetupCommand.options = {
     stack: {
         description: '[--no-stack] Enable/Disable system stack checks on setup',


### PR DESCRIPTION
This PR covers two things:

1. Running of multiple setup stages with one command (e.g. `ghost setup nginx ssl systemd`). This addition will also preserve stage order, so if you type `ghost setup ssl systemd nginx`, it will still run in the right order (`nginx`, `ssl`, then `systemd`).

2. Addition of stage "dependencies". A stage can depend on other stages having run, and two things can occur if a dependent stage hasn't run yet:

    - ~~If the user is running individual stages (e.g. `ghost setup stage1 stage2`), and the dependent stage is not in the list & has not yet been run, it will automatically be added to the list~~ (nixed, too complex)
    - if the user is running the general setup command and the stage has been skipped, the stage that depends on it will also be skipped, with a message stating why.

- [ ] test on ubuntu