### PR TITLE
Mysql extension

### DIFF
--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -2,6 +2,7 @@
 
 const Promise = require('bluebird');
 const mysql = require('mysql');
+const crypto = require('crypto');
 const omit = require('lodash/omit');
 const cli = require('../../lib');
 
@@ -16,41 +17,104 @@ class MySQLExtension extends cli.Extension {
     }
 
     setupMySQL(argv, ctx, task) {
-	let databaseConfig = ctx.instance.config.get('database');
 	let self = this;
+	this.databaseConfig = ctx.instance.config.get('database');
 	
-	return this.canConnect(databaseConfig)
-	    .then(function() {
-		if (databaseConfig.connection.user === 'root') {
+	return this.canConnect()
+	    .then(function() {		
+		if (self.databaseConfig.connection.user === 'root') {
 		    return self.ui.confirm('Your MySQL user is root. Would you like to create a `ghost` MySQL user?', true)
 			.then(function(res) {
 			    if (res.yes) {
-				return self.createMySQLUser();
+				return self.createMySQLUser(ctx);
 			    }
 			});
-		}		
+		}
+
+		self.ui.log('MySQL: Your user is: ' + self.databaseConfig.connection.user, 'green');
+	    })
+	    .finally(function() {
+		self.connection.end();
 	    });
     }   
 
-    canConnect(databaseConfig) {
-	let connection = mysql.createConnection(omit(databaseConfig.connection, 'database'));
+    canConnect() {
 	let self = this;
+	this.connection = mysql.createConnection(omit(self.databaseConfig.connection, 'database'));
 
 	return new Promise(function(resolve, reject) {
-	    connection.connect(function(err) {
+	    self.connection.connect(function(err) {
 		if (err) {
-		    self.ui.log('MySQL connection error.', 'yellow');
+		    self.ui.log('MySQL: connection error.', 'yellow');
 		    return reject(new cli.errors.SystemError(err.message));
 		}
 
-		self.ui.log('MySQL connection successful.', 'green');
-		connection.end();
+		self.ui.log('MySQL: connection successful.', 'green');
 		resolve();
-	    });		
+	    });
 	});
     }
 
-    createMySQLUser() {
+    createMySQLUser(ctx) {
+	let self = this;
+	let randomPassword = crypto.randomBytes(10).toString('hex');
+	let host = self.databaseConfig.connection.host;
+	
+	return new Promise(function(resolve, reject) {
+	    self.connection.query('CREATE USER \'ghost\'@\'' + host + '\' IDENTIFIED BY \'' + randomPassword + '\';', function(err) {
+		if (err) {
+		    // CASE: user exists, we are not able to figure out the original password, skip mysql setup
+		    if (err.errno === 1396) {
+			self.ui.log('MySQL: `ghost` user exists. Skipping.', 'yellow');
+			return resolve();
+		    }
+
+		    self.ui.log('MySQL: unable to create `ghost` user.', 'yellow');
+		    return reject(new cli.errors.SystemError(err.message));
+		}
+
+		self.ui.log('MySQL: successfully created `ghost` user.', 'green');
+
+		self.grantPermissions()
+		    .then(function() {
+			ctx.instance.config.set('database.connection.user', 'ghost');
+			ctx.instance.config.set('database.connection.password', randomPassword);
+			resolve();
+		    })
+		    .catch(reject);
+	    });	    
+	});
+    }
+
+    grantPermissions() {
+	let self = this;
+	let host = self.databaseConfig.connection.host;
+	let database = self.databaseConfig.connection.database;
+	
+	return new Promise(function(resolve, reject) {
+	    self.connection.query('GRANT ALL PRIVILEGES ON ' + database + '.* TO \'ghost\'@\'' + host + '\';', function(err) {
+		if (err) {
+		    self.ui.log('MySQL: unable to grant permissions for `ghost` user.', 'yellow');
+		    return reject(new cli.errors.SystemError(err.message));		    
+		}
+
+		self.ui.log('MySQL: successfully granted permissions for `ghost` user.', 'green');
+
+		self.connection.query('FLUSH PRIVILEGES;', function(err) {
+		    if (err) {
+			self.ui.log('MySQL: unable to flush privileges.', 'yellow');
+			return reject(new cli.errors.SystemError(err.message));		    
+		    }
+
+		    self.ui.log('MySQL: flushed privileges', 'green');
+
+		    resolve();
+		});		    
+	    });	    
+	});	
+    }
+
+    updateGhostConfig() {
 	
     }
 }

--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -26,7 +26,7 @@ class MySQLExtension extends cli.Extension {
         return this.canConnect()
             .then(() => {
                 if (this.databaseConfig.connection.user === 'root') {
-                    return this.ui.confirm('Your MySQL user is root. Would you like to create a `ghost` MySQL user?', true)
+                    return this.ui.confirm('Your MySQL user is root. Would you like to create a custom Ghost MySQL user?', true)
                         .then((res) => {
                             if (res.yes) {
                                 return this.createMySQLUser(ctx);
@@ -50,13 +50,18 @@ class MySQLExtension extends cli.Extension {
 	    })
 	    .catch((err) => {
                 this.ui.log('MySQL: connection error.', 'yellow');
-                throw new cli.errors.SystemError(err.message);
+                throw new cli.errors.SystemError({
+		    message: err.message,
+		    context: 'Either MySQL is not installed or the entered MySQL host ' + this.databaseConfig.connection.host + ':' + (this.databaseConfig.connection.port || '3306')  + ' is unreachable.',
+		    help: 'Please run `ghost config` and then `ghost setup mysql` again.'
+		});
 	    });
     }
 
     createMySQLUser(ctx) {
         let randomPassword = crypto.randomBytes(10).toString('hex');
         let host = self.databaseConfig.connection.host;
+	let username = 'ghost-';
 
 	return this._query('CREATE USER \'ghost\'@\'' + host + '\' IDENTIFIED BY \'' + randomPassword + '\';')
 	    .then(() => {
@@ -78,7 +83,6 @@ class MySQLExtension extends cli.Extension {
                 this.ui.log('MySQL: unable to create `ghost` user.', 'yellow');
                 throw new cli.errors.SystemError(err.message);
 	    });
-        });
     }
 
     grantPermissions() {
@@ -89,7 +93,7 @@ class MySQLExtension extends cli.Extension {
 	    .then(() => {		
                 this.ui.log('MySQL: successfully granted permissions for `ghost` user.', 'green');
 
-                this._query('FLUSH PRIVILEGES;')
+                return this._query('FLUSH PRIVILEGES;')
 		    .then(() => {
 			this.ui.log('MySQL: flushed privileges', 'green');
 		    })
@@ -97,14 +101,11 @@ class MySQLExtension extends cli.Extension {
 			this.ui.log('MySQL: unable to flush privileges.', 'yellow');
                         throw new cli.errors.SystemError(err.message);
 		    });
-                });
-
 	    })
 	    .catch((err) => {
 		this.ui.log('MySQL: unable to grant permissions for `ghost` user.', 'yellow');
                 throw new cli.errors.SystemError(err.message);
 	    });
-        });
     }
 }
 

--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -50,10 +50,27 @@ class MySQLExtension extends cli.Extension {
             })
             .catch((err) => {
                 this.ui.log('MySQL: connection error.', 'yellow');
-                throw new cli.errors.SystemError({
+
+		if (err.code === 'ER_ACCESS_DENIED_ERROR') {
+                    throw new cli.errors.ConfigError({
+			message: err.message,
+			configs: {
+			    'database.connection.user': this.databaseConfig.connection.user,
+			    'database.connection.password': this.databaseConfig.connection.password
+			},
+			environment: ctx.instance.system.environment,
+			help: 'You can run `ghost config` to re-enter the correct credentials. Alternatively you can run `ghost setup` again.'
+                    });
+		}
+		
+                throw new cli.errors.ConfigError({
                     message: err.message,
-                    context: 'Either MySQL is not installed or the entered MySQL host ' + this.databaseConfig.connection.host + ':' + (this.databaseConfig.connection.port || '3306') + ' is unreachable.',
-                    help: 'Please run `ghost config` and then `ghost setup mysql` again.'
+		    configs: {
+			'database.connection.host': this.databaseConfig.connection.host,
+			'database.connection.port': this.databaseConfig.connection.port || '3306'
+		    },
+		    environment: ctx.instance.system.environment,
+                    help: 'Please ensure that MySQL is installed and reachable. You can always re-run `ghost setup` and try it again.'
                 });
             });
     }

--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -51,25 +51,25 @@ class MySQLExtension extends cli.Extension {
             .catch((err) => {
                 this.ui.log('MySQL: connection error.', 'yellow');
 
-		if (err.code === 'ER_ACCESS_DENIED_ERROR') {
+                if (err.code === 'ER_ACCESS_DENIED_ERROR') {
                     throw new cli.errors.ConfigError({
-			message: err.message,
-			configs: {
-			    'database.connection.user': this.databaseConfig.connection.user,
-			    'database.connection.password': this.databaseConfig.connection.password
-			},
-			environment: ctx.instance.system.environment,
-			help: 'You can run `ghost config` to re-enter the correct credentials. Alternatively you can run `ghost setup` again.'
+                        message: err.message,
+                        configs: {
+                            'database.connection.user': this.databaseConfig.connection.user,
+                            'database.connection.password': this.databaseConfig.connection.password
+                        },
+                        environment: ctx.instance.system.environment,
+                        help: 'You can run `ghost config` to re-enter the correct credentials. Alternatively you can run `ghost setup` again.'
                     });
-		}
-		
+                }
+
                 throw new cli.errors.ConfigError({
                     message: err.message,
-		    configs: {
-			'database.connection.host': this.databaseConfig.connection.host,
-			'database.connection.port': this.databaseConfig.connection.port || '3306'
-		    },
-		    environment: ctx.instance.system.environment,
+                    configs: {
+                        'database.connection.host': this.databaseConfig.connection.host,
+                        'database.connection.port': this.databaseConfig.connection.port || '3306'
+                    },
+                    environment: ctx.instance.system.environment,
                     help: 'Please ensure that MySQL is installed and reachable. You can always re-run `ghost setup` and try it again.'
                 });
             });
@@ -79,11 +79,11 @@ class MySQLExtension extends cli.Extension {
         let randomPassword = crypto.randomBytes(10).toString('hex');
         let host = this.databaseConfig.connection.host;
 
-	// IMPORTANT: we generate random MySQL usernames
-	// e.g. you delete all your Ghost instances from your droplet and start from scratch, the MySQL users would remain and the CLI has to generate a random user name to be able to
-	// e.g. if we would rely on the instance name, the instance naming only auto increments if there are existing instances
-	// the most important fact is, that if a MySQL user exists, we have no access to the password, which we need to autofill the Ghost config
-	// disadvantage: the CLI could potentially create lot's of MySQL users (but this should only happen if the user installs Ghost over and over again with root credentials)
+        // IMPORTANT: we generate random MySQL usernames
+        // e.g. you delete all your Ghost instances from your droplet and start from scratch, the MySQL users would remain and the CLI has to generate a random user name to be able to
+        // e.g. if we would rely on the instance name, the instance naming only auto increments if there are existing instances
+        // the most important fact is, that if a MySQL user exists, we have no access to the password, which we need to autofill the Ghost config
+        // disadvantage: the CLI could potentially create lot's of MySQL users (but this should only happen if the user installs Ghost over and over again with root credentials)
         let username = 'ghost-' + Math.floor(Math.random() * 1000);
 
         return this._query('CREATE USER \'' + username + '\'@\'' + host + '\' IDENTIFIED BY \'' + randomPassword + '\';')
@@ -111,7 +111,7 @@ class MySQLExtension extends cli.Extension {
     grantPermissions(options) {
         let host = this.databaseConfig.connection.host;
         let database = this.databaseConfig.connection.database;
-	let username = options.username;
+        let username = options.username;
 
         return this._query('GRANT ALL PRIVILEGES ON ' + database + '.* TO \'' + username + '\'@\'' + host + '\';')
             .then(() => {

--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -8,114 +8,110 @@ const cli = require('../../lib');
 
 class MySQLExtension extends cli.Extension {
     setup(cmd, argv) {
-	// ghost setup --local, skip
-	if (argv.local) {
-	    return;
-	}
+        // ghost setup --local, skip
+        if (argv.local) {
+            return;
+        }
 
-	cmd.addStage('mysql', this.setupMySQL.bind(this));
+        cmd.addStage('mysql', this.setupMySQL.bind(this));
     }
 
     setupMySQL(argv, ctx, task) {
-	let self = this;
-	this.databaseConfig = ctx.instance.config.get('database');
-	
-	return this.canConnect()
-	    .then(function() {		
-		if (self.databaseConfig.connection.user === 'root') {
-		    return self.ui.confirm('Your MySQL user is root. Would you like to create a `ghost` MySQL user?', true)
-			.then(function(res) {
-			    if (res.yes) {
-				return self.createMySQLUser(ctx);
-			    }
-			});
-		}
+        let self = this;
+        this.databaseConfig = ctx.instance.config.get('database');
 
-		self.ui.log('MySQL: Your user is: ' + self.databaseConfig.connection.user, 'green');
-	    })
-	    .finally(function() {
-		self.connection.end();
-	    });
-    }   
+        return this.canConnect()
+            .then(function () {
+                if (self.databaseConfig.connection.user === 'root') {
+                    return self.ui.confirm('Your MySQL user is root. Would you like to create a `ghost` MySQL user?', true)
+                        .then(function (res) {
+                            if (res.yes) {
+                                return self.createMySQLUser(ctx);
+                            }
+                        });
+                }
+
+                self.ui.log('MySQL: Your user is: ' + self.databaseConfig.connection.user, 'green');
+            })
+            .finally(function () {
+                self.connection.end();
+            });
+    }
 
     canConnect() {
-	let self = this;
-	this.connection = mysql.createConnection(omit(self.databaseConfig.connection, 'database'));
+        let self = this;
+        this.connection = mysql.createConnection(omit(self.databaseConfig.connection, 'database'));
 
-	return new Promise(function(resolve, reject) {
-	    self.connection.connect(function(err) {
-		if (err) {
-		    self.ui.log('MySQL: connection error.', 'yellow');
-		    return reject(new cli.errors.SystemError(err.message));
-		}
+        return new Promise(function (resolve, reject) {
+            self.connection.connect(function (err) {
+                if (err) {
+                    self.ui.log('MySQL: connection error.', 'yellow');
+                    return reject(new cli.errors.SystemError(err.message));
+                }
 
-		self.ui.log('MySQL: connection successful.', 'green');
-		resolve();
-	    });
-	});
+                self.ui.log('MySQL: connection successful.', 'green');
+                resolve();
+            });
+        });
     }
 
     createMySQLUser(ctx) {
-	let self = this;
-	let randomPassword = crypto.randomBytes(10).toString('hex');
-	let host = self.databaseConfig.connection.host;
-	
-	return new Promise(function(resolve, reject) {
-	    self.connection.query('CREATE USER \'ghost\'@\'' + host + '\' IDENTIFIED BY \'' + randomPassword + '\';', function(err) {
-		if (err) {
-		    // CASE: user exists, we are not able to figure out the original password, skip mysql setup
-		    if (err.errno === 1396) {
-			self.ui.log('MySQL: `ghost` user exists. Skipping.', 'yellow');
-			return resolve();
-		    }
+        let self = this;
+        let randomPassword = crypto.randomBytes(10).toString('hex');
+        let host = self.databaseConfig.connection.host;
 
-		    self.ui.log('MySQL: unable to create `ghost` user.', 'yellow');
-		    return reject(new cli.errors.SystemError(err.message));
-		}
+        return new Promise(function (resolve, reject) {
+            self.connection.query('CREATE USER \'ghost\'@\'' + host + '\' IDENTIFIED BY \'' + randomPassword + '\';', function (err) {
+                if (err) {
+                    // CASE: user exists, we are not able to figure out the original password, skip mysql setup
+                    if (err.errno === 1396) {
+                        self.ui.log('MySQL: `ghost` user exists. Skipping.', 'yellow');
+                        return resolve();
+                    }
 
-		self.ui.log('MySQL: successfully created `ghost` user.', 'green');
+                    self.ui.log('MySQL: unable to create `ghost` user.', 'yellow');
+                    return reject(new cli.errors.SystemError(err.message));
+                }
 
-		self.grantPermissions()
-		    .then(function() {
-			ctx.instance.config.set('database.connection.user', 'ghost');
-			ctx.instance.config.set('database.connection.password', randomPassword);
-			resolve();
-		    })
-		    .catch(reject);
-	    });	    
-	});
+                self.ui.log('MySQL: successfully created `ghost` user.', 'green');
+
+                self.grantPermissions()
+                    .then(function () {
+                        ctx.instance.config.set('database.connection.user', 'ghost');
+                        ctx.instance.config.set('database.connection.password', randomPassword);
+                        resolve();
+                    })
+                    .catch(reject);
+            });
+        });
     }
 
     grantPermissions() {
-	let self = this;
-	let host = self.databaseConfig.connection.host;
-	let database = self.databaseConfig.connection.database;
-	
-	return new Promise(function(resolve, reject) {
-	    self.connection.query('GRANT ALL PRIVILEGES ON ' + database + '.* TO \'ghost\'@\'' + host + '\';', function(err) {
-		if (err) {
-		    self.ui.log('MySQL: unable to grant permissions for `ghost` user.', 'yellow');
-		    return reject(new cli.errors.SystemError(err.message));		    
-		}
+        let self = this;
+        let host = self.databaseConfig.connection.host;
+        let database = self.databaseConfig.connection.database;
 
-		self.ui.log('MySQL: successfully granted permissions for `ghost` user.', 'green');
+        return new Promise(function (resolve, reject) {
+            self.connection.query('GRANT ALL PRIVILEGES ON ' + database + '.* TO \'ghost\'@\'' + host + '\';', function (err) {
+                if (err) {
+                    self.ui.log('MySQL: unable to grant permissions for `ghost` user.', 'yellow');
+                    return reject(new cli.errors.SystemError(err.message));
+                }
 
-		self.connection.query('FLUSH PRIVILEGES;', function(err) {
-		    if (err) {
-			self.ui.log('MySQL: unable to flush privileges.', 'yellow');
-			return reject(new cli.errors.SystemError(err.message));		    
-		    }
+                self.ui.log('MySQL: successfully granted permissions for `ghost` user.', 'green');
 
-		    self.ui.log('MySQL: flushed privileges', 'green');
+                self.connection.query('FLUSH PRIVILEGES;', function (err) {
+                    if (err) {
+                        self.ui.log('MySQL: unable to flush privileges.', 'yellow');
+                        return reject(new cli.errors.SystemError(err.message));
+                    }
 
-		    resolve();
-		});		    
-	    });	    
-	});	
-    }
+                    self.ui.log('MySQL: flushed privileges', 'green');
 
-    updateGhostConfig() {
-	
+                    resolve();
+                });
+            });
+        });
     }
 }
 

--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const Promise = require('bluebird');
+const mysql = require('mysql');
+const omit = require('lodash/omit');
+const cli = require('../../lib');
+
+class MySQLExtension extends cli.Extension {
+    setup(cmd, argv) {
+	// ghost setup --local, skip
+	if (argv.local) {
+	    return;
+	}
+
+	cmd.addStage('mysql', this.setupMySQL.bind(this));
+    }
+
+    setupMySQL(argv, ctx, task) {
+	let databaseConfig = ctx.instance.config.get('database');
+	let self = this;
+	
+	return this.canConnect(databaseConfig)
+	    .then(function() {
+		if (databaseConfig.connection.user === 'root') {
+		    return self.ui.confirm('Your MySQL user is root. Would you like to create a `ghost` MySQL user?', true)
+			.then(function(res) {
+			    if (res.yes) {
+				return self.createMySQLUser();
+			    }
+			});
+		}		
+	    });
+    }   
+
+    canConnect(databaseConfig) {
+	let connection = mysql.createConnection(omit(databaseConfig.connection, 'database'));
+	let self = this;
+
+	return new Promise(function(resolve, reject) {
+	    connection.connect(function(err) {
+		if (err) {
+		    self.ui.log('MySQL connection error.', 'yellow');
+		    return reject(new cli.errors.SystemError(err.message));
+		}
+
+		self.ui.log('MySQL connection successful.', 'green');
+		connection.end();
+		resolve();
+	    });		
+	});
+    }
+
+    createMySQLUser() {
+	
+    }
+}
+
+module.exports = MySQLExtension;

--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -34,7 +34,7 @@ class MySQLExtension extends cli.Extension {
                         });
                 }
 
-                self.ui.log('MySQL: Your user is: ' + this.databaseConfig.connection.user, 'green');
+                this.ui.log('MySQL: Your user is: ' + this.databaseConfig.connection.user, 'green');
             })
             .finally(() => {
                 this.connection.end();
@@ -60,7 +60,7 @@ class MySQLExtension extends cli.Extension {
 
     createMySQLUser(ctx) {
         let randomPassword = crypto.randomBytes(10).toString('hex');
-        let host = self.databaseConfig.connection.host;
+        let host = this.databaseConfig.connection.host;
         let username = 'ghost-';
 
         return this._query('CREATE USER \'ghost\'@\'' + host + '\' IDENTIFIED BY \'' + randomPassword + '\';')
@@ -86,8 +86,8 @@ class MySQLExtension extends cli.Extension {
     }
 
     grantPermissions() {
-        let host = self.databaseConfig.connection.host;
-        let database = self.databaseConfig.connection.database;
+        let host = this.databaseConfig.connection.host;
+        let database = this.databaseConfig.connection.database;
 
         return this._query('GRANT ALL PRIVILEGES ON ' + database + '.* TO \'ghost\'@\'' + host + '\';')
             .then(() => {

--- a/extensions/mysql/package.json
+++ b/extensions/mysql/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "ghost-cli-config-mysql",
+  "name": "ghost-cli-mysql",
   "version": "0.0.0",
   "description": "MySQL configuration handling for Ghost-CLI",
   "keywords": [
     "ghost-cli-extension"
-  ]
+  ],
+  "main": "index.js"
 }

--- a/lib/commands/doctor/checks/setup.js
+++ b/lib/commands/doctor/checks/setup.js
@@ -38,7 +38,7 @@ module.exports = [{
 
             // If the error caught is not a SystemError, something went wrong with execa,
             // so throw a ProcessError instead
-            if (!(error.errors[0] instanceof errors.SystemError)) {
+            if (!(error instanceof errors.SystemError)) {
                 return Promise.reject(new errors.ProcessError(error));
             }
 

--- a/lib/commands/doctor/checks/setup.js
+++ b/lib/commands/doctor/checks/setup.js
@@ -38,7 +38,7 @@ module.exports = [{
 
             // If the error caught is not a SystemError, something went wrong with execa,
             // so throw a ProcessError instead
-            if (!(error instanceof errors.SystemError)) {
+            if (!(error.errors[0] instanceof errors.SystemError)) {
                 return Promise.reject(new errors.ProcessError(error));
             }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -51,6 +51,14 @@ class CliError extends Error {
     toString(verbose) {
         let output = `${chalk.yellow('Message:')} ${this.message}\n`;
 
+	if (this.options.context) {
+	    output += `${chalk.yellow('Context:')} ${this.options.context}\n`;
+	}
+
+	if (this.options.help) {
+	    output += `${chalk.green('Help:')} ${this.options.help}\n`;
+	}
+
         if (verbose) {
             output += `${chalk.yellow('Stack:')} ${this.stack}\n`;
         }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -51,14 +51,6 @@ class CliError extends Error {
     toString(verbose) {
         let output = `${chalk.yellow('Message:')} ${this.message}\n`;
 
-	if (this.options.context) {
-	    output += `${chalk.yellow('Context:')} ${this.options.context}\n`;
-	}
-
-	if (this.options.help) {
-	    output += `${chalk.green('Help:')} ${this.options.help}\n`;
-	}
-
         if (verbose) {
             output += `${chalk.yellow('Stack:')} ${this.stack}\n`;
         }
@@ -141,11 +133,25 @@ class ConfigError extends CliError {
         let initial = chalk.red(`Error detected in the ${this.options.environment} configuration.\n\n`) +
             `${chalk.gray('Message:')} ${this.options.message}\n`;
 
+	// @TODO: merge this solution into one
         if (this.options.configKey) {
             initial += `${chalk.gray('Configuration Key:')} ${this.options.configKey}\n` +
                 `${chalk.gray('Current Value:')} ${this.options.configValue}\n\n` +
                 chalk.blue(`Run \`${chalk.underline(`ghost config ${this.options.configKey} <new value>`)}\` to fix it.\n`);
-        }
+        } else if (this.options.configs) {
+	    initial += '\n';
+	    
+	    for (let key in this.options.configs) {
+		initial += `${chalk.gray('Configuration Key:')} ${key}\n` +
+                    `${chalk.gray('Current Value:')} ${this.options.configs[key]}\n\n`;
+	    }
+
+	    if (this.options.help) {
+		initial += '\n';
+		initial += `${chalk.gray('Help:')} ${this.options.help}`;
+		initial += '\n';
+	    }
+	}
 
         return initial;
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -98,7 +98,8 @@ class ProcessError extends CliError {
  * @class GhostError
  * @extends CliError
  */
-class GhostError extends CliError {}
+class GhostError extends CliError {
+}
 
 /**
  * Handles all errors resulting from system issues
@@ -133,25 +134,27 @@ class ConfigError extends CliError {
         let initial = chalk.red(`Error detected in the ${this.options.environment} configuration.\n\n`) +
             `${chalk.gray('Message:')} ${this.options.message}\n`;
 
-	// @TODO: merge this solution into one
+        // @TODO: merge this solution into one
         if (this.options.configKey) {
             initial += `${chalk.gray('Configuration Key:')} ${this.options.configKey}\n` +
                 `${chalk.gray('Current Value:')} ${this.options.configValue}\n\n` +
                 chalk.blue(`Run \`${chalk.underline(`ghost config ${this.options.configKey} <new value>`)}\` to fix it.\n`);
         } else if (this.options.configs) {
-	    initial += '\n';
-	    
-	    for (let key in this.options.configs) {
-		initial += `${chalk.gray('Configuration Key:')} ${key}\n` +
-                    `${chalk.gray('Current Value:')} ${this.options.configs[key]}\n\n`;
-	    }
+            initial += '\n';
 
-	    if (this.options.help) {
-		initial += '\n';
-		initial += `${chalk.gray('Help:')} ${this.options.help}`;
-		initial += '\n';
-	    }
-	}
+            for (const key in this.options.configs) {
+                if (this.options.configs.hasOwnProperty(key)) {
+                    initial += `${chalk.gray('Configuration Key:')} ${key}\n` +
+                        `${chalk.gray('Current Value:')} ${this.options.configs[key]}\n\n`;
+                }
+            }
+
+            if (this.options.help) {
+                initial += '\n';
+                initial += `${chalk.gray('Help:')} ${this.options.help}`;
+                initial += '\n';
+            }
+        }
 
         return initial;
     }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "knex-migrator": "2.0.16",
     "listr": "0.12.0",
     "lodash": "4.17.4",
-    "mysql": "^2.13.0",
+    "mysql": "2.13.0",
     "nginx-conf": "1.3.0",
     "ora": "1.3.0",
     "portfinder": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "knex-migrator": "2.0.16",
     "listr": "0.12.0",
     "lodash": "4.17.4",
+    "mysql": "^2.13.0",
     "nginx-conf": "1.3.0",
     "ora": "1.3.0",
     "portfinder": "1.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,7 +2449,7 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-mysql@^2.11.1, mysql@^2.13.0:
+mysql@2.13.0, mysql@^2.11.1:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.13.0.tgz#998f1f8ca46e2e3dd7149ce982413653986aae47"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,7 +2449,7 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-mysql@^2.11.1:
+mysql@^2.11.1, mysql@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.13.0.tgz#998f1f8ca46e2e3dd7149ce982413653986aae47"
   dependencies:


### PR DESCRIPTION
refs #191 

### to discuss/edge cases
- If the mysql `ghost` user exists, the CLI can detect that, but that's it - we won't be able to figure out the password - so imagine you run `ghost setup` twice. on the first run the CLI creates the mysql user and stores this user inside the config.production.json. Then the user manually deletes this file. And he runs `ghost setup` again, he enters the root credentials again. The CLI would detect that the custom mysql user exists, but without a password, we can't do anything. Edge case?
- there is a tricky case: imagine we have created the mysql user for you. the ghost user is part of the config file. alright, now you re-run `ghost setup` and change the database name. You can't change your privileges without the root credentials, we would have to prompt the credentials again.

### TODO
- [x] remove hotfix for lib/commands/doctor/checks/setup.js, wait that the fix is merged
