### PR TITLE
feat(linux): add linux user extension

### DIFF
--- a/extensions/linux/index.js
+++ b/extensions/linux/index.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const os = require('os');
+const execa = require('execa');
+
+const cli = require('../../lib');
+
+class LinuxExtension extends cli.Extension {
+    setup(cmd, argv) {
+        if (argv.local) {
+            return;
+        }
+
+        cmd.addStage('linux-user', this.addGhostUser.bind(this), null, 'a ghost system user');
+    }
+
+    addGhostUser(argv, ctx, task) {
+        if (os.platform() !== 'linux') {
+            this.ui.log('Platform is not linux', 'yellow');
+            return task.skip();
+        }
+
+        try {
+            execa.shellSync('id ghost');
+            this.ui.log('Ghost user already exists', 'cyan');
+            return task.skip();
+        } catch (e) {
+            if (!e.message.match(/no such user/)) {
+                return Promise.reject(e);
+            }
+        }
+
+        return this.ui.listr([{
+            title: 'Creating ghost system user',
+            task: () => this.ui.sudo('useradd --system --user-group ghost')
+        }, {
+            title: 'Changing directory permissions',
+            task: () => this.ui.sudo(`chown -R ghost:ghost ${ctx.instance.dir}`)
+        }, {
+            title: 'Adding current user to ghost group',
+            task: (ctx) => {
+                return execa.shell('id -un').then((result) => {
+                    ctx.currentuser = result.stdout;
+                    return this.ui.sudo(`gpasswd --add ${ctx.currentuser} ghost`);
+                });
+            }
+        }], false);
+    }
+}
+
+module.exports = LinuxExtension;

--- a/extensions/linux/package.json
+++ b/extensions/linux/package.json
@@ -2,6 +2,7 @@
   "name": "ghost-cli-linux",
   "description": "general linux user configuration for Ghost",
   "version": "0.0.0",
+  "main": "index.js",
   "keywords":[
     "ghost-cli-extension"
   ]

--- a/extensions/systemd/index.js
+++ b/extensions/systemd/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const execa = require('execa');
 const template = require('lodash/template');
 
 const cli = require('../../lib');
@@ -11,18 +12,31 @@ class SystemdExtension extends cli.Extension {
         let instance = this.system.getInstance();
 
         if (!argv.local && instance.config.get('process') === 'systemd') {
-            cmd.addStage('systemd', this._setup.bind(this));
+            cmd.addStage('systemd', this._setup.bind(this), 'linux-user');
         }
     }
 
-    _setup(argv, ctx) {
+    _setup(argv, ctx, task) {
+        let uid;
+
+        try {
+            uid = execa.shellSync('id -u ghost').stdout;
+        } catch (e) {
+            if (!e.message.match(/no such user/)) {
+                return Promise.reject(e);
+            }
+
+            this.ui.log('Ghost user has not been set up, please run `ghost setup linux-user` first', 'yellow');
+            return task.skip();
+        }
+
         let service = template(fs.readFileSync(path.join(__dirname, 'ghost.service.template'), 'utf8'));
         let serviceFilename = `ghost_${ctx.instance.name}.service`;
 
         return ctx.instance.template(service({
             name: ctx.instance.name,
             dir: process.cwd(),
-            user: process.getuid(),
+            user: uid,
             environment: this.system.environment,
             ghost_exec_path: process.argv.slice(0,2).join(' ')
         }), 'systemd service file', serviceFilename, '/lib/systemd/system').then(() => {


### PR DESCRIPTION
closes #189
- add linux extension that creates a `ghost` user on the system, used by systemd (and potentially any other process manager)

- [x] test on ubuntu box