### PR TITLE
👀  Log LTS warning when `config.js` file is found

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -12,7 +12,6 @@ const kebabCase = require('lodash/kebabCase');
 
 const UI = require('./ui');
 const System = require('./system');
-const Config = require('./utils/config');
 
 const debug = createDebug('ghost-cli:command');
 
@@ -39,9 +38,20 @@ function checkValidInstall(name) {
     }
 
     /*
+     * CASE: a `config.js` file exists, which means this is a LTS installation
+     * which we don't support in the CLI
+     */
+    if (fs.existsSync(path.join(process.cwd(), 'config.js'))) {
+        console.error('Ghost-CLI only works with Ghost versions >= 1.0.0. ' +
+        `Please run 'ghost ${name}' again within a valid Ghost installation.`);
+
+        process.exit(1);
+    }
+
+    /*
      * Assume it's not a valid CLI install if the `.ghost-cli` file doesn't exist
      */
-    if (!Config.exists(path.join(process.cwd(), '.ghost-cli'))) {
+    if (!fs.existsSync(path.join(process.cwd(), '.ghost-cli'))) {
         console.error('Working directory is not a valid Ghost installation. ' +
         `Please run 'ghost ${name}' again within a valid Ghost installation.`);
 


### PR DESCRIPTION
refs #236
refs #216

Logs a more useful error warning, if user attempts to use Ghost-CLI within a LTS installation. Indicator for LTS installation is the presence of a `config.js` file.

![image](https://user-images.githubusercontent.com/8037602/27850213-33378c28-617d-11e7-93ea-426bc87b78d2.png)
