### PR TITLE
📖  Add troubleshooting link to errors

### DIFF
--- a/lib/commands/doctor/checks/install.js
+++ b/lib/commands/doctor/checks/install.js
@@ -15,7 +15,7 @@ module.exports = [{
                 `${chalk.red('The version of node you are using is not supported.')}${eol}` +
                 `${chalk.gray('Supported: ')}${cliPackage.engines.node}${eol}` +
                 `${chalk.gray('Installed: ')}${process.versions.node}${eol}` +
-                `See ${chalk.underline.blue('https://support.ghost.org/supported-node-versions')} ` +
+                `See ${chalk.underline.blue('https://docs.ghost.org/docs/supported-node-versions')} ` +
                 'for more information'
             ));
         }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,6 +24,7 @@ class CliError extends Error {
 
         this.context = options.context || {};
         this.options = options;
+        this.help = 'Please refer to https://docs.ghost.org/docs/installing-ghost-via-the-cli#troubleshooting for troubleshooting.'
     }
 
     /**

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -294,6 +294,8 @@ class UI {
                 let logLocation = system.writeErrorLog(stripAnsi(`${debugInfo}\n${verboseOutput}`));
                 this.log(`\nAdditional log info available in: ${logLocation}`);
             }
+
+            this.log('\n' + error.help, 'blue');
         } else if (error instanceof Error) {
             // System errors or regular old errors go here.
             let output = `An error occurred.\n${chalk.yellow('Message:')} '${error.message}'\n\n`;
@@ -321,6 +323,7 @@ class UI {
             this.log(debugInfo, 'yellow');
             let logLocation = system.writeErrorLog(stripAnsi(`${debugInfo}\n${output}`));
             this.log(`\nAdditional log info available in: ${logLocation}`);
+            this.log('\nPlease refer to https://docs.ghost.org/docs/installing-ghost-via-the-cli#troubleshooting for troubleshooting.', 'blue');
         } else if (isObject(error)) {
             // TODO: find better way to handle object errors?
             this.log(JSON.stringify(error), null, true);


### PR DESCRIPTION
refs #216

- adds message "Please refer to https://docs.ghost.org for troubleshooting." to CliError as `help` property.
- adds the same message to the ui handling for native JS errors.
- changes the link for supported node versions to the docs