### PR TITLE
fix(prompt): respect `--no-prompt` option in other areas

### DIFF
--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -116,10 +116,11 @@ class ConfigCommand extends Command {
             return Promise.resolve();
         }
 
-        // If url && db are set or if
-        // every prompt is provided in options
-        // then skip prompts
-        if ((argv.db && argv.url) || every(prompts.map((prompt) => prompt.name), (name) => argv[name])) {
+        // 3 cases for skipping
+        //   1: both db and url are provided
+        //   2: Prompting has been disabled (via --no-prompt)
+        //   3: All prompt values have been supplied
+        if ((argv.db && argv.url) || !argv.prompt || every(prompts.map((prompt) => prompt.name), (name) => argv[name])) {
             return this.handleAdvancedOptions(argv);
         }
 

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -8,7 +8,7 @@ class UninstallCommand extends Command {
     run(argv) {
         let prompt;
 
-        if (!argv.force) {
+        if (!argv.force && argv.prompt) {
             this.ui.log('WARNING: Running this command will delete all of your themes, images, data, and any files related to this ghost instance!\n' +
                 'There is no going back!', 'yellow');
 


### PR DESCRIPTION
closes #276, refs #280
- fix various instances where the --no-prompt option was not correctly respected,  resulting in an error

- [x] test on ubuntu