### PR TITLE
🐛 fix(linux): give ghost folder correct perms

### DIFF
--- a/extensions/linux/index.js
+++ b/extensions/linux/index.js
@@ -37,6 +37,9 @@ class LinuxExtension extends cli.Extension {
             task: () => this.ui.sudo('useradd --system --user-group ghost')
         }, {
             title: 'Changing directory permissions',
+            task: () => this.ui.sudo(`chmod -R 775 ${ctx.instance.dir}`)
+        },  {
+            title: 'Changing directory ownership',
             task: () => this.ui.sudo(`chown -R ghost:ghost ${ctx.instance.dir}`)
         }, {
             title: 'Adding current user to ghost group',


### PR DESCRIPTION
This fixes a problem where the ghost folder doesn't have enough permissions for the group that owns it. The quickest solution would have been to do `g+w`, however that would only solve one case.

The best solution is to set the exact mode we want, however this gets us into a wider discussion of the best permissions for all folders and files.

I've raised #294 to deal with the wider problem after 1.0.0, for now I'm setting permissions to 774, which hopefully should be good enough for now.

closes #290, refs #294 

- as well as ownership, we need to set permissions
- for now, I've set this to 774
- see #294 for a better plan long term