### PR TITLE
fix(ssl): fix acme.sh location and cleanup error handling

### DIFF
--- a/extensions/nginx/commands/ssl-renew.js
+++ b/extensions/nginx/commands/ssl-renew.js
@@ -12,15 +12,7 @@ class SslRenewCommand extends cli.Command {
         }
 
         let email = instance.cliConfig.get('extension.sslemail');
-        return this.ui.run(letsencrypt(instance, email, false, true), 'Renewing SSL certificate')
-            .catch((error) => {
-                if (error.stdout.match(/Skip/)) {
-                    this.ui.log('Certificate not due for renewal yet, skipping', 'yellow');
-                    return;
-                }
-
-                return Promise.reject(new cli.errors.ProcessError(error));
-            });
+        return this.ui.run(letsencrypt(instance, email, false, true), 'Renewing SSL certificate');
     }
 }
 

--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -162,8 +162,7 @@ class NginxExtension extends cli.Extension {
         }, {
             title: 'Getting SSL Certificate',
             task: () => {
-                return letsencrypt(ctx.instance, argv.sslemail, argv.sslstaging)
-                    .catch((error) => Promise.reject(new cli.errors.ProcessError(error)));
+                return letsencrypt(ctx.instance, argv.sslemail, argv.sslstaging);
             }
         }, {
             title: 'Generating Encryption Key (may take a few minutes)',


### PR DESCRIPTION
no issue
- downloads acme to local install rather than global folder
- cleans up error handling so we don't throw a ProcessError if we get an error from download