### PR TITLE
fix(systemd): improve setup checks of extension and process manager

### DIFF
--- a/extensions/systemd/get-uid.js
+++ b/extensions/systemd/get-uid.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const execa = require('execa');
+
+/**
+ * Helper function used by both the extension setup method
+ * and the systemd process manager. This checks if the
+ * linux ghost user has been set up. If not, the function returns null,
+ * but if so, it returns the user id of the ghost user
+ */
+module.exports = function getUid(dir) {
+    try {
+        let uid = execa.shellSync('id -u ghost').stdout;
+        let stat = fs.lstatSync(path.join(dir, 'content'));
+
+        if (stat.uid.toString() !== uid) {
+            // Ghost user is not the owner of this folder, return null
+            return null;
+        }
+
+        return uid;
+    } catch (e) {
+        if (!e.message.match(/no such user/)) {
+            throw e;
+        }
+
+        return null;
+    }
+};

--- a/extensions/systemd/index.js
+++ b/extensions/systemd/index.js
@@ -2,10 +2,10 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const execa = require('execa');
 const template = require('lodash/template');
 
 const cli = require('../../lib');
+const getUid = require('./get-uid');
 
 class SystemdExtension extends cli.Extension {
     setup(cmd, argv) {
@@ -17,15 +17,9 @@ class SystemdExtension extends cli.Extension {
     }
 
     _setup(argv, ctx, task) {
-        let uid;
+        let uid = getUid(ctx.instance.dir);
 
-        try {
-            uid = execa.shellSync('id -u ghost').stdout;
-        } catch (e) {
-            if (!e.message.match(/no such user/)) {
-                return Promise.reject(e);
-            }
-
+        if (!uid) {
             this.ui.log('Ghost user has not been set up, please run `ghost setup linux-user` first', 'yellow');
             return task.skip();
         }


### PR DESCRIPTION
closes #291
- add function to double check that linux-user has been run
- make help messaging more clear