### PR TITLE
fix(systemd): update is-enabled error handling to be better

### DIFF
--- a/extensions/systemd/systemd.js
+++ b/extensions/systemd/systemd.js
@@ -37,7 +37,8 @@ class SystemdProcessManager extends cli.ProcessManager {
             return true;
         } catch (e) {
             // Systemd prints out "disabled" if service isn't enabled
-            if (!e.message.match(/disabled/)) {
+            // or "failed to get unit file state" if something else goes wrong
+            if (!e.message.match(/disabled|Failed to get unit file state/)) {
                 throw e;
             }
 


### PR DESCRIPTION
closes #293
- expands error message regex to also check for failed unit file state

cc @sebgie would be good to get your eyes on this - i'm not sure if there's any other potential implications of this change.

my thought is that the enable check is somehow running before ghost has completely started, leading to the "failed to get unit file state" error, but I could be wrong.