### PR TITLE
Various SSL setup fixes

### DIFF
--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -161,9 +161,7 @@ class NginxExtension extends cli.Extension {
             task: () => this.restartNginx()
         }, {
             title: 'Getting SSL Certificate',
-            task: () => {
-                return letsencrypt(ctx.instance, argv.sslemail, argv.sslstaging);
-            }
+            task: () => letsencrypt(ctx.instance, argv.sslemail, argv.sslstaging)
         }, {
             title: 'Generating Encryption Key (may take a few minutes)',
             task: (ctx) => {

--- a/extensions/nginx/letsencrypt.js
+++ b/extensions/nginx/letsencrypt.js
@@ -46,7 +46,7 @@ module.exports = function letsencrypt(instance, email, staging, renew) {
         if (error.stdout.match(/Skip/)) {
             // Certificate already exists
             if (renew) {
-                instance.ui.log('Certificate not due for renewal yet, skipping', 'yellow');
+                instance.ui.log('SSL certificate not due for renewal yet, skipping', 'yellow');
                 return;
             }
 


### PR DESCRIPTION
closes #309
- if a user deletes their instance and recreates it with the same domain, then acme will fail to generate the certificate because it already exists & is not due for renewal. We work around this issue by looking for the error and copying the right keys if it already exists

closes #302 
- checks if ssl has already been setup, if it has then skips
- better cleanup/handling of well-known config block