### PR TITLE
fix(run): set content path in config rather than in environment

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -14,7 +14,9 @@ class RunCommand extends Command {
 
         let instance = this.system.getInstance();
 
-        process.env.paths__contentPath = path.join(process.cwd(), 'content');
+        if (!instance.config.has('paths.contentPath')) {
+            instance.config.set('paths.contentPath', path.join(instance.dir, 'content')).save();
+        }
 
         this.child = spawn(process.execPath, ['current/index.js'], {
             cwd: process.cwd(),

--- a/lib/tasks/migrate.js
+++ b/lib/tasks/migrate.js
@@ -5,8 +5,11 @@ const KnexMigrator = require('knex-migrator');
 const errors = require('../errors');
 
 module.exports = function runMigrations(context) {
-    process.env.paths__contentPath = path.join(process.cwd(), 'content');
     let config = context.instance.config;
+
+    if (!config.has('paths.contentPath')) {
+        config.set('paths.contentPath', path.join(context.instance.dir, 'content')).save();
+    }
 
     let transports = config.get('logging.transports', null);
     // TODO: revisit just hiding migration output altogether

--- a/test/unit/tasks/migrate-spec.js
+++ b/test/unit/tasks/migrate-spec.js
@@ -15,11 +15,38 @@ class TestError extends Error {
     }
 }
 
+function getConfigStub(noContentPath) {
+    let config = {
+        get: sinon.stub(),
+        set: sinon.stub().returnsThis(),
+        has: sinon.stub(),
+        save: sinon.stub().returnsThis()
+    };
+
+    config.has.withArgs('paths.contentPath').returns(!noContentPath);
+    return config;
+}
+
 describe('Unit: Tasks > Migrate', function () {
+    it('sets content path if it does not exist', function () {
+        let config = getConfigStub(true);
+        let migrate = proxyquire(migratePath, {
+            'knex-migrator': class KnexMigrator {
+                isDatabaseOK() { return Promise.resolve() }
+            }
+        });
+
+        migrate({ instance: { config: config, dir: '/test/' } }).then(() => {
+            expect(config.has.calledOnce).to.be.true;
+            expect(config.set.called).to.be.true;
+            expect(config.set.args[0]).to.deep.equal(['paths.contentPath', '/test/content']);
+            expect(config.save.called).to.be.true;
+        });
+    });
+
     it('disables stdout log in config and re-enables it after completion', function () {
-        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
-        let setStub = sinon.stub().returnsThis();
-        let saveStub = sinon.stub().returnsThis();
+        let config = getConfigStub();
+        config.get.withArgs('logging.transports', null).returns(['stdout', 'file']);
         let dbOkStub = sinon.stub().resolves();
 
         let migrate = proxyquire(migratePath, {
@@ -28,24 +55,19 @@ describe('Unit: Tasks > Migrate', function () {
             }
         });
 
-        return migrate({ instance: { config: {
-            get: getStub,
-            set: setStub,
-            save: saveStub
-        } } }).then(() => {
+        return migrate({ instance: { config: config } }).then(() => {
             expect(dbOkStub.calledOnce).to.be.true;
-            expect(getStub.calledOnce).to.be.true;
-            expect(setStub.calledTwice).to.be.true;
-            expect(setStub.args[0]).to.deep.equal(['logging.transports', []]);
-            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
-            expect(saveStub.calledTwice).to.be.true;
+            expect(config.get.calledOnce).to.be.true;
+            expect(config.set.calledTwice).to.be.true;
+            expect(config.set.args[0]).to.deep.equal(['logging.transports', []]);
+            expect(config.set.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+            expect(config.save.calledTwice).to.be.true;
         });
     });
 
     it('runs init if database is not initialized', function () {
-        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
-        let setStub = sinon.stub().returnsThis();
-        let saveStub = sinon.stub().returnsThis();
+        let config = getConfigStub();
+        config.get.withArgs('logging.transports', null).returns(['stdout', 'file'])
         let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('DB_NOT_INITIALISED')));
         let initStub = sinon.stub().resolves();
 
@@ -56,21 +78,18 @@ describe('Unit: Tasks > Migrate', function () {
             }
         });
 
-        return migrate({ instance: { config: {
-            get: getStub, set: setStub, save: saveStub
-        } } }).then(() => {
+        return migrate({ instance: { config: config } }).then(() => {
             expect(dbOkStub.calledOnce).to.be.true;
             expect(initStub.calledOnce).to.be.true;
-            expect(setStub.calledTwice).to.be.true;
-            expect(setStub.args[0]).to.deep.equal(['logging.transports', []]);
-            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+            expect(config.set.calledTwice).to.be.true;
+            expect(config.set.args[0]).to.deep.equal(['logging.transports', []]);
+            expect(config.set.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
         });
     });
 
     it('runs init if migration table is missing', function () {
-        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
-        let setStub = sinon.stub().returnsThis();
-        let saveStub = sinon.stub().returnsThis();
+        let config = getConfigStub();
+        config.get.withArgs('logging.transports', null).returns(['stdout', 'file'])
         let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('MIGRATION_TABLE_IS_MISSING')));
         let initStub = sinon.stub().resolves();
 
@@ -81,21 +100,18 @@ describe('Unit: Tasks > Migrate', function () {
             }
         });
 
-        return migrate({ instance: { config: {
-            get: getStub, set: setStub, save: saveStub
-        } } }).then(() => {
+        return migrate({ instance: { config: config } }).then(() => {
             expect(dbOkStub.calledOnce).to.be.true;
             expect(initStub.calledOnce).to.be.true;
-            expect(setStub.calledTwice).to.be.true;
-            expect(setStub.args[0]).to.deep.equal(['logging.transports', []]);
-            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+            expect(config.set.calledTwice).to.be.true;
+            expect(config.set.args[0]).to.deep.equal(['logging.transports', []]);
+            expect(config.set.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
         });
     });
 
     it('runs migrate if db needs migration', function () {
-        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
-        let setStub = sinon.stub().returnsThis();
-        let saveStub = sinon.stub().returnsThis();
+        let config = getConfigStub();
+        config.get.withArgs('logging.transports', null).returns(['stdout', 'file']);
         let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('DB_NEEDS_MIGRATION')));
         let migrateStub = sinon.stub().resolves();
 
@@ -106,21 +122,18 @@ describe('Unit: Tasks > Migrate', function () {
             }
         });
 
-        return migrate({ instance: { config: {
-            get: getStub, set: setStub, save: saveStub
-        } } }).then(() => {
+        return migrate({ instance: { config: config } }).then(() => {
             expect(dbOkStub.calledOnce).to.be.true;
             expect(migrateStub.calledOnce).to.be.true;
-            expect(setStub.calledTwice).to.be.true;
-            expect(setStub.args[0]).to.deep.equal(['logging.transports', []]);
-            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+            expect(config.set.calledTwice).to.be.true;
+            expect(config.set.args[0]).to.deep.equal(['logging.transports', []]);
+            expect(config.set.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
         });
     });
 
     it('throws config error with db host if database not found', function () {
-        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
-        let setStub = sinon.stub().returnsThis();
-        let saveStub = sinon.stub().returnsThis();
+        let config = getConfigStub();
+        config.get.withArgs('logging.transports', null).returns(['stdout', 'file']);
         let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('ENOTFOUND')));
 
         let migrate = proxyquire(migratePath, {
@@ -130,9 +143,7 @@ describe('Unit: Tasks > Migrate', function () {
         });
 
         return migrate({ instance: {
-            config: {
-                get: getStub, set: setStub, save: saveStub
-            },
+            config: config,
             system: { environment: 'testing' }
         } }).then(() => {
             expect(false, 'error should have been thrown').to.be.true;
@@ -140,16 +151,15 @@ describe('Unit: Tasks > Migrate', function () {
             expect(error).to.be.an.instanceof(errors.ConfigError);
             expect(error.options.config).to.have.key('database.connection.host');
             expect(dbOkStub.calledOnce).to.be.true;
-            expect(setStub.calledTwice).to.be.true;
-            expect(setStub.args[0]).to.deep.equal(['logging.transports', []]);
-            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+            expect(config.set.calledTwice).to.be.true;
+            expect(config.set.args[0]).to.deep.equal(['logging.transports', []]);
+            expect(config.set.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
         });
     });
 
     it('throws config error with db user if access denied error', function () {
-        let getStub = sinon.stub().withArgs('logging.transports', null).returns(['stdout', 'file']);
-        let setStub = sinon.stub().returnsThis();
-        let saveStub = sinon.stub().returnsThis();
+        let config = getConfigStub();
+        config.get.withArgs('logging.transports', null).returns(['stdout', 'file'])
         let dbOkStub = sinon.stub().returns(Promise.reject(new TestError('ER_ACCESS_DENIED_ERROR')));
 
         let migrate = proxyquire(migratePath, {
@@ -159,9 +169,7 @@ describe('Unit: Tasks > Migrate', function () {
         });
 
         return migrate({ instance: {
-            config: {
-                get: getStub, set: setStub, save: saveStub
-            },
+            config: config,
             system: { environment: 'testing' }
         } }).then(() => {
             expect(false, 'error should have been thrown').to.be.true;
@@ -169,9 +177,9 @@ describe('Unit: Tasks > Migrate', function () {
             expect(error).to.be.an.instanceof(errors.ConfigError);
             expect(error.options.config).to.have.all.keys('database.connection.user', 'database.connection.password');
             expect(dbOkStub.calledOnce).to.be.true;
-            expect(setStub.calledTwice).to.be.true;
-            expect(setStub.args[0]).to.deep.equal(['logging.transports', []]);
-            expect(setStub.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
+            expect(config.set.calledTwice).to.be.true;
+            expect(config.set.args[0]).to.deep.equal(['logging.transports', []]);
+            expect(config.set.args[1]).to.deep.equal(['logging.transports', ['stdout', 'file']]);
         });
     });
 });


### PR DESCRIPTION
closes #307
- instead of mutating process.env, set the contentPath in config if it does not exist