### PR TITLE
🎨 fix(ui): fixes to --start --enable and --quiet flags

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -147,7 +147,15 @@ class SetupCommand extends Command {
             }
 
             return this.ui.listr(tasks, {setup: true}).then(() => {
-                if (!argv.prompt || argv.start) {
+                // If we are not allowed to prompt, set the default value, which should be true
+                if (!argv.prompt) {
+                    argv.start = true;
+                }
+
+                // If argv.start has a value, this means either --start or --no-start were explicitly provided
+                // (or --no-prompt was provided, and we already defaulted to true)
+                // In this case, we don't prompt, we use the value of argv.start
+                if (argv.start || argv.start === false) {
                     return Promise.resolve({yes: argv.start});
                 }
 
@@ -163,9 +171,8 @@ SetupCommand.description = 'Setup an installation of Ghost (after it is installe
 SetupCommand.params = '[stages..]';
 SetupCommand.options = {
     start: {
-        description: 'Automatically start Ghost without prompting',
-        type: 'boolean',
-        default: false
+        description: '[--no-start] Enable/disable automatically starting Ghost',
+        type: 'boolean'
     },
     local: {
         alias: 'l',

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -35,26 +35,18 @@ class StartCommand extends Command {
                 instance.running = this.system.environment;
             });
 
+            // @TODO --quiet will make enable never happen!
             if (argv.quiet) {
                 return start();
             }
 
             return this.ui.run(start, 'Starting Ghost').then(() => {
-                // If process manager doesn't support enable behavior OR
-                // it's already enabled, then skip prompt
+                // If process manager doesn't support enable behavior OR it's already enabled, don't try to enable
                 if (!ProcessManager.supportsEnableBehavior(processInstance) || processInstance.isEnabled()) {
-                    return Promise.resolve({yes: false});
+                    argv.enable = false;
                 }
 
-                // If prompts are disabled or enable is passed,
-                // skip prompt
-                if (argv.enable || !argv.prompt) {
-                    return Promise.resolve({yes: argv.enable});
-                }
-
-                return this.ui.confirm('Do you wish to enable the Ghost instance to start on reboot?')
-            }).then((answer) => {
-                if (!answer.yes) {
+                if (!argv.enable) {
                     return Promise.resolve();
                 }
 
@@ -74,8 +66,9 @@ class StartCommand extends Command {
 StartCommand.description = 'Start an instance of Ghost';
 StartCommand.options = {
     enable: {
-        description: 'Enable the instance to restart on server reboot (if the process manager supports it)',
-        type: 'boolean'
+        description: '[--no-enable] Enable/don\'t enable the instance to restart on server reboot (if the process manager supports it)',
+        type: 'boolean',
+        default: true
     }
 };
 

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -22,6 +22,7 @@ class StartCommand extends Command {
 
     run(argv) {
         let instance = this.system.getInstance();
+        const runOptions = {quiet: argv.quiet};
 
         if (instance.running) {
             return Promise.reject(new Error('Ghost is already running. Use `ghost ls` to see details.'));
@@ -31,16 +32,12 @@ class StartCommand extends Command {
 
         return this.ui.listr(startupChecks, {environment: this.system.environment, config: instance.config}).then(() => {
             let processInstance = instance.process;
+
             let start = () => Promise.resolve(processInstance.start(process.cwd(), this.system.environment)).then(() => {
                 instance.running = this.system.environment;
             });
 
-            // @TODO --quiet will make enable never happen!
-            if (argv.quiet) {
-                return start();
-            }
-
-            return this.ui.run(start, 'Starting Ghost').then(() => {
+            return this.ui.run(start, 'Starting Ghost', runOptions).then(() => {
                 // If process manager doesn't support enable behavior OR it's already enabled, don't try to enable
                 if (!ProcessManager.supportsEnableBehavior(processInstance) || processInstance.isEnabled()) {
                     argv.enable = false;
@@ -50,13 +47,15 @@ class StartCommand extends Command {
                     return Promise.resolve();
                 }
 
-                return this.ui.run(processInstance.enable(), 'Enabling Ghost instance startup on server boot');
+                return this.ui.run(processInstance.enable(), 'Enabling Ghost instance startup on server boot', runOptions);
             }).then(() => {
-                this.ui.log(`You can access your blog at ${instance.config.get('url')}`, 'cyan');
+                if (!argv.quiet) {
+                    this.ui.log(`You can access your blog at ${instance.config.get('url')}`, 'cyan');
 
-                if (instance.config.get('mail.transport') === 'Direct') {
-                    this.ui.log('\nGhost uses direct mail by default', 'green');
-                    this.ui.log('To set up an alternative email method read our docs at https://docs.ghost.org/docs/mail-config', 'green');
+                    if (instance.config.get('mail.transport') === 'Direct') {
+                        this.ui.log('\nGhost uses direct mail by default', 'green');
+                        this.ui.log('To set up an alternative email method read our docs at https://docs.ghost.org/docs/mail-config', 'green');
+                    }
                 }
             });
         });

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -22,6 +22,8 @@ class StopCommand extends Command {
     }
 
     run(argv) {
+        const runOptions = {quiet: argv.quiet};
+
         if (argv.all) {
             return this.stopAll();
         }
@@ -48,13 +50,9 @@ class StopCommand extends Command {
             instance.running = null;
         });
 
-        if (argv.quiet) {
-            return stop();
-        }
-
-        return this.ui.run(stop, 'Stopping Ghost').then(() => {
+        return this.ui.run(stop, 'Stopping Ghost', runOptions).then(() => {
             if (argv.disable && ProcessManager.supportsEnableBehavior(instance.process) && instance.process.isEnabled()) {
-                return this.ui.run(instance.process.disable(), 'Disabling Ghost instance startup on server boot');
+                return this.ui.run(instance.process.disable(), 'Disabling Ghost instance startup on server boot', runOptions);
             }
         });
     }

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -33,9 +33,9 @@ class UninstallCommand extends Command {
                 skip: () => !instance.running,
                 task: () => {
                     instance.loadRunningEnvironment(true);
-                    // If the instance is currently running we need to make
-                    // sure it gets stopped
-                    return this.runCommand(StopCommand, {quiet: true});
+                    // If the instance is currently running we need to make sure
+                    // it gets stopped and disabled if possible
+                    return this.runCommand(StopCommand, {disable: true});
                 }
             }, {
                 title: 'Removing related configuration',

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -35,7 +35,7 @@ class UninstallCommand extends Command {
                     instance.loadRunningEnvironment(true);
                     // If the instance is currently running we need to make sure
                     // it gets stopped and disabled if possible
-                    return this.runCommand(StopCommand, {disable: true});
+                    return this.runCommand(StopCommand, {quiet: true, disable: true});
                 }
             }, {
                 title: 'Removing related configuration',

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -69,6 +69,11 @@ class UI {
         options.spinner = options.spinner || 'hamburger';
         options.stream = this.stdout;
 
+        // The --quiet flag will skip outputting anything to the UI.
+        if (options.quiet) {
+            return Promise.resolve(isFunction(promiseOrFunction) ? promiseOrFunction() : promiseOrFunction);
+        }
+
         this.spinner = ora(options).start();
 
         return Promise.resolve(isFunction(promiseOrFunction) ? promiseOrFunction() : promiseOrFunction)


### PR DESCRIPTION
refs #313

This removes the prompt for enabling as described in #313 and also deals with the slightly weird start command, as mentioned in https://github.com/TryGhost/Ghost-CLI/pull/246

- the `ghost setup --start` flag
  - The default value for "start" is "prompt"
  - The fallback default value for "start", if it's not allowed to prompt is true
  - Passing --no-start will set start to false, and not prompt
  - Passing --start will set start to true, and not prompt

- the `ghost start --enable` flag
  - Enabling doesn't trigger any prompt
  - The default value for "enable" is true
  - Passing --enable doesn't change anything
  - Passing --no-enable prevents enabling

- calling `ghost uninstall` will now call `ghost stop --disable`

----

This caused a bug with `stopping ghost` outputting multiple times

closes #335

- implement --quiet inside of ui.run

Note: even with this fix, `Starting Ghost` can output multiple times, I think because the promise for processInstance.enabled() can resolve early, and trip up the spinner logic? Not sure....