### PR TITLE
fix(ui): 🎨 template prompt adjustments

### DIFF
--- a/extensions/systemd/index.js
+++ b/extensions/systemd/index.js
@@ -33,7 +33,7 @@ class SystemdExtension extends cli.Extension {
             user: uid,
             environment: this.system.environment,
             ghost_exec_path: process.argv.slice(0,2).join(' ')
-        }), 'systemd service file', serviceFilename, '/lib/systemd/system').then((generated) => {
+        }), 'systemd service', serviceFilename, '/lib/systemd/system').then((generated) => {
             if (!generated) {
                 this.ui.log('Systemd unit file not generated', 'yellow');
                 return;

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -13,7 +13,7 @@ const Promise = require('bluebird');
  */
 class Instance {
     /**
-     * Local insatne config (.ghost-cli)
+     * Local instance config (.ghost-cli)
      * Contains some instance-specific variables
      *
      * @property
@@ -207,61 +207,57 @@ class Instance {
      * @public
      */
     template(contents, descriptor, file, dir) {
-        // If `--no-prompt` is passed to the CLI, just generate the template
-        if (!this.ui.allowPrompt) {
-            return this._generateTemplate(contents, file, dir);
+        // If `--no-prompt` is passed to the CLI or the `--verbose` flag was not passed, don't show anything
+        if (!this.ui.allowPrompt || !this.ui.verbose) {
+            return this._generateTemplate(contents, descriptor, file, dir);
+        } else {
+            return this.ui.prompt({
+                type: 'expand',
+                name: 'choice',
+                message: `Would you like to view or edit the ${descriptor} file?`,
+                default: 'n',
+                choices: [
+                    {key: 'n', name: 'No, continue', value: 'continue'},
+                    {key: 'v', name: 'View the file', value: 'view'},
+                    {key: 'e', name: 'Edit the file before generation', value: 'edit'}
+                ]
+            }).then((answer) => {
+                let choice = answer.choice;
+
+                if (choice === 'continue') {
+                    return this._generateTemplate(contents, descriptor, file, dir);
+                }
+
+                if (choice === 'view') {
+                    this.ui.log(contents);
+                    return this.template(contents, descriptor, file, dir);
+                }
+
+                if (choice === 'edit') {
+                    return this.ui.prompt({
+                        type: 'editor',
+                        name: 'contents',
+                        message: 'Edit the generated file',
+                        default: contents
+                    }).then((answer) => {
+                        contents = answer.contents;
+                        return this._generateTemplate(contents, descriptor, file, dir);
+                    });
+                }
+            });
         }
-
-        return this.ui.prompt({
-            type: 'expand',
-            name: 'choice',
-            message: `Ghost-CLI would like to generate a ${descriptor} file.`,
-            default: 'y',
-            choices: [
-                { key: 'y', name: 'Yes, write config file', value: 'write' },
-                { key: 'n', name: 'No, don\'t create the file', value: 'skip' },
-                { key: 'v', name: 'View the file', value: 'view' },
-                { key: 'e', name: 'Edit the file before generation', value: 'edit' }
-            ]
-        }).then((answer) => {
-            let choice = answer.choice;
-
-            if (choice === 'skip') {
-                return Promise.resolve(false);
-            }
-
-            if (choice === 'write') {
-                return this._generateTemplate(contents, file, dir);
-            }
-
-            if (choice === 'view') {
-                this.ui.log(contents);
-                return this.template(contents, descriptor, file, dir);
-            }
-
-            if (choice === 'edit') {
-                return this.ui.prompt({
-                    type: 'editor',
-                    name: 'contents',
-                    message: 'Edit the generated file',
-                    default: contents
-                }).then((answer) => {
-                    contents = answer.contents;
-                    return this._generateTemplate(contents, file, dir);
-                });
-            }
-        });
     }
 
     /**
      * Actually handles saving the file. Used by the template method
      *
      * @param {string} contents Contents of file
+     * @param {string} descriptor description of file
      * @param {string} file Filename
-     * @param {string} dir Directroy to link
+     * @param {string} dir Directory to link
      * @return {bool} True if the file was successfully created & linked
      */
-    _generateTemplate(contents, file, dir) {
+    _generateTemplate(contents, descriptor, file, dir) {
         let tmplDir = path.join(this.dir, 'system', 'files');
         let tmplFile = path.join(tmplDir, file);
 
@@ -272,6 +268,7 @@ class Instance {
 
         if (dir) {
             let outputLocation = path.join(dir, file);
+            this.ui.success(`Creating ${descriptor} file at ${tmplFile}`);
             promises.push(() => this.ui.sudo(`ln -sf ${tmplFile} ${outputLocation}`));
         }
 

--- a/test/unit/instance-spec.js
+++ b/test/unit/instance-spec.js
@@ -365,64 +365,12 @@ describe('Unit: Instance', function () {
     });
 
     describe('template', function () {
-        it('resolves with false if the choice is to skip', function () {
-            let promptStub = sandbox.stub().resolves({ choice: 'skip' });
-            let testInstance = new Instance({ prompt: promptStub, allowPrompt: true }, {}, '');
-
-            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
-                expect(promptStub.calledOnce).to.be.true;
-                expect(result).to.be.false;
-            });
-        });
-
-        it('generates template if the choice is to proceeed', function () {
-            let promptStub = sandbox.stub().resolves({choice: 'write'});
-            let testInstance = new Instance({ prompt: promptStub, allowPrompt: true }, {} , '');
-            let generateStub = sandbox.stub(testInstance, '_generateTemplate').resolves(true);
-
-            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
-                expect(result).to.be.true;
-                expect(generateStub.calledOnce).to.be.true;
-                expect(promptStub.calledOnce).to.be.true;
-                expect(generateStub.args[0]).to.deep.equal(['some contents', 'file.txt', '/some/dir']);
-            });
-        });
-
-        it('logs and calls template method again if choice is view', function () {
-            let promptStub = sandbox.stub();
-            promptStub.onCall(0).resolves({choice: 'view'});
-            promptStub.onCall(1).resolves({choice: 'skip'});
-            let logStub = sandbox.stub();
-            let testInstance = new Instance({ log: logStub, prompt: promptStub, allowPrompt: true }, {}, '');
-
-            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
-                expect(result).to.be.false;
-                expect(promptStub.calledTwice).to.be.true;
-                expect(logStub.calledOnce).to.be.true;
-                expect(logStub.args[0][0]).to.equal('some contents');
-            });
-        });
-
-        it('opens editor and generates template with contents if choice is edit', function () {
-            let promptStub = sandbox.stub();
-            promptStub.onCall(0).resolves({choice: 'edit'});
-            promptStub.onCall(1).resolves({contents: 'some edited contents'});
-            let testInstance = new Instance({ prompt: promptStub, allowPrompt: true }, {}, '');
-            let generateStub = sandbox.stub(testInstance, '_generateTemplate').resolves(true);
-
-            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
-                expect(result).to.be.true;
-                expect(promptStub.calledTwice).to.be.true;
-                expect(generateStub.calledOnce).to.be.true;
-                expect(generateStub.args[0][0]).to.equal('some edited contents');
-            });
-        });
-
         it('immediately calls _generateTemplate if ui.allowPrompt is false', function () {
             let promptStub = sandbox.stub().resolves();
             let testInstance = new Instance({
                 prompt: promptStub,
-                allowPrompt: false
+                allowPrompt: false,
+                verbose: true
             }, {}, '');
             let generateStub = sandbox.stub(testInstance, '_generateTemplate').resolves(true);
 
@@ -433,33 +381,118 @@ describe('Unit: Instance', function () {
                 expect(generateStub.args[0][0]).to.equal('some contents');
             });
         });
+
+        it('immediately calls _generateTemplate if ui.verbose is false', function () {
+            let promptStub = sandbox.stub().resolves();
+            let testInstance = new Instance({
+                prompt: promptStub,
+                allowPrompt: true,
+                verbose: false
+            }, {}, '');
+            let generateStub = sandbox.stub(testInstance, '_generateTemplate').resolves(true);
+
+            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
+                expect(result).to.be.true;
+                expect(promptStub.called).to.be.false;
+                expect(generateStub.calledOnce).to.be.true;
+                expect(generateStub.args[0][0]).to.equal('some contents');
+            });
+        });
+
+        it('immediately calls _generateTemplate if ui.allowPrompt and ui.verbose is false', function () {
+            let promptStub = sandbox.stub().resolves();
+            let testInstance = new Instance({
+                prompt: promptStub,
+                allowPrompt: true,
+                verbose: false
+            }, {}, '');
+            let generateStub = sandbox.stub(testInstance, '_generateTemplate').resolves(true);
+
+            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
+                expect(result).to.be.true;
+                expect(promptStub.called).to.be.false;
+                expect(generateStub.calledOnce).to.be.true;
+                expect(generateStub.args[0][0]).to.equal('some contents');
+            });
+        });
+
+        it('generates template if the choice is to continue (with --verbose)', function () {
+            let promptStub = sandbox.stub().resolves({choice: 'continue'});
+            let testInstance = new Instance({ prompt: promptStub, allowPrompt: true, verbose: true }, {} , '');
+            let generateStub = sandbox.stub(testInstance, '_generateTemplate').resolves(true);
+
+            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
+                expect(result).to.be.true;
+                expect(generateStub.calledOnce).to.be.true;
+                expect(promptStub.calledOnce).to.be.true;
+                expect(generateStub.args[0]).to.deep.equal(['some contents', 'a file', 'file.txt', '/some/dir']);
+            });
+        });
+
+        it('logs and calls template method again if choice is view (with --verbose)', function () {
+            let promptStub = sandbox.stub();
+            promptStub.onCall(0).resolves({choice: 'view'});
+            promptStub.onCall(1).resolves({choice: 'continue'});
+            let logStub = sandbox.stub();
+            let testInstance = new Instance({ log: logStub, prompt: promptStub, allowPrompt: true, verbose: true }, {}, '');
+            let generateStub = sandbox.stub(testInstance, '_generateTemplate').resolves(true);
+
+            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
+                expect(result).to.be.true;
+                expect(promptStub.calledTwice).to.be.true;
+                expect(logStub.calledOnce).to.be.true;
+                expect(logStub.args[0][0]).to.equal('some contents');
+                expect(generateStub.calledOnce).to.be.true;
+                expect(generateStub.args[0]).to.deep.equal(['some contents', 'a file', 'file.txt', '/some/dir']);
+            });
+        });
+
+        it('opens editor and generates template with contents if choice is edit (with --verbose)', function () {
+            let promptStub = sandbox.stub();
+            promptStub.onCall(0).resolves({choice: 'edit'});
+            promptStub.onCall(1).resolves({contents: 'some edited contents'});
+            let testInstance = new Instance({ prompt: promptStub, allowPrompt: true, verbose: true }, {}, '');
+            let generateStub = sandbox.stub(testInstance, '_generateTemplate').resolves(true);
+
+            return testInstance.template('some contents', 'a file', 'file.txt', '/some/dir').then((result) => {
+                expect(result).to.be.true;
+                expect(promptStub.calledTwice).to.be.true;
+                expect(generateStub.calledOnce).to.be.true;
+                expect(generateStub.args[0][0]).to.equal('some edited contents');
+            });
+        });
     });
 
     describe('_generateTemplate', function () {
         it('writes out template to correct directory but doesn\'t link if no dir is passed', function () {
             let dir = tmp.dirSync({unsafeCleanup: true}).name;
-            let testInstance = new Instance({}, {}, dir);
+            let successStub = sandbox.stub();
+            let testInstance = new Instance({success: successStub}, {}, dir);
 
-            return testInstance._generateTemplate('some contents', 'file.txt').then((result) => {
+            return testInstance._generateTemplate('some contents', 'a file', 'file.txt').then((result) => {
                 expect(result).to.be.true;
                 let fpath = path.join(dir, 'system', 'files', 'file.txt');
                 expect(fs.existsSync(fpath)).to.be.true;
                 expect(fs.readFileSync(fpath, 'utf8')).to.equal('some contents');
+                expect(successStub.called).to.be.false;
             });
         });
 
         it('writes out template and links it correctly if dir is passed', function () {
             let dir = tmp.dirSync({unsafeCleanup: true}).name;
             let sudoStub = sandbox.stub().resolves();
-            let testInstance = new Instance({ sudo: sudoStub }, {}, dir);
+            let successStub = sandbox.stub();
+            let testInstance = new Instance({ sudo: sudoStub, success: successStub }, {}, dir);
 
-            return testInstance._generateTemplate('some contents', 'file.txt', '/another/dir').then((result) => {
+            return testInstance._generateTemplate('some contents', 'a file', 'file.txt', '/another/dir').then((result) => {
                 expect(result).to.be.true;
                 let fpath = path.join(dir, 'system', 'files', 'file.txt');
                 expect(fs.existsSync(fpath)).to.be.true;
                 expect(fs.readFileSync(fpath, 'utf8')).to.equal('some contents');
                 expect(sudoStub.calledOnce).to.be.true;
                 expect(sudoStub.args[0][0]).to.equal(`ln -sf ${fpath} /another/dir/file.txt`);
+                expect(successStub.calledOnce).to.be.true;
+                expect(successStub.firstCall.args[0]).to.match(/^Creating a file file at/);
             });
         });
     });


### PR DESCRIPTION
Note: I'm not sure the ui.log thing here is the correct pattern. It outputs without a checkmark/tick, and looks a bit weird.

![](https://puu.sh/wGkAi.png)

refs #313

- don't allow users to skip, as this would break things
- only show the option to continue, view or edit if --verbose is passed and --no-prompt is not
- reword the question to be would you like to view or edit
- fix the duplicate word "file" for systemd
- add a ui.log for creating the files

- TODO: use a checkmark?!