### PR TITLE
fix(ui): make fail and success methods to output symbols

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -8,6 +8,7 @@ const assign    = require('lodash/assign');
 const Promise   = require('bluebird');
 const inquirer  = require('inquirer');
 const stripAnsi = require('strip-ansi');
+const logSymbols = require('log-symbols');
 const isFunction = require('lodash/isFunction');
 const isObject = require('lodash/isObject');
 
@@ -268,7 +269,7 @@ class UI {
      * @public
      */
     success(message) {
-        return this.log(message, 'green');
+        return this.log(`${logSymbols.success} ${message}`);
     }
 
     /**
@@ -280,7 +281,7 @@ class UI {
      * @public
      */
     fail(message) {
-        return this.log(message, 'red');
+        return this.log(`${logSymbols.error} ${message}`);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "knex-migrator": "2.0.16",
     "listr": "0.12.0",
     "lodash": "4.17.4",
+    "log-symbols": "1.0.2",
     "mysql": "2.13.0",
     "nginx-conf": "1.3.0",
     "ora": "1.3.0",

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -2,6 +2,7 @@
 const expect = require('chai').expect;
 const chalk = require('chalk');
 const sinon = require('sinon');
+const logSymbols = require('log-symbols');
 const streamTestUtils = require('../../utils/stream');
 const UI = require('../../../lib/ui');
 
@@ -65,13 +66,12 @@ describe('Unit: UI', function () {
         });
     });
 
-    it('#success outputs message with correct formatting', function (done) {
+    it('#success outputs message with correct symbols', function (done) {
         let stdout, ui;
 
         stdout = streamTestUtils.getWritableStream(function (output) {
             expect(output, 'output exists').to.be.ok;
-            expect(chalk.hasColor(output), 'output has color').to.be.true;
-            expect(output, 'output value').to.equal(chalk.green('test') + '\n');
+            expect(output, 'output value').to.equal(`${logSymbols.success} test\n`);
 
             done();
         });
@@ -86,8 +86,7 @@ describe('Unit: UI', function () {
 
         stdout = streamTestUtils.getWritableStream(function (output) {
             expect(output, 'output exists').to.be.ok;
-            expect(chalk.hasColor(output), 'output has color').to.be.true;
-            expect(output, 'output value').to.equal(chalk.red('test') + '\n');
+            expect(output, 'output value').to.equal(`${logSymbols.error} test\n`);
 
             done();
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,7 +2128,7 @@ log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
-log-symbols@^1.0.2:
+log-symbols@1.0.2, log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
   dependencies:


### PR DESCRIPTION
no issue
- deps: log-symbols@1.0.2
- ui.success and ui.fail output symbols now