### PR TITLE
Various fixes

### DIFF
--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -80,7 +80,7 @@ class ConfigCommand extends Command {
             });
         }
 
-        if (!argv.db || argv.db === 'sqlite3') {
+        if (!argv.db || argv.db !== 'sqlite3') {
             prompts.push({
                 type: 'input',
                 name: 'dbhost',

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -189,8 +189,7 @@ SetupCommand.description = 'Setup an installation of Ghost (after it is installe
 SetupCommand.params = '[stages..]';
 SetupCommand.options = {
     start: {
-        description: '[--no-start] Enable/disable automatically starting Ghost',
-        type: 'boolean'
+        description: '[--no-start] Enable/disable automatically starting Ghost'
     },
     local: {
         alias: 'l',

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -266,9 +266,12 @@ class Instance {
             () => fs.writeFile(tmplFile, contents)
         ];
 
+        // Dir is optional, if a file just needs to be created locally
+        // so we log here
+        this.ui.success(`Creating ${descriptor} file at ${tmplFile}`);
+
         if (dir) {
             let outputLocation = path.join(dir, file);
-            this.ui.success(`Creating ${descriptor} file at ${tmplFile}`);
             promises.push(() => this.ui.sudo(`ln -sf ${tmplFile} ${outputLocation}`));
         }
 

--- a/test/unit/instance-spec.js
+++ b/test/unit/instance-spec.js
@@ -474,7 +474,7 @@ describe('Unit: Instance', function () {
                 let fpath = path.join(dir, 'system', 'files', 'file.txt');
                 expect(fs.existsSync(fpath)).to.be.true;
                 expect(fs.readFileSync(fpath, 'utf8')).to.equal('some contents');
-                expect(successStub.called).to.be.false;
+                expect(successStub.calledOnce).to.be.true;
             });
         });
 


### PR DESCRIPTION
These are just a few tiny issues I noticed while testing #338 

- don't prompt for mysql if we shouldn't prompt for mysql (boolean logic is fun)
- make start/no-start work as intended
- log successful template generation regardless if linked to system dir or not.