### PR TITLE
fix(config): add default dbpath when db is sqlite

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -77,7 +77,15 @@ module.exports = {
         description: 'Path to the database file (sqlite3 only)',
         configPath: 'database.connection.filename',
         type: 'string',
-        group: 'Database Options:'
+        group: 'Database Options:',
+        defaultValue: (config, environment) => {
+            if (config.get('database.client') !== 'sqlite3') {
+                return null;
+            }
+
+            let dbFile = (environment === 'production') ? 'ghost.db' : 'ghost-dev.db';
+            return `./content/data/${dbFile}`;
+        }
     },
     dbhost: {
         description: 'Database host',


### PR DESCRIPTION
closes #349
- add defaultValue function to dbpath argument

TODO: do a quick sanity check locally and on ubuntu
