### PR TITLE
[WIP] 🐛  fix local installation

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -65,7 +65,7 @@ class RunCommand extends Command {
 
         this.child.on('message', (message) => {
             if (message.started) {
-                instance.process.success();
+                instance.process.success({pid: this.child.pid});
                 return;
             }
 

--- a/lib/utils/local-process.js
+++ b/lib/utils/local-process.js
@@ -2,6 +2,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const fkill = require('fkill');
+const extend = require('lodash/extend');
 const spawn = require('child_process').spawn;
 const assign = require('lodash/assign');
 const isRunning = require('is-running');
@@ -40,13 +41,9 @@ class LocalProcess extends ProcessManager {
                 env: assign({}, process.env, {NODE_ENV: environment})
             });
 
-            // Stick the pid into the pidfile so we can stop the process later
-            fs.writeFileSync(path.join(cwd, PID_FILE), cp.pid);
-
             cp.on('error', reject);
 
             cp.on('exit', (code) => {
-                fs.removeSync(path.join(cwd, PID_FILE));
                 reject(new errors.GhostError(`Ghost process exited with code: ${code}`));
             });
 
@@ -59,10 +56,10 @@ class LocalProcess extends ProcessManager {
             // Wait until Ghost tells us that it's started correctly, then resolve
             cp.on('message', (msg) => {
                 if (msg.error) {
-                    fs.removeSync(path.join(cwd, PID_FILE));
-
                     return reject(new errors.GhostError(msg));
                 }
+
+                fs.writeFileSync(path.join(cwd, PID_FILE), msg && msg.pid ? msg.pid : cp.pid);
 
                 if (msg.started) {
                     cp.disconnect();
@@ -113,8 +110,9 @@ class LocalProcess extends ProcessManager {
      * @method success
      * @public
      */
-    success() {
-        if (process.send) {process.send({started: true});}
+    success(options) {
+        options = options || {};
+        if (process.send) {process.send(extend({started: true}, options));}
     }
 
     /**


### PR DESCRIPTION
closes #368

- if you run `ghost start`, the CLI will spawn a detached process
- this detached process will spawn another process
- the `cp.pid` was wrong in any case
- forward the pid from the spawned process back to parent process

- [x] test on mac
- [ ] test on windows
- [ ] test on linux