### PR TITLE
fix(local): only force kill on Windows

### DIFF
--- a/lib/utils/local-process.js
+++ b/lib/utils/local-process.js
@@ -29,14 +29,11 @@ class LocalProcess extends ProcessManager {
      * @public
      */
     start(cwd, environment) {
-        let isWindows = process.platorm === 'win32';
-
         return new Promise((resolve, reject) => {
             let cp = spawn('node', [process.argv[1] , 'run'], {
                 cwd: cwd,
                 detached: true,
-                // IPC doesn't work on windows, so we just use 'ignore'
-                stdio: isWindows ? 'ignore' : ['ignore', 'ignore', 'ignore', 'ipc'],
+                stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
                 env: assign({}, process.env, {NODE_ENV: environment})
             });
 
@@ -49,12 +46,6 @@ class LocalProcess extends ProcessManager {
                 fs.removeSync(path.join(cwd, PID_FILE));
                 reject(new errors.GhostError(`Ghost process exited with code: ${code}`));
             });
-
-            if (isWindows) {
-                cp.disconnect();
-                cp.unref();
-                return resolve();
-            }
 
             // Wait until Ghost tells us that it's started correctly, then resolve
             cp.on('message', (msg) => {
@@ -96,7 +87,9 @@ class LocalProcess extends ProcessManager {
             throw e;
         }
 
-        return fkill(pid, {force: true}).catch((error) => {
+        let isWindows = process.platform === 'win32';
+
+        return fkill(pid, {force: isWindows}).catch((error) => {
             // TODO: verify windows outputs same error message as mac/linux
             if (!error.message.match(/No such process/)) {
                 throw error;


### PR DESCRIPTION
closes #368
- force killing on mac/linux doesn't allow the child process (ghost run) to kill the ghost server process, resulting in a orphan process that the user has to kill manually
- on windows force: true works because fkill kills the process tree, which includes the ghost server

--

- [x] test on Windows