### PR TITLE
feat(update): add pre-stable warning message with docs link

### DIFF
--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -1,6 +1,8 @@
 'use strict';
 const fs = require('fs-extra');
 const path = require('path');
+const chalk = require('chalk');
+const semver = require('semver');
 const symlinkSync = require('symlink-or-copy').sync;
 
 // Utils
@@ -18,6 +20,17 @@ const StartCommand = require('./start');
 class UpdateCommand extends Command {
     run(argv) {
         let instance = this.system.getInstance();
+
+        // If installed with a version < 1.0
+        if (semver.lt(instance.cliConfig.get('cli-version'), '1.0.0')) {
+            this.ui.log(
+                `Ghost was installed with Ghost-CLI v${instance.cliConfig.get('cli-version')}, which is a pre-release version.\n` +
+                'Your Ghost install is using out-of-date configuration & requires manual changes.\n' +
+                `Please visit ${chalk.blue.underline('https://docs.ghost.org/docs/how-to-upgrade-ghost#section-upgrading-ghost-cli')}\n` +
+                'for instructions on how to upgrade your instance.\n',
+                'yellow'
+            );
+        }
 
         let context = {
             instance: instance,


### PR DESCRIPTION
closes #364
- if an instance was installed with a pre-stable version of Ghost-CLI, this message is output so that people know they need to do things to update their instance to work with the newest CLI version