### PR TITLE
feat(help): custom aliases

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -93,7 +93,7 @@ class Command {
 
         return yargs.command({
             command: command,
-            aliases: aliases,
+            aliases: this.aliases ? aliases.concat(this.aliases) : aliases,
             describe: this.description,
             builder: (commandArgs) => {
                 debug(`building options for ${ commandName }`);

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -135,5 +135,6 @@ InstallCommand.options = {
         default: true
     }
 };
+InstallCommand.aliases = ['intsall', 'insall'];
 
 module.exports = InstallCommand;

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -147,5 +147,6 @@ UpdateCommand.options = {
         type: 'boolean'
     }
 };
+UpdateCommand.aliases = ['upgrade', 'udpate'];
 
 module.exports = UpdateCommand;


### PR DESCRIPTION
This can wait - I've just had it sat around, not sure if it's desirable, but I can never remember whether its `ghost update` or `ghost upgrade` 🙈 

- main task here was to add upgrade as an alias of update
- also added my fave typo of intsall 😁