### PR TITLE
feat(help): status alias

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -16,6 +16,7 @@ const extraAliases = {
     busters: 'buster',
     intsall: 'install',
     insall: 'install',
+    status: 'ls',
     upgrade: 'update',
     udpate: 'update'
 };


### PR DESCRIPTION
After seeing #375 I realised I find myself constantly having to lookup the `ls` command when I really just want to see the `status` of the running instances.