### PR TITLE
fix(migration): don't hide migration errors

### DIFF
--- a/lib/tasks/migrate.js
+++ b/lib/tasks/migrate.js
@@ -31,9 +31,7 @@ module.exports = function runMigrations(context) {
     } else {
         knexMigratorPromise = execa('knex-migrator-migrate', args, {
             preferLocal: true,
-            localDir: __dirname,
-            stdout: 'ignore',
-            stderr: 'pipe'
+            localDir: __dirname
         });
     }
 


### PR DESCRIPTION
closes #378
- don't ignore stdout, as knex errors are written to it