### PR TITLE
fix(config): Allow all wellknown mail services

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -8,8 +8,8 @@ const url = require('url');
 
 const BASE_PORT = '2368';
 const knownMailServices = [
-    'AOL', 'DynectEmail', 'Gmail', 'hot.ee', 'Hotmail', 'iCloud', 'mail.ee', 'Mail.Ru', 'Mailgun',
-    'Mailjet', 'Mandrill', 'Postmark', 'QQ', 'QQex (Tencent Business Email)', 'SendGrid',
+    'AOL', 'DynectEmail', 'FastMail', 'Gmail', 'GoDaddy', 'GoDaddyAsia', 'GoDaddyEurope', 'hot.ee', 'Hotmail', 'iCloud',
+    'mail.ee', 'Mail.Ru', 'Mailgun', 'Mailjet', 'Mandrill', 'Postmark', 'QQ', 'QQex', 'SendGrid',
     'SendCloud', 'SES', 'Yahoo', 'yandex', 'Zoho'
 ];
 


### PR DESCRIPTION
closes #383

- remove extra text from QQex so that it can be validated
- add GoDaddy, GoDaddyAsia and GoDaddyEurope
- add FastMail
- official list: https://github.com/nodemailer/nodemailer/blob/0.7/lib/wellknown.js