### PR TITLE
fix(doctor): add install checks for various nvm edge cases

### DIFF
--- a/lib/commands/doctor/checks/install.js
+++ b/lib/commands/doctor/checks/install.js
@@ -17,7 +17,7 @@ const eol = os.EOL;
 
 const tasks = {
     // While it's not an actual task, we put it here to make it easier to test
-    checkDirectoryAndAbove: function checkDirectoryAndAbove(dir) {
+    checkDirectoryAndAbove: function checkDirectoryAndAbove(dir, extra) {
         if (isRoot(dir)) {
             return Promise.resolve();
         }
@@ -29,14 +29,24 @@ const tasks = {
                 return Promise.reject(new errors.SystemError(
                     `The path ${dir} is not readable by other users on the system.${eol}` +
                     'This can cause issues with the CLI, please either make this directory ' +
-                    'readable by others or install in another location.'
+                    `readable by others or ${extra} in another location.`
                 ));
             }
 
-            return checkDirectoryAndAbove(path.join(dir, '../'));
+            return tasks.checkDirectoryAndAbove(path.join(dir, '../'), extra);
         });
     },
-    nodeVersion: function nodeVersion() {
+    nodeVersion: function nodeVersion(ctx) {
+        let globalBin = execa.shellSync('npm bin -g').stdout;
+
+        if (process.argv[1] !== path.join(__dirname, '../../../../bin/ghost') && !process.argv[1].startsWith(globalBin)) {
+            return Promise.reject(new errors.SystemError(
+                `The version of Ghost-CLI you are running was not installed with this version of Node.${eol}` +
+                `This means there are likely two versions of Node running on your system, please ensure${eol}` +
+                'that you are only running one global version of Node before continuing.'
+            ));
+        }
+
         if (process.env.GHOST_NODE_VERSION_CHECK !== 'false' &&
             !semver.satisfies(process.versions.node, cliPackage.engines.node)) {
             return Promise.reject(new errors.SystemError(
@@ -48,7 +58,11 @@ const tasks = {
             ));
         }
 
-        return Promise.resolve();
+        if (ctx.local || os.platform() !== 'linux' || (ctx.argv && ctx.argv['setup-linux-user'] === false)) {
+            return Promise.resolve();
+        }
+
+        return tasks.checkDirectoryAndAbove(process.argv[0], 'install node and Ghost-CLI');
     },
     folderPermissions: function folderPermissions(ctx) {
         return fs.access(process.cwd(), constants.R_OK | constants.W_OK).catch(() => {
@@ -61,7 +75,7 @@ const tasks = {
                 return Promise.resolve();
             }
 
-            return tasks.checkDirectoryAndAbove(process.cwd());
+            return tasks.checkDirectoryAndAbove(process.cwd(), 'run `ghost install`');
         });
     },
     systemStack: function systemStack(ctx) {


### PR DESCRIPTION
closes #281
- skip directory check if `--no-setup-linux-user` option is passed
- throw error if npm bin directory is not the same as the one used to install ghost-cli

TODO:
- [ ] test this on ubuntu