### PR TITLE
fix(doctor): skip parent folder perm check if linux user is skipped

### DIFF
--- a/lib/commands/doctor/checks/install.js
+++ b/lib/commands/doctor/checks/install.js
@@ -57,7 +57,7 @@ const tasks = {
                 'Please fix your directory permissions.'
             ));
         }).then(() => {
-            if (ctx.local || os.platform() !== 'linux') {
+            if (ctx.local || os.platform() !== 'linux' || (ctx.argv && ctx.argv['setup-linux-user'] === false)) {
                 return Promise.resolve();
             }
 

--- a/test/unit/commands/doctor/install-spec.js
+++ b/test/unit/commands/doctor/install-spec.js
@@ -210,6 +210,22 @@ describe('Unit: Doctor Checks > Install', function () {
             });
         });
 
+        it('skips checking parent folder permissions if --no-setup-linux-user is passed', function () {
+            let accessStub = sinon.stub().resolves();
+            let platformStub = sinon.stub().returns('linux');
+            const tasks = proxyquire(modulePath, {
+                'fs-extra': {access: accessStub},
+                os: {platform: platformStub}
+            }).tasks;
+            let checkDirectoryAndAbove = sinon.stub(tasks, 'checkDirectoryAndAbove').resolves();
+
+            return tasks.folderPermissions({argv: {'setup-linux-user': false}}).then(() => {
+                expect(accessStub.calledOnce).to.be.true;
+                expect(platformStub.calledOnce).to.be.true;
+                expect(checkDirectoryAndAbove.called).to.be.false;
+            });
+        });
+
         it('runs checkParentAndAbove if local not set and platform is linux', function () {
             let accessStub = sinon.stub().resolves();
             let platformStub = sinon.stub().returns('linux');


### PR DESCRIPTION
closes #405
- skip directory check if `--no-setup-linux-user` option is passed

This is a split-out from #409 -> this change is a bugfix whereas the changes in the other PR would require a minor version bump.