### PR TITLE
fix(linux): make ghost user regex check case insensitive

### DIFF
--- a/lib/utils/use-ghost-user.js
+++ b/lib/utils/use-ghost-user.js
@@ -16,7 +16,7 @@ module.exports = function useGhostUser(contentDir) {
         ghostuid = execa.shellSync('id -u ghost').stdout;
         ghostgid = execa.shellSync('id -g ghost').stdout;
     } catch (e) {
-        if (!e.message.match(/no such user/)) {
+        if (!e.message.match(/no such user/i)) {
             throw new errors.ProcessError(e);
         }
 

--- a/test/unit/utils/use-ghost-user-spec.js
+++ b/test/unit/utils/use-ghost-user-spec.js
@@ -52,6 +52,20 @@ describe('Unit: Utils > useGhostUser', function () {
         expect(execaStub.calledOnce).to.be.true;
     });
 
+    it('returns false if "no such error" error is thrown (this time, with caps)', function () {
+        let platformStub = sinon.stub().returns('linux');
+        let execaStub = sinon.stub().throws(new Error('No such user'));
+        let useGhostUser = proxyquire(modulePath, {
+            os: { platform: platformStub },
+            execa: { shellSync: execaStub }
+        });
+
+        let result = useGhostUser();
+        expect(result).to.be.false;
+        expect(platformStub.calledOnce).to.be.true;
+        expect(execaStub.calledOnce).to.be.true;
+    });
+
     it('returns false if the ghost owner/group is not the owner of the content folder', function () {
         let platformStub = sinon.stub().returns('linux');
         let execaStub = sinon.stub().returns({stdout: '50'});


### PR DESCRIPTION
closes #400
- for `id -u ghost` -> centos returns "No such user" - this made the use-ghost-user check fail