### PR TITLE
fix(config): 🐛  don't enforce case for mail config

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -8,9 +8,9 @@ const url = require('url');
 
 const BASE_PORT = '2368';
 const knownMailServices = [
-    'AOL', 'DynectEmail', 'FastMail', 'Gmail', 'GoDaddy', 'GoDaddyAsia', 'GoDaddyEurope', 'hot.ee', 'Hotmail', 'iCloud',
-    'mail.ee', 'Mail.Ru', 'Mailgun', 'Mailjet', 'Mandrill', 'Postmark', 'QQ', 'QQex', 'SendGrid',
-    'SendCloud', 'SES', 'Yahoo', 'yandex', 'Zoho'
+    'aol', 'dynectemail', 'fastmail', 'gmail', 'godaddy', 'godaddyasia', 'godaddyeurope', 'hot.ee', 'hotmail', 'icloud',
+    'mail.ee', 'mail.ru', 'mailgun', 'mailjet', 'mandrill', 'postmark', 'qq', 'qqex', 'sendgrid',
+    'sendcloud', 'ses', 'yahoo', 'yandex', 'zoho'
 ];
 
 /*
@@ -119,7 +119,7 @@ module.exports = {
     // Designed to support the most common mail configs, more advanced configs will require editing the config file
     mail: {
         description: 'Mail transport, E.g SMTP, Sendmail or Direct',
-        validate: value => includes(['SMTP', 'Sendmail', 'Direct'], value) || 'Invalid mail transport',
+        validate: value => includes(['smtp', 'sendmail', 'direct'], value.toLowerCase()) || 'Invalid mail transport',
         configPath: 'mail.transport',
         type: 'string',
         default: 'Direct',
@@ -128,7 +128,7 @@ module.exports = {
     mailservice: {
         description: 'Mail service (used with SMTP transport), E.g. Mailgun, Sendgrid, Gmail, SES...',
         configPath: 'mail.options.service',
-        validate: value => includes(knownMailServices, value) || 'Invalid mail service',
+        validate: value => includes(knownMailServices, value.toLowerCase()) || 'Invalid mail service',
         type: 'string',
         group: 'Mail Options:'
     },


### PR DESCRIPTION
TODO:

- [x] test this once we get past the 1.4 issues

closes #421

- uses toLowerCase() and lists all config options in lowercase