### PR TITLE
Remove old Ghost versions during `ghost update`

### DIFF
--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -12,9 +12,6 @@ class UpdateCommand extends Command {
         const semver = require('semver');
 
         const migrate = require('../tasks/migrate');
-        const yarnInstall = require('../tasks/yarn-install');
-        const StopCommand = require('./stop');
-        const StartCommand = require('./start');
 
         let instance = this.system.getInstance();
 
@@ -38,7 +35,7 @@ class UpdateCommand extends Command {
 
         if (argv.rollback) {
             if (!instance.cliConfig.get('previous-version')) {
-                throw new Error('No previous version found');
+                return Promise.reject(new Error('No previous version found'));
             }
 
             context.rollback = true;
@@ -56,29 +53,11 @@ class UpdateCommand extends Command {
         let tasks = [{
             title: 'Downloading and updating Ghost',
             skip: (ctx) => ctx.rollback,
-            task: (ctx, task) => {
-                if (fs.existsSync(ctx.installPath)) {
-                    if (!ctx.force) {
-                        task.skip('Version already installed.');
-                        return;
-                    }
-
-                    fs.removeSync(ctx.installPath);
-                }
-
-                task.title = `Downloading and updating Ghost to v${ctx.version}`;
-                return yarnInstall(ctx.ui);
-            }
+            task: this.downloadAndUpdate
         }, {
             title: 'Stopping Ghost',
             skip: (ctx) => !ctx.instance.running(),
-            task: () => {
-                return this.runCommand(StopCommand, {quiet: true}).catch((error) => {
-                    if (!(error instanceof errors.SystemError) || !error.message.match(/No running Ghost instance/)) {
-                        return Promise.reject(error);
-                    }
-                });
-            }
+            task: this.stop.bind(this)
         }, {
             title: 'Linking latest Ghost and recording versions',
             task: this.link
@@ -88,9 +67,7 @@ class UpdateCommand extends Command {
             task: migrate
         }, {
             title: 'Restarting Ghost',
-            task: () => {
-                return this.runCommand(StartCommand, {quiet: true});
-            }
+            task: this.restart.bind(this)
         }];
 
         return this.ui.run(() => this.version(context), 'Checking for latest Ghost version').then((result) => {
@@ -101,6 +78,38 @@ class UpdateCommand extends Command {
 
             return this.ui.listr(tasks, context);
         });
+    }
+
+    downloadAndUpdate(ctx, task) {
+        const yarnInstall = require('../tasks/yarn-install');
+
+        if (fs.existsSync(ctx.installPath)) {
+            if (!ctx.force) {
+                task.skip('Version already installed.');
+                return Promise.resolve();
+            }
+
+            fs.removeSync(ctx.installPath);
+        }
+
+        task.title = `Downloading and updating Ghost to v${ctx.version}`;
+        return yarnInstall(ctx.ui);
+    }
+
+    stop() {
+        const StopCommand = require('./stop');
+
+        return this.runCommand(StopCommand, {quiet: true}).catch((error) => {
+            if (!(error instanceof errors.SystemError) || !error.message.match(/No running Ghost instance/)) {
+                return Promise.reject(error);
+            }
+        });
+    }
+
+    restart() {
+        const StartCommand = require('./start');
+
+        return this.runCommand(StartCommand, {quiet: true});
     }
 
     version(context) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -68,6 +68,10 @@ class UpdateCommand extends Command {
         }, {
             title: 'Restarting Ghost',
             task: this.restart.bind(this)
+        }, {
+            title: 'Removing old Ghost versions',
+            skip: (ctx) => ctx.rollback,
+            task: this.removeOldVersions
         }];
 
         return this.ui.run(() => this.version(context), 'Checking for latest Ghost version').then((result) => {
@@ -110,6 +114,26 @@ class UpdateCommand extends Command {
         const StartCommand = require('./start');
 
         return this.runCommand(StartCommand, {quiet: true});
+    }
+
+    removeOldVersions(ctx, task) {
+        const semver = require('semver');
+
+        return fs.readdir(path.join(process.cwd(), 'versions')).then((versions) => {
+            versions = versions.filter(semver.valid);
+            if (versions.length <= 5) {
+                task.skip();
+                return;
+            }
+
+            versions.sort((a, b) => semver.lt(a, b) ? -1 : 1);
+
+            const promises = versions.slice(0, -5).map((version) => {
+                return fs.remove(path.join(process.cwd(), 'versions', version));
+            });
+
+            return Promise.all(promises);
+        });
     }
 
     version(context) {

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -1,8 +1,579 @@
 'use strict';
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+const configStub = require('../../utils/config-stub');
+const setupEnv = require('../../utils/env');
+const Promise = require('bluebird');
+const path = require('path');
+const fs = require('fs-extra');
 
 const modulePath = '../../../lib/commands/update';
+const errors = require('../../../lib/errors');
+const Instance = require('../../../lib/instance');
 
-// TODO: remove line once tests are implemented
-require(modulePath);
+describe('Unit: Commands > Update', function () {
+    describe('run', function () {
+        it('doesn\'t run tasks if no new versions are available', function () {
+            const UpdateCommand = require(modulePath);
+            const config = configStub();
+            config.get.withArgs('cli-version').returns('1.0.0-beta.1');
+            config.get.withArgs('active-version').returns('1.0.0');
+            const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
+            const system = {getInstance: sinon.stub()};
+            ui.run.callsFake(fn => fn());
 
-describe.skip('Unit: Commands > Update', function () {});
+            class TestInstance extends Instance {
+                get cliConfig() { return config; }
+            }
+            const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
+            system.getInstance.returns(fakeInstance);
+            fakeInstance.running.returns(true);
+            const cmdInstance = new UpdateCommand(ui, system);
+            const versionStub = sinon.stub(cmdInstance, 'version').resolves(false);
+
+            return cmdInstance.run({version: '1.0.0', force: false}).then(() => {
+                expect(ui.run.calledOnce).to.be.true;
+                expect(versionStub.calledOnce).to.be.true;
+                expect(versionStub.args[0][0]).to.deep.equal({
+                    version: '1.0.0',
+                    force: false,
+                    instance: fakeInstance,
+                    activeVersion: '1.0.0'
+                });
+                expect(ui.log.calledTwice).to.be.true;
+                expect(ui.log.args[0][0]).to.match(/install is using out\-of\-date configuration/);
+                expect(ui.log.args[1][0]).to.match(/up to date/);
+                expect(ui.listr.called).to.be.false;
+                expect(fakeInstance.running.calledOnce).to.be.true;
+                expect(fakeInstance.loadRunningEnvironment.calledOnce).to.be.true;
+                expect(fakeInstance.checkEnvironment.calledOnce).to.be.true;
+            });
+        });
+
+        it('rejects if rollback is passed and no previous version exists', function () {
+            const UpdateCommand = require(modulePath);
+            const config = configStub();
+            config.get.withArgs('cli-version').returns('1.0.0');
+            config.get.withArgs('active-version').returns('1.0.0');
+            config.get.withArgs('previous-version').returns(null);
+            const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
+            const system = {getInstance: sinon.stub()};
+            ui.run.callsFake(fn => fn());
+
+            class TestInstance extends Instance {
+                get cliConfig() { return config; }
+            }
+            const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
+            system.getInstance.returns(fakeInstance);
+            fakeInstance.running.returns(true);
+            const cmdInstance = new UpdateCommand(ui, system);
+            const versionStub = sinon.stub(cmdInstance, 'version').resolves(false);
+
+            return cmdInstance.run({rollback: true}).then(() => {
+                expect(false, 'error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.an.instanceof(Error);
+                expect(error.message).to.equal('No previous version found');
+                expect(ui.run.called).to.be.false;
+                expect(versionStub.called).to.be.false;
+                expect(ui.log.called).to.be.false;
+                expect(ui.listr.called).to.be.false;
+            });
+        });
+
+        it('populates context with correct data if rollback is passed and previous version exists', function () {
+            const UpdateCommand = require(modulePath);
+            const config = configStub();
+            config.get.withArgs('cli-version').returns('1.0.0');
+            config.get.withArgs('active-version').returns('1.1.0');
+            config.get.withArgs('previous-version').returns('1.0.0');
+            const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
+            const system = {getInstance: sinon.stub()};
+            ui.run.callsFake(fn => fn());
+
+            class TestInstance extends Instance {
+                get cliConfig() { return config; }
+            }
+            const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
+            system.getInstance.returns(fakeInstance);
+            fakeInstance.running.returns(false);
+            const cmdInstance = new UpdateCommand(ui, system);
+            const versionStub = sinon.stub(cmdInstance, 'version').resolves(false);
+            const cwdStub = sinon.stub(process, 'cwd').returns(fakeInstance.dir);
+
+            return cmdInstance.run({rollback: true, force: false}).then(() => {
+                cwdStub.restore();
+
+                expect(ui.run.calledOnce).to.be.true;
+                expect(versionStub.calledOnce).to.be.true;
+                expect(versionStub.args[0][0]).to.deep.equal({
+                    version: '1.0.0',
+                    force: false,
+                    instance: fakeInstance,
+                    activeVersion: '1.1.0',
+                    installPath: '/var/www/ghost/versions/1.0.0',
+                    rollback: true
+                });
+                expect(ui.log.calledOnce).to.be.true;
+                expect(ui.log.args[0][0]).to.match(/up to date/);
+                expect(ui.listr.called).to.be.false;
+                expect(fakeInstance.running.calledOnce).to.be.true;
+                expect(fakeInstance.loadRunningEnvironment.called).to.be.false;
+                expect(fakeInstance.checkEnvironment.calledOnce).to.be.true;
+            });
+        });
+
+        it('runs all tasks if rollback is false and running is true', function () {
+            const migrateStub = sinon.stub().resolves();
+            const UpdateCommand = proxyquire(modulePath, {
+                '../tasks/migrate': migrateStub
+            });
+            const config = configStub();
+            config.get.withArgs('cli-version').returns('1.0.0');
+            config.get.withArgs('active-version').returns('1.0.0');
+            const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
+            const system = {getInstance: sinon.stub()};
+            ui.run.callsFake(fn => fn());
+            ui.listr.callsFake((tasks, ctx) => {
+                return Promise.each(tasks, (task) => {
+                    if (task.skip && task.skip(ctx)) {
+                        return;
+                    }
+
+                    return task.task(ctx);
+                });
+            });
+
+            class TestInstance extends Instance {
+                get cliConfig() { return config; }
+            }
+            const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
+            system.getInstance.returns(fakeInstance);
+            fakeInstance.running.returns(true);
+            const cmdInstance = new UpdateCommand(ui, system);
+            const versionStub = sinon.stub(cmdInstance, 'version').resolves(true);
+            const stopStub = sinon.stub(cmdInstance, 'stop').resolves();
+            const restartStub = sinon.stub(cmdInstance, 'restart').resolves();
+            const linkStub = sinon.stub(cmdInstance, 'link').resolves();
+            const cwdStub = sinon.stub(process, 'cwd').returns(fakeInstance.dir);
+            const downloadStub = sinon.stub(cmdInstance, 'downloadAndUpdate');
+
+            return cmdInstance.run({version: '1.1.0', rollback: false, force: false}).then(() => {
+                cwdStub.restore();
+
+                expect(ui.run.calledOnce).to.be.true;
+                expect(versionStub.calledOnce).to.be.true;
+                expect(ui.log.called).to.be.false;
+                expect(ui.listr.called).to.be.true;
+
+                expect(downloadStub.calledOnce).to.be.true;
+                expect(stopStub.calledOnce).to.be.true;
+                expect(linkStub.calledOnce).to.be.true;
+                expect(migrateStub.calledOnce).to.be.true;
+                expect(restartStub.calledOnce).to.be.true;
+            });
+        })
+
+        it('skips download and migrate if rollback is true', function () {
+            const migrateStub = sinon.stub().resolves();
+            const UpdateCommand = proxyquire(modulePath, {
+                '../tasks/migrate': migrateStub
+            });
+            const config = configStub();
+            config.get.withArgs('cli-version').returns('1.0.0');
+            config.get.withArgs('active-version').returns('1.1.0');
+            config.get.withArgs('previous-version').returns('1.0.0');
+            const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
+            const system = {getInstance: sinon.stub()};
+            ui.run.callsFake(fn => fn());
+            ui.listr.callsFake((tasks, ctx) => {
+                return Promise.each(tasks, (task) => {
+                    if (task.skip && task.skip(ctx)) {
+                        return;
+                    }
+
+                    return task.task(ctx);
+                });
+            });
+
+            class TestInstance extends Instance {
+                get cliConfig() { return config; }
+            }
+            const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
+            system.getInstance.returns(fakeInstance);
+            fakeInstance.running.returns(false);
+            const cmdInstance = new UpdateCommand(ui, system);
+            const versionStub = sinon.stub(cmdInstance, 'version').resolves(true);
+            sinon.stub(cmdInstance, 'stop').resolves();
+            sinon.stub(cmdInstance, 'restart').resolves();
+            sinon.stub(cmdInstance, 'link').resolves();
+            const cwdStub = sinon.stub(process, 'cwd').returns(fakeInstance.dir);
+            const downloadStub = sinon.stub(cmdInstance, 'downloadAndUpdate');
+
+            return cmdInstance.run({rollback: true, force: false}).then(() => {
+                cwdStub.restore();
+                const expectedCtx = {
+                    version: '1.0.0',
+                    force: false,
+                    instance: fakeInstance,
+                    activeVersion: '1.1.0',
+                    installPath: '/var/www/ghost/versions/1.0.0',
+                    rollback: true
+                };
+
+                expect(ui.run.calledOnce).to.be.true;
+                expect(versionStub.calledOnce).to.be.true;
+                expect(versionStub.args[0][0]).to.deep.equal(expectedCtx);
+                expect(ui.log.called).to.be.false;
+                expect(ui.listr.called).to.be.true;
+
+                expect(downloadStub.called).to.be.false;
+                expect(migrateStub.called).to.be.false;
+            });
+        });
+
+        it('skips stop task if running returns false', function () {
+            const migrateStub = sinon.stub().resolves();
+            const UpdateCommand = proxyquire(modulePath, {
+                '../tasks/migrate': migrateStub
+            });
+            const config = configStub();
+            config.get.withArgs('cli-version').returns('1.0.0');
+            config.get.withArgs('active-version').returns('1.1.0');
+            config.get.withArgs('previous-version').returns('1.0.0');
+            const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
+            const system = {getInstance: sinon.stub()};
+            ui.run.callsFake(fn => fn());
+            ui.listr.callsFake((tasks, ctx) => {
+                return Promise.each(tasks, (task) => {
+                    if (task.skip && task.skip(ctx)) {
+                        return;
+                    }
+
+                    return task.task(ctx);
+                });
+            });
+
+            class TestInstance extends Instance {
+                get cliConfig() { return config; }
+            }
+            const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
+            system.getInstance.returns(fakeInstance);
+            fakeInstance.running.returns(false);
+            const cmdInstance = new UpdateCommand(ui, system);
+            const versionStub = sinon.stub(cmdInstance, 'version').resolves(true);
+            const stopStub = sinon.stub(cmdInstance, 'stop').resolves();
+            sinon.stub(cmdInstance, 'restart').resolves();
+            sinon.stub(cmdInstance, 'link').resolves();
+            const cwdStub = sinon.stub(process, 'cwd').returns(fakeInstance.dir);
+            sinon.stub(cmdInstance, 'downloadAndUpdate');
+
+            return cmdInstance.run({rollback: true, force: false}).then(() => {
+                cwdStub.restore();
+                const expectedCtx = {
+                    version: '1.0.0',
+                    force: false,
+                    instance: fakeInstance,
+                    activeVersion: '1.1.0',
+                    installPath: '/var/www/ghost/versions/1.0.0',
+                    rollback: true
+                };
+
+                expect(ui.run.calledOnce).to.be.true;
+                expect(versionStub.calledOnce).to.be.true;
+                expect(versionStub.args[0][0]).to.deep.equal(expectedCtx);
+                expect(ui.log.called).to.be.false;
+                expect(ui.listr.called).to.be.true;
+
+                expect(stopStub.called).to.be.false;
+            });
+        });
+    });
+
+    describe('downloadAndUpdate task', function () {
+        it('runs yarnInstall task, sets title', function () {
+            const yarnInstallStub = sinon.stub().resolves();
+            const UpdateCommand = proxyquire(modulePath, {
+                '../tasks/yarn-install': yarnInstallStub
+            });
+            const instance = new UpdateCommand({}, {});
+            const env = setupEnv();
+            const ctx = {
+                installPath: path.join(env.dir, 'versions/1.0.0'),
+                version: '1.0.0'
+            };
+            const task = {};
+
+            return instance.downloadAndUpdate(ctx, task).then(() => {
+                expect(yarnInstallStub.calledOnce).to.be.true;
+                expect(task.title).to.equal('Downloading and updating Ghost to v1.0.0');
+                env.cleanup();
+            });
+        });
+
+        it('skips if install path exists and force is false', function () {
+            const yarnInstallStub = sinon.stub().resolves();
+            const UpdateCommand = proxyquire(modulePath, {
+                '../tasks/yarn-install': yarnInstallStub
+            });
+            const instance = new UpdateCommand({}, {});
+            const envCfg = {
+                dirs: ['versions/1.0.0', 'versions/1.0.1'],
+                links: [['versions/1.0.0', 'current']]
+            };
+            const env = setupEnv(envCfg);
+            const ctx = {
+                installPath: path.join(env.dir, 'versions/1.0.1'),
+                force: false
+            };
+            const task = {skip: sinon.stub()};
+
+            expect(fs.existsSync(ctx.installPath)).to.be.true;
+
+            return instance.downloadAndUpdate(ctx, task).then(() => {
+                expect(fs.existsSync(ctx.installPath)).to.be.true;
+                expect(yarnInstallStub.called).to.be.false;
+                expect(task.skip.calledOnce).to.be.true;
+
+                env.cleanup();
+            });
+        });
+
+        it('removes install path if it exists and force is true', function () {
+            const yarnInstallStub = sinon.stub().resolves();
+            const UpdateCommand = proxyquire(modulePath, {
+                '../tasks/yarn-install': yarnInstallStub
+            });
+            const instance = new UpdateCommand({}, {});
+            const envCfg = {
+                dirs: ['versions/1.0.0', 'versions/1.0.1'],
+                links: [['versions/1.0.0', 'current']]
+            };
+            const env = setupEnv(envCfg);
+            const ctx = {
+                installPath: path.join(env.dir, 'versions/1.0.1'),
+                force: true
+            };
+
+            expect(fs.existsSync(ctx.installPath)).to.be.true;
+
+            return instance.downloadAndUpdate(ctx, {}).then(() => {
+                expect(fs.existsSync(ctx.installPath)).to.be.false;
+                expect(yarnInstallStub.calledOnce).to.be.true;
+
+                env.cleanup();
+            });
+        });
+    });
+
+    describe('stop task', function () {
+        it('runs stop command', function () {
+            const UpdateCommand = proxyquire(modulePath, {
+                './stop': {StopCommand: true}
+            });
+            const instance = new UpdateCommand({}, {});
+            const runCommandStub = sinon.stub(instance, 'runCommand').resolves();
+
+            return instance.stop().then(() => {
+                expect(runCommandStub.calledOnce).to.be.true;
+                expect(runCommandStub.args[0][0]).to.deep.equal({StopCommand: true});
+                expect(runCommandStub.args[0][1]).to.deep.equal({quiet: true});
+            });
+        });
+
+        it('swallows SystemError with "no instance running" message', function () {
+            const UpdateCommand = proxyquire(modulePath, {
+                './stop': {StopCommand: true}
+            });
+            const instance = new UpdateCommand({}, {});
+            const runCommandStub = sinon.stub(instance, 'runCommand').rejects(new errors.SystemError(
+                'No running Ghost instance found here'
+            ));
+
+            return instance.stop().then(() => {
+                expect(runCommandStub.calledOnce).to.be.true;
+                expect(runCommandStub.args[0][0]).to.deep.equal({StopCommand: true});
+                expect(runCommandStub.args[0][1]).to.deep.equal({quiet: true});
+            });
+        });
+
+        it('rethrows any unexpected error', function () {
+            const UpdateCommand = proxyquire(modulePath, {
+                './stop': {StopCommand: true}
+            });
+            const instance = new UpdateCommand({}, {});
+            const runCommandStub = sinon.stub(instance, 'runCommand').rejects(new Error('uh-oh'));
+
+            return instance.stop().then(() => {
+                expect(false, 'error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.an.instanceof(Error);
+                expect(error.message).to.equal('uh-oh');
+                expect(runCommandStub.calledOnce).to.be.true;
+                expect(runCommandStub.args[0][0]).to.deep.equal({StopCommand: true});
+                expect(runCommandStub.args[0][1]).to.deep.equal({quiet: true});
+            });
+        });
+    });
+
+    it('restart task runs start command', function () {
+        const UpdateCommand = proxyquire(modulePath, {
+            './start': {StartCommand: true}
+        });
+        const instance = new UpdateCommand({}, {});
+        const runCommandStub = sinon.stub(instance, 'runCommand').resolves();
+
+        return instance.restart().then(() => {
+            expect(runCommandStub.calledOnce).to.be.true;
+            expect(runCommandStub.args[0][0]).to.deep.equal({StartCommand: true});
+            expect(runCommandStub.args[0][1]).to.deep.equal({quiet: true});
+        });
+    });
+
+    describe('version', function () {
+        it('resolves with true if rollback is true', function () {
+            const UpdateCommand = require(modulePath);
+            const instance = new UpdateCommand({}, {});
+
+            return instance.version({rollback: true}).then((result) => {
+                expect(result).to.be.true;
+            });
+        });
+
+        it('calls resolveVersion util with correct args and sets version and installPath in context', function () {
+            const resolveVersion = sinon.stub().resolves('1.0.1');
+            const UpdateCommand = proxyquire(modulePath, {
+                '../utils/resolve-version': resolveVersion
+            });
+            const instance = new UpdateCommand({}, {});
+            const context = {
+                rollback: false,
+                force: false,
+                version: null,
+                activeVersion: '1.0.0'
+            };
+            const cwdStub = sinon.stub(process, 'cwd').returns('/var/www/ghost');
+
+            return instance.version(context).then((result) => {
+                expect(result).to.be.true;
+                expect(resolveVersion.calledOnce).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, '1.0.0')).to.be.true;
+                expect(context.version).to.equal('1.0.1');
+                expect(context.installPath).to.equal('/var/www/ghost/versions/1.0.1');
+                cwdStub.restore();
+            });
+        });
+
+        it('swallows CliErrors from resolveVersion util', function () {
+            const resolveVersion = sinon.stub().rejects(new errors.CliError('No valid versions found'));
+            const UpdateCommand = proxyquire(modulePath, {
+                '../utils/resolve-version': resolveVersion
+            });
+            const instance = new UpdateCommand({}, {});
+            const context = {
+                rollback: false,
+                force: true,
+                version: null,
+                activeVersion: '1.0.0'
+            };
+
+            return instance.version(context).then((result) => {
+                expect(result).to.be.false;
+                expect(resolveVersion.calledOnce).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, null)).to.be.true;
+            });
+        });
+
+        it('re-throws non CliErrors from resolveVersion util', function () {
+            const resolveVersion = sinon.stub().callsFake(() => {
+                // sinon's reject handling doesn't work quite well enough
+                // for this so we do it manually
+                return Promise.reject(new Error('something bad'));
+            });
+            const UpdateCommand = proxyquire(modulePath, {
+                '../utils/resolve-version': resolveVersion
+            });
+            const instance = new UpdateCommand({}, {});
+            const context = {
+                rollback: false,
+                force: true,
+                version: null,
+                activeVersion: '1.0.0'
+            };
+
+            return instance.version(context).then(() => {
+                expect(false, 'error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.an.instanceof(Error);
+                expect(error.message).to.equal('something bad');
+                expect(resolveVersion.calledOnce).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, null)).to.be.true;
+            });
+        });
+    });
+
+    describe('link', function () {
+        const UpdateCommand = require(modulePath);
+
+        it('does things correctly with normal upgrade', function () {
+            const instance = new UpdateCommand({}, {});
+            const envCfg = {
+                dirs: ['versions/1.0.0', 'versions/1.0.1'],
+                links: [['versions/1.0.0', 'current']]
+            }
+            const env = setupEnv(envCfg);
+            const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
+            const config = configStub();
+            config.get.withArgs('active-version').returns('1.0.0');
+            const context = {
+                installPath: path.join(env.dir, 'versions/1.0.1'),
+                version: '1.0.1',
+                rollback: false,
+                instance: {
+                    cliConfig: config
+                }
+            };
+
+            instance.link(context);
+            expect(fs.readlinkSync(path.join(env.dir, 'current'))).to.equal(path.join(env.dir, 'versions/1.0.1'));
+            expect(config.set.calledTwice).to.be.true;
+            expect(config.set.calledWithExactly('previous-version', '1.0.0')).to.be.true;
+            expect(config.set.calledWithExactly('active-version', '1.0.1')).to.be.true;
+            expect(config.save.calledOnce).to.be.true;
+
+            cwdStub.restore();
+            env.cleanup();
+        });
+
+        it('does things correctly with rollback', function () {
+            const instance = new UpdateCommand({}, {});
+            const envCfg = {
+                dirs: ['versions/1.0.0', 'versions/1.0.1'],
+                links: [['versions/1.0.1', 'current']]
+            }
+            const env = setupEnv(envCfg);
+            const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
+            const config = configStub();
+            config.get.withArgs('active-version').returns('1.0.1');
+            const context = {
+                installPath: path.join(env.dir, 'versions/1.0.0'),
+                version: '1.0.0',
+                rollback: true,
+                instance: {
+                    cliConfig: config
+                }
+            };
+
+            instance.link(context);
+            expect(fs.readlinkSync(path.join(env.dir, 'current'))).to.equal(path.join(env.dir, 'versions/1.0.0'));
+            expect(config.set.calledTwice).to.be.true;
+            expect(config.set.calledWithExactly('previous-version', null)).to.be.true;
+            expect(config.set.calledWithExactly('active-version', '1.0.0')).to.be.true;
+            expect(config.save.calledOnce).to.be.true;
+
+            cwdStub.restore();
+            env.cleanup();
+        });
+    });
+});


### PR DESCRIPTION
This PR removes old Ghost versions during `ghost update`, keeping only the most recent 5 versions.

It also adds a bunch of tests 😁 

TODO:
- [x] ubuntu test sanity check