### PR TITLE
chore(docs): Updated all docs urls to use /v1/

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -145,7 +145,7 @@ module.exports = {
         // Yargs magic
         // TODO: evaluate if `wrap` is actually needed?
         yargs.wrap(Math.min(100, yargs.terminalWidth()))
-            .epilogue('For more information, see our docs at https://docs.ghost.org/docs/ghost-cli')
+            .epilogue('For more information, see our docs at https://docs.ghost.org/v1/docs/ghost-cli')
             .option('D', {
                 alias: 'development',
                 describe: 'Run in development mode',

--- a/lib/command.js
+++ b/lib/command.js
@@ -32,7 +32,7 @@ function checkValidInstall(name) {
         console.error(
             chalk.yellow('Ghost-CLI only works with Ghost versions >= 1.0.0.'),
             '\nIf you are trying to upgrade Ghost LTS to 1.0.0 ' +
-            `please see ${chalk.blue.underline('https://docs.ghost.org/docs/migrating-to-1-0-0')}.`,
+            `please see ${chalk.blue.underline('https://docs.ghost.org/v1/docs/migrating-to-1-0-0')}.`,
             `\nOtherwise, please run \`ghost ${name}\` again within a valid Ghost installation.`
         );
         process.exit(1);
@@ -145,7 +145,7 @@ class Command {
             yargs.usage(this.longDescription);
         }
 
-        yargs.epilogue('For more information, see our docs at https://docs.ghost.org/docs/ghost-cli');
+        yargs.epilogue('For more information, see our docs at https://docs.ghost.org/v1/docs/ghost-cli');
 
         return yargs;
     }

--- a/lib/commands/doctor/checks/install.js
+++ b/lib/commands/doctor/checks/install.js
@@ -53,7 +53,7 @@ const tasks = {
                 `${chalk.red('The version of Node.js you are using is not supported.')}${eol}` +
                 `${chalk.gray('Supported: ')}${cliPackage.engines.node}${eol}` +
                 `${chalk.gray('Installed: ')}${process.versions.node}${eol}` +
-                `See ${chalk.underline.blue('https://docs.ghost.org/docs/supported-node-versions')} ` +
+                `See ${chalk.underline.blue('https://docs.ghost.org/v1/docs/supported-node-versions')} ` +
                 'for more information'
             ));
         }

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -20,7 +20,7 @@ class UpdateCommand extends Command {
             this.ui.log(
                 `Ghost was installed with Ghost-CLI v${instance.cliConfig.get('cli-version')}, which is a pre-release version.\n` +
                 'Your Ghost install is using out-of-date configuration & requires manual changes.\n' +
-                `Please visit ${chalk.blue.underline('https://docs.ghost.org/docs/how-to-upgrade-ghost#section-upgrading-ghost-cli')}\n` +
+                `Please visit ${chalk.blue.underline('https://docs.ghost.org/v1/docs/how-to-upgrade-ghost#section-upgrading-ghost-cli')}\n` +
                 'for instructions on how to upgrade your instance.\n',
                 'yellow'
             );

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,7 +24,7 @@ class CliError extends Error {
 
         this.context = options.context || {};
         this.options = options;
-        this.help = 'Please refer to https://docs.ghost.org/docs/troubleshooting#section-cli-errors for troubleshooting.'
+        this.help = 'Please refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.'
     }
 
     /**

--- a/lib/tasks/migrate.js
+++ b/lib/tasks/migrate.js
@@ -61,7 +61,7 @@ module.exports = function runMigrations(context) {
             error = new errors.SystemError({
                 message: 'It appears that sqlite3 did not install properly when Ghost-CLI was installed.\n' +
                     'Please either uninstall and reinstall Ghost-CLI, or switch to MySQL',
-                help: 'https://docs.ghost.org/v1.0.0/docs/troubleshooting#section-sqlite3-install-failure'
+                help: 'https://docs.ghost.org/v1/docs/troubleshooting#section-sqlite3-install-failure'
             });
         }
 

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -342,7 +342,7 @@ class UI {
             this.log(debugInfo, 'yellow');
             let logLocation = system.writeErrorLog(stripAnsi(`${debugInfo}\n${output}`));
             this.log(`\nAdditional log info available in: ${logLocation}`);
-            this.log('\nPlease refer to https://docs.ghost.org/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
+            this.log('\nPlease refer to https://docs.ghost.org/docs/v1/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
         } else if (isObject(error)) {
             // TODO: find better way to handle object errors?
             this.log(JSON.stringify(error), null, true);


### PR DESCRIPTION
We have changed docs.ghost.org to have 2 distinct versions, 

docs.ghost.org/v0.11/

and 

docs.ghost.org/v1

The old full-semver v1.0.0 is going away, as it doesn't make sense when we're on 1.6.x etc, we're still in the v1 stream and unlike the theme docs, the main install docs don't change from version to version in that way, instead they improve over time.

Therefore, I've updated all the occurrences in this codebase to point to docs.ghost.org/v1/docs, which should ensure their longevity and correctness!

no issue

- We've now got a standard /v1/ version of docs.ghost.org
- Using this ensures that the URLs are always correct, and users end up on the right version of the document