### PR TITLE
Fixed bug where BASE_PORT is appended to instead of incremented by one

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -6,7 +6,7 @@ const includes = require('lodash/includes');
 const validator = require('validator');
 const url = require('url');
 
-const BASE_PORT = '2368';
+const BASE_PORT = 2368;
 const knownMailServices = [
     'aol', 'dynectemail', 'fastmail', 'gmail', 'godaddy', 'godaddyasia', 'godaddyeurope', 'hot.ee', 'hotmail', 'icloud',
     'mail.ee', 'mail.ru', 'mailgun', 'mailjet', 'mandrill', 'postmark', 'qq', 'qqex', 'sendgrid',

--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -47,12 +47,12 @@ module.exports = {
                 return 'Port must be an integer.';
             }
 
-            return portfinder.getPortPromise({port: value}).then((port) => {
-                return (port === value) || `Port '${value}' is in use.`;
+            return portfinder.getPortPromise({port: parseInt(value)}).then((port) => {
+                return (parseInt(port) === parseInt(value)) || `Port '${value}' is in use.`;
             });
         },
         defaultValue: config => {
-            let port = url.parse(config.get('url')).port || BASE_PORT;
+            let port = parseInt(url.parse(config.get('url')).port || BASE_PORT);
             return portfinder.getPortPromise({port: port});
         },
         default: 2368,

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -401,10 +401,10 @@ describe('Unit: Command > Config', function () {
                 expect(results.validateExpectsTrue).to.be.true;
                 expect(results.validateExpectsMessage).to.match(/'2366' is in use/);
 
-                expect(portPromiseStub.calledWithExactly({ port: '2366' })).to.be.true;
-                expect(portPromiseStub.calledWithExactly({ port: '2367' })).to.be.true;
-                expect(portPromiseStub.calledWithExactly({ port: '2368' })).to.be.true;
-                expect(portPromiseStub.calledWithExactly({ port: '2369' })).to.be.true;
+                expect(portPromiseStub.calledWithExactly({ port: 2366 })).to.be.true;
+                expect(portPromiseStub.calledWithExactly({ port: 2367 })).to.be.true;
+                expect(portPromiseStub.calledWithExactly({ port: 2368 })).to.be.true;
+                expect(portPromiseStub.calledWithExactly({ port: 2369 })).to.be.true;
             });
         });
     });


### PR DESCRIPTION
closes #451 

When you use `ghost install` and specify the blog url without a port number, BASE_PORT is treated as a string so that, by the third blog instance, it fails as it has tried ports: 2368, 23681, 236811 (which is > 65535). Changing BASE_PORT to be an integer fixes the problem.

Debug Information:
    Node Version: v6.11.2
    Ghost-CLI Version: 1.1.0
    Environment: production
    Command: 'ghost install'

Please refer to https://docs.ghost.org/docs/troubleshooting#section-cli-errors for troubleshooting. and specify a blog url without a port number, BASE_PORT is treated as a string so by the third installation it fails as it tried port 2368, then 23681, then 236811 (which is greater than 65535).