### PR TITLE
Offer better default database name when installing

### DIFF
--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -71,6 +71,8 @@ class ConfigCommand extends Command {
 
     getConfigPrompts(argv) {
         const validator     = require('validator');
+        const path = require('path');
+
         let prompts = [];
 
         if (!argv.url) {
@@ -119,7 +121,7 @@ class ConfigCommand extends Command {
                     type: 'input',
                     name: 'dbname',
                     message: 'Enter your Ghost database name:',
-                    default: this.instance.config.get('database.connection.database', `ghost_${this.system.environment}`)
+                    default: this.instance.config.get('database.connection.database', `ghost_${this.system.environment}_${path.basename(process.cwd())}`)
                 });
             }
         }


### PR DESCRIPTION
Names the default mysql database to be `ghost_environment_foldername`.

e.g. If you run `ghost install` in `/var/www/tom` then the default database name will be `ghost_production_tom`.

closes #453 