### PR TITLE
Update migration docs URL

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -32,7 +32,7 @@ function checkValidInstall(name) {
         console.error(
             chalk.yellow('Ghost-CLI only works with Ghost versions >= 1.0.0.'),
             '\nIf you are trying to upgrade Ghost LTS to 1.0.0 ' +
-            `please see ${chalk.blue.underline('https://docs.ghost.org/v1/docs/migrating-to-1-0-0')}.`,
+            `please see ${chalk.blue.underline('https://docs.ghost.org/v0.11/docs/migrating-to-ghost-version-100')}.`,
             `\nOtherwise, please run \`ghost ${name}\` again within a valid Ghost installation.`
         );
         process.exit(1);

--- a/lib/command.js
+++ b/lib/command.js
@@ -32,7 +32,7 @@ function checkValidInstall(name) {
         console.error(
             chalk.yellow('Ghost-CLI only works with Ghost versions >= 1.0.0.'),
             '\nIf you are trying to upgrade Ghost LTS to 1.0.0 ' +
-            `please see ${chalk.blue.underline('https://docs.ghost.org/v0.11/docs/migrating-to-ghost-version-100')}.`,
+            `please see ${chalk.blue.underline('https://docs.ghost.org/v1/docs/migrating-to-ghost-1-0-0')}.`,
             `\nOtherwise, please run \`ghost ${name}\` again within a valid Ghost installation.`
         );
         process.exit(1);


### PR DESCRIPTION
- Fixes TryGhost/Ghost#8948
- Using v0.x URL (https://docs.ghost.org/v0.11/docs/migrating-to-ghost-version-100) over v1.x (https://docs.ghost.org/v1/docs/migrating-to-1-0-0) since the install is assumed to be 0.x