### PR TITLE
Update typos in docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Documentation
 
-- [Complete Setup Guide](https://docs.ghost.org/docs/install)
+- [Complete Setup Guide](https://docs.ghost.org/v1/docs/install)
 - [Command Reference](https://docs.ghost.org/v1/docs/ghost-cli)
 - [Troubleshooting Guide](https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors)
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 ## Documentation
 
 - [Complete Setup Guide](https://docs.ghost.org/docs/install)
-- [Command Reference](https://docs.ghost.org/v1.0.0/docs/ghost-cli)
-- [Troubleshooting Guide](https://docs.ghost.org/v1.0.0/docs/troubleshooting#section-cli-errors)
+- [Command Reference](https://docs.ghost.org/v1/docs/ghost-cli)
+- [Troubleshooting Guide](https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors)
 
 ## Developer Setup (for contributing)
 

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -342,7 +342,7 @@ class UI {
             this.log(debugInfo, 'yellow');
             let logLocation = system.writeErrorLog(stripAnsi(`${debugInfo}\n${output}`));
             this.log(`\nAdditional log info available in: ${logLocation}`);
-            this.log('\nPlease refer to https://docs.ghost.org/docs/v1/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
+            this.log('\nPlease refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
         } else if (isObject(error)) {
             // TODO: find better way to handle object errors?
             this.log(JSON.stringify(error), null, true);


### PR DESCRIPTION
- Normalized explicit versioning (from `1.0.0` to `1.0`)
- docs and v1 was flipped for another URL