### PR TITLE
fix(setup): don’t rewrite no-start option when no-prompt is passed

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -174,7 +174,7 @@ class SetupCommand extends Command {
 
             return this.ui.listr(tasks, {setup: true}).then(() => {
                 // If we are not allowed to prompt, set the default value, which should be true
-                if (!argv.prompt) {
+                if (!argv.prompt && typeof argv.start === 'undefined') {
                     argv.start = true;
                 }
 


### PR DESCRIPTION
Now it is possible to pass both `--no-prompt` and `--no-start` options.
Before this fix `--no-start` was ignored if `--no-prompt` is present.

It’s very annoying when building containers with Ghost.