### PR TITLE
fix(config): ensure non-string args are handled correctly

### DIFF
--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -21,7 +21,7 @@ class ConfigCommand extends Command {
             let value = argv[key];
             const configKey = option.configPath || key;
 
-            if (!value || !value.length) {
+            if (!value || !value.toString().length) {
                 if (!option.defaultValue) {
                     return Promise.resolve();
                 }

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -117,6 +117,21 @@ describe('Unit: Command > Config', function () {
                 expect(error.options.config).to.deep.equal({url: 'http://localhost:2368'});
             });
         });
+
+        it('handles non-string arg values correctly', function () {
+            const ConfigCommand = require(modulePath);
+            const instanceConfig = new Config('config.json');
+            const getInstanceStub = sinon.stub().returns({config: instanceConfig});
+            const save = sinon.stub(instanceConfig, 'save');
+            const config = new ConfigCommand({}, {getInstance: getInstanceStub});
+
+            return config.handleAdvancedOptions({url: 'http://localhost:2368/', port: 1234}).then(() => {
+                expect(getInstanceStub.calledOnce).to.be.true;
+                expect(save.calledOnce).to.be.true;
+                expect(instanceConfig.get('url')).to.equal('http://localhost:1234/');
+                expect(instanceConfig.get('server.port')).to.equal(1234);
+            });
+        });
     });
 
     describe('getConfigPrompts', function () {


### PR DESCRIPTION
closes #479
- the `--port` option is handled as an integer, which was causing the `value.length` check to fail. Now we cast it to a string and check the length