### PR TITLE
Strips undesirable characters out of DB name

### DIFF
--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -117,11 +117,13 @@ class ConfigCommand extends Command {
             }
 
             if (!argv.dbname) {
+                const sanitizedDirName = path.basename(process.cwd()).replace(/[^a-zA-Z0-9_]+/g, '_');
                 prompts.push({
                     type: 'input',
                     name: 'dbname',
                     message: 'Enter your Ghost database name:',
-                    default: this.instance.config.get('database.connection.database', `ghost_${this.system.environment}_${path.basename(process.cwd())}`)
+                    default: this.instance.config.get('database.connection.database', `ghost_${this.system.environment}_${sanitizedDirName}`),
+                    validate: (val) => !/[^a-zA-Z0-9_]/.test(val) || 'MySQL database names may consist of only alphanumeric characters and underscores.'
                 });
             }
         }

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -192,7 +192,12 @@ describe('Unit: Command > Config', function () {
             expect(passprompt).to.be.ok;
             expect(passprompt.message).to.match(/skip to keep current/);
 
-            expect(result.find(prompt => prompt.name === 'dbname')).to.be.ok;
+            const nameprompt = result.find(prompt => prompt.name === 'dbname');
+            expect(nameprompt).to.be.ok;
+            expect(nameprompt.validate('example123')).to.be.true;
+            expect(nameprompt.validate('example123.com')).to.match(/consist of only alpha/);
+            expect(nameprompt.validate('example-123')).to.match(/consist of only alpha/);
+            expect(nameprompt.validate('example!!!')).to.match(/consist of only alpha/);
         });
 
         it('doesn\'t return dbhost prompt if dbhost provided', function () {


### PR DESCRIPTION
If installing Ghost from a folder with a period in its name, for example:

```bash
$ cd example.com
$ ghost install -V
```

The default database name used will contain a period, for example `ghost_production_example.com`.

However, Ghost-CLI will then fail when it attempts to grant permissions to its new user.

This PR strips undesirable characters out of the DB name.