### PR TITLE
Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "yarn run lint && yarn run test:all"
   },
   "engines": {
-    "node": "^4.5.0 || ^6.5.0"
+    "node": "^4.5.0 || ^6.5.0 || ^8.6.0"
   },
   "preferGlobal": true,
   "dependencies": {


### PR DESCRIPTION
This is not making node 8 officially supported by the CLI yet - the official support still follows https://docs.ghost.org/v1/docs/supported-node-versions

This PR exists to find any places that will be pain points in the future as we seek to enable node 8 support at the end of the month.