### PR TITLE
Update supported node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "yarn run lint && yarn run test:all"
   },
   "engines": {
-    "node": "^4.5.0 || ^6.5.0"
+    "node": "^4.5.0 || ^6.9.0"
   },
   "preferGlobal": true,
   "dependencies": {


### PR DESCRIPTION
For node Boron (v6), the [docs](https://docs.ghost.org/docs/supported-node-versions) say there's only support for >=6.9. The CLI checks the node version based on [package.engines.node](https://github.com/TryGhost/Ghost-CLI/blob/master/lib/commands/doctor/checks/install.js#L51) which requires >= 6.5. This pull request fixes this discrepancy. Issue initially discovered by fredylg on Slack