### PR TITLE
Remove redundant linebreak filter

### DIFF
--- a/lib/ui/renderer.js
+++ b/lib/ui/renderer.js
@@ -82,7 +82,7 @@ class CLIRenderer {
     buildText(task) {
         if (!task.hasSubtasks()) {
             if (task.output && typeof task.output === 'string') {
-                const data = task.output.trim().split('\n').filter(Boolean).pop();
+                const data = task.output.trim();
                 return `${task.title} ${this.constructor.separator} ${chalk.gray(data)}`;
             }
 

--- a/lib/ui/renderer.js
+++ b/lib/ui/renderer.js
@@ -82,7 +82,7 @@ class CLIRenderer {
     buildText(task) {
         if (!task.hasSubtasks()) {
             if (task.output && typeof task.output === 'string') {
-                const data = task.output.trim();
+                const data = task.output.trim().split('\n').pop();
                 return `${task.title} ${this.constructor.separator} ${chalk.gray(data)}`;
             }
 


### PR DESCRIPTION
The `trim` method removes linebreaks by default so `split('\n')` would do nothing