### PR TITLE
Updated package.json to add support for Node v8.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "yarn run lint && yarn run test:all"
   },
   "engines": {
-    "node": "^4.5.0 || ^6.9.0"
+    "node": "^4.5.0 || ^6.9.0 || ^8.8.0"
   },
   "preferGlobal": true,
   "dependencies": {


### PR DESCRIPTION
To comply with the following statement found in [supported-node-versions](https://docs.ghost.org/docs/supported-node-versions).

`Ghost 1.0.0 currently supports Node versions 8.8+, 6.9+ and 4.5+ only.`