### PR TITLE
Fix Node 8 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "yarn run lint && yarn run test:all"
   },
   "engines": {
-    "node": "^4.5.0 || ^6.9.0 || ^8.8.0"
+    "node": "^4.5.0 || ^6.9.0 || ^8.9.0"
   },
   "preferGlobal": true,
   "dependencies": {


### PR DESCRIPTION
No issue

[Ghost](https://github.com/TryGhost/Ghost/blob/89e57ad6b298319123802de453ef40d0d813b1df/package.json) and the [docs](https://docs.ghost.org/docs/supported-node-versions) suggest support for ^8.9.0, not ^8.8.0