### PR TITLE
fix(config): ports work again

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -55,7 +55,6 @@ module.exports = {
             const port = parseInt(url.parse(config.get('url')).port || BASE_PORT);
             return portfinder.getPortPromise({port: port});
         },
-        default: 2368,
         type: 'number',
         group: 'Ghost Options:'
     },


### PR DESCRIPTION
closes #519

- `ghost install` -> uses the next available port (starts with 2368)
- `ghost install --url http://localhost:4000` (uses 4000)
- `ghost install --url http://localhost:4000 --port 2390` (uses 2390 and saves localhost:2390)