### PR TITLE
Don't check coverage on test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint bin lib test extensions",
     "release": "standard-version",
-    "test:unit": "nyc --reporter=html --reporter=text mocha --recursive test/unit extensions/**/test",
+    "test:unit": "nyc --reporter=html --reporter=text -x '**/*-spec.js' mocha --recursive test/unit extensions/**/test",
     "test:acceptance": "mocha --timeout 10000 test/acceptance/**/*-spec.js",
     "test:all": "yarn run test:unit && yarn run test:acceptance",
     "test": "yarn run lint && yarn run test:all"

--- a/package.json
+++ b/package.json
@@ -29,10 +29,16 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint bin lib test extensions",
     "release": "standard-version",
-    "test:unit": "nyc --reporter=html --reporter=text -x '**/*-spec.js' mocha --recursive test/unit extensions/**/test",
+    "test:unit": "nyc --reporter=html --reporter=text mocha --recursive test/unit extensions/**/test",
     "test:acceptance": "mocha --timeout 10000 test/acceptance/**/*-spec.js",
     "test:all": "yarn run test:unit && yarn run test:acceptance",
     "test": "yarn run lint && yarn run test:all"
+  },
+  "nyc": {
+    "exclude": [
+      "**/*-spec.js",
+      "test"
+     ]
   },
   "engines": {
     "node": "^4.5.0 || ^6.9.0 || ^8.9.0"


### PR DESCRIPTION
Currently, test files (`*-spec.js`) are tested for coverage in nyc. This isn't necessarily something that should be done, since the goal of tests is to execute core files, and certain areas _should not_ be run.

Ref: #541 (kind of)

Full documentation available in [nyc readme](https://github.com/istanbuljs/nyc#excluding-files)