### PR TITLE
Fix generated mysql user compatibility with secure installations

### DIFF
--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -2,9 +2,9 @@
 
 const Promise = require('bluebird');
 const mysql = require('mysql');
-const crypto = require('crypto');
 const omit = require('lodash/omit');
 const cli = require('../../lib');
+const generator = require('generate-password');
 
 class MySQLExtension extends cli.Extension {
     setup(cmd, argv) {
@@ -77,7 +77,12 @@ class MySQLExtension extends cli.Extension {
     }
 
     createUser(ctx, dbconfig) {
-        const randomPassword = crypto.randomBytes(10).toString('hex');
+        const randomPassword = generator.generate({
+            length: 20,
+            numbers: true,
+            symbols: true,
+            strict: true
+        });
 
         let username;
 

--- a/extensions/mysql/test/extension-spec.js
+++ b/extensions/mysql/test/extension-spec.js
@@ -192,7 +192,7 @@ describe('Unit: Mysql extension', function () {
             return instance.createUser(ctx, {host: 'localhost'}).then(() => {
                 expect(queryStub.calledThrice).to.be.true;
                 expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
-                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[0-9A-Fa-f]*'\) AS password;$/);
+                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
                 expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
                 expect(logStub.calledThrice).to.be.true;
                 expect(logStub.args[0][0]).to.match(/disabled old_password/);
@@ -200,7 +200,7 @@ describe('Unit: Mysql extension', function () {
                 expect(logStub.args[2][0]).to.match(/successfully created new user/);
                 expect(ctx.mysql).to.exist;
                 expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
-                expect(ctx.mysql.password).to.match(/^[0-9A-Fa-f]*$/);
+                expect(ctx.mysql.password).to.match(/^[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*$/);
             });
         });
 
@@ -219,7 +219,7 @@ describe('Unit: Mysql extension', function () {
             return instance.createUser(ctx, {host: 'localhost'}).then(() => {
                 expect(queryStub.callCount).to.equal(4);
                 expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
-                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[0-9A-Fa-f]*'\) AS password;$/);
+                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
                 expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
                 expect(queryStub.args[3][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
                 expect(logStub.callCount).to.equal(4);
@@ -229,7 +229,7 @@ describe('Unit: Mysql extension', function () {
                 expect(logStub.args[3][0]).to.match(/successfully created new user/);
                 expect(ctx.mysql).to.exist;
                 expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
-                expect(ctx.mysql.password).to.match(/^[0-9A-Fa-f]*$/);
+                expect(ctx.mysql.password).to.match(/^[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*$/);
             });
         });
 
@@ -249,7 +249,7 @@ describe('Unit: Mysql extension', function () {
                 expect(error.message).to.match(/Creating new mysql user errored/);
                 expect(queryStub.callCount).to.equal(3);
                 expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
-                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[0-9A-Fa-f]*'\) AS password;$/);
+                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
                 expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
                 expect(logStub.callCount).to.equal(3);
                 expect(logStub.args[0][0]).to.match(/disabled old_password/);

--- a/extensions/mysql/test/extension-spec.js
+++ b/extensions/mysql/test/extension-spec.js
@@ -186,17 +186,18 @@ describe('Unit: Mysql extension', function () {
             const logStub = sinon.stub();
             const instance = new MysqlExtension({logVerbose: logStub}, {}, {}, '/some/dir');
             const queryStub = sinon.stub(instance, '_query').resolves();
+            queryStub.onSecondCall().resolves([{password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'}]);
             const ctx = {};
 
             return instance.createUser(ctx, {host: 'localhost'}).then(() => {
                 expect(queryStub.calledThrice).to.be.true;
-                expect(queryStub.args[0][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password;$/);
-                expect(queryStub.args[1][0]).to.equal('SET old_passwords = 0;');
-                expect(queryStub.args[2][0]).to.match(/^SET PASSWORD FOR 'ghost-[0-9]{1,4}'@'localhost' = PASSWORD\('[0-9A-Fa-f]*'\);$/);
+                expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
+                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[0-9A-Fa-f]*'\) AS password;$/);
+                expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
                 expect(logStub.calledThrice).to.be.true;
-                expect(logStub.args[0][0]).to.match(/created new user/);
-                expect(logStub.args[1][0]).to.match(/disabled old_password/);
-                expect(logStub.args[2][0]).to.match(/successfully created password for user/);
+                expect(logStub.args[0][0]).to.match(/disabled old_password/);
+                expect(logStub.args[1][0]).to.match(/created password hash/);
+                expect(logStub.args[2][0]).to.match(/successfully created new user/);
                 expect(ctx.mysql).to.exist;
                 expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
                 expect(ctx.mysql.password).to.match(/^[0-9A-Fa-f]*$/);
@@ -207,7 +208,8 @@ describe('Unit: Mysql extension', function () {
             const logStub = sinon.stub();
             const instance = new MysqlExtension({logVerbose: logStub}, {}, {}, '/some/dir');
             const queryStub = sinon.stub(instance, '_query').resolves();
-            queryStub.onFirstCall().callsFake(() => {
+            queryStub.onSecondCall().resolves([{password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'}]);
+            queryStub.onThirdCall().callsFake(() => {
                 const error = new Error();
                 error.errno = 1396;
                 return Promise.reject(error);
@@ -216,18 +218,44 @@ describe('Unit: Mysql extension', function () {
 
             return instance.createUser(ctx, {host: 'localhost'}).then(() => {
                 expect(queryStub.callCount).to.equal(4);
-                expect(queryStub.args[0][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password;$/);
-                expect(queryStub.args[1][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password;$/);
-                expect(queryStub.args[2][0]).to.equal('SET old_passwords = 0;');
-                expect(queryStub.args[3][0]).to.match(/^SET PASSWORD FOR 'ghost-[0-9]{1,4}'@'localhost' = PASSWORD\('[0-9A-Fa-f]*'\);$/);
+                expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
+                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[0-9A-Fa-f]*'\) AS password;$/);
+                expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
+                expect(queryStub.args[3][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
                 expect(logStub.callCount).to.equal(4);
-                expect(logStub.args[0][0]).to.match(/user exists, re-trying user creation/);
-                expect(logStub.args[1][0]).to.match(/created new user/);
-                expect(logStub.args[2][0]).to.match(/disabled old_password/);
-                expect(logStub.args[3][0]).to.match(/successfully created password for user/);
+                expect(logStub.args[0][0]).to.match(/disabled old_password/);
+                expect(logStub.args[1][0]).to.match(/created password hash/);
+                expect(logStub.args[2][0]).to.match(/user exists, re-trying user creation/);
+                expect(logStub.args[3][0]).to.match(/successfully created new user/);
                 expect(ctx.mysql).to.exist;
                 expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
                 expect(ctx.mysql.password).to.match(/^[0-9A-Fa-f]*$/);
+            });
+        });
+
+        it('rejects if error occurs during user creation', function () {
+            const logStub = sinon.stub();
+            const instance = new MysqlExtension({logVerbose: logStub}, {}, {}, '/some/dir');
+            const queryStub = sinon.stub(instance, '_query').resolves();
+            queryStub.onSecondCall().resolves([{password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'}]);
+            queryStub.onThirdCall().rejects();
+            const endStub = sinon.stub();
+            instance.connection = {end: endStub};
+
+            return instance.createUser({}, {host: 'localhost'}).then(() => {
+                expect(false, 'error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.an.instanceof(errors.SystemError);
+                expect(error.message).to.match(/Creating new mysql user errored/);
+                expect(queryStub.callCount).to.equal(3);
+                expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
+                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[0-9A-Fa-f]*'\) AS password;$/);
+                expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
+                expect(logStub.callCount).to.equal(3);
+                expect(logStub.args[0][0]).to.match(/disabled old_password/);
+                expect(logStub.args[1][0]).to.match(/created password hash/);
+                expect(logStub.args[2][0]).to.match(/Unable to create custom Ghost user/);
+                expect(endStub.calledOnce).to.be.true;
             });
         });
 
@@ -244,7 +272,7 @@ describe('Unit: Mysql extension', function () {
                 expect(error).to.be.an.instanceof(errors.SystemError);
                 expect(error.message).to.match(/Creating new mysql user errored/);
                 expect(queryStub.calledOnce).to.be.true;
-                expect(queryStub.args[0][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password;$/);
+                expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
                 expect(logStub.calledOnce).to.be.true;
                 expect(logStub.args[0][0]).to.match(/Unable to create custom Ghost user/);
                 expect(endStub.calledOnce).to.be.true;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "find-plugins": "1.1.3",
     "fkill": "5.1.0",
     "fs-extra": "4.0.2",
+    "generate-password": "1.3.0",
     "ghost-ignition": "2.8.16",
     "got": "7.1.0",
     "inquirer": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,6 +1464,10 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
+generate-password@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/generate-password/-/generate-password-1.3.0.tgz#4da4c154530d21c1995a77aac5a3ea04882fc8ad"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"


### PR DESCRIPTION
closes #511 

This is a combination of my own commit and the commit from #534 

TODO: 
- [x] test on ubuntu instance w/mysql\_secure\_installation
- [x] test on ubuntu instance w/o mysql\_secure\_installation