### PR TITLE
fix(run): make `ghost run` responsible for outputting running env

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -1,10 +1,11 @@
 'use strict';
+const fs = require('fs-extra');
+const path = require('path');
 const spawn = require('child_process').spawn;
 const Command = require('../command');
 
 class RunCommand extends Command {
     run() {
-        const path = require('path');
         const shouldUseGhostUser = require('../utils/use-ghost-user');
 
         // If the user is running this command directly, output a little note
@@ -14,17 +15,17 @@ class RunCommand extends Command {
                 'If you\'re not running this to debug something, you should run `ghost start` instead.', 'yellow');
         }
 
-        const instance = this.system.getInstance();
+        this.instance = this.system.getInstance();
 
-        if (!instance.config.has('paths.contentPath')) {
-            instance.config.set('paths.contentPath', path.join(instance.dir, 'content')).save();
+        if (!this.instance.config.has('paths.contentPath')) {
+            this.instance.config.set('paths.contentPath', path.join(this.instance.dir, 'content')).save();
         }
 
-        if (shouldUseGhostUser(path.join(instance.dir, 'content'))) {
-            return this.useGhostUser(instance);
+        if (shouldUseGhostUser(path.join(this.instance.dir, 'content'))) {
+            return this.useGhostUser(this.instance);
         }
 
-        return this.useDirect(instance);
+        return this.useDirect(this.instance);
     }
 
     useGhostUser(instance) {
@@ -50,6 +51,8 @@ class RunCommand extends Command {
             if (message.error) {
                 throw new errors.GhostError(message.error);
             }
+
+            this.writeEnvironment();
         });
         this.sudo = true;
     }
@@ -67,6 +70,8 @@ class RunCommand extends Command {
 
         this.child.on('message', (message) => {
             if (message.started) {
+                this.writeEnvironment();
+
                 instance.process.success();
                 return;
             }
@@ -82,11 +87,24 @@ class RunCommand extends Command {
 
         try {
             this.child.kill();
+
+            this.writeEnvironment(true);
         } catch (e) {
             if (!this.sudo || e.code !== 'EPERM') {
                 throw e;
             }
         }
+    }
+
+    writeEnvironment(remove) {
+        const environmentPath = path.join(this.instance.dir, 'content/.environment');
+
+        if (remove) {
+            fs.removeSync(environmentPath);
+            return;
+        }
+
+        fs.writeFileSync(environmentPath, this.system.environment, {encoding: 'utf8'});
     }
 }
 

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -36,8 +36,7 @@ class StartCommand extends Command {
             const processInstance = instance.process;
 
             const start = () => {
-                return Promise.resolve(processInstance.start(process.cwd(), this.system.environment))
-                    .then(() => { instance.running(this.system.environment); });
+                return Promise.resolve(processInstance.start(process.cwd(), this.system.environment));
             };
 
             return this.ui.run(start, 'Starting Ghost', runOptions).then(() => {

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -46,9 +46,7 @@ class StopCommand extends Command {
 
         instance.loadRunningEnvironment();
 
-        const stop = () => Promise.resolve(instance.process.stop(process.cwd())).then(() => {
-            instance.running(null);
-        });
+        const stop = () => Promise.resolve(instance.process.stop(process.cwd()));
 
         return this.ui.run(stop, 'Stopping Ghost', runOptions).then(() => {
             if (

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -62,6 +62,34 @@ class Instance {
     }
 
     /**
+     * Look for the running environment in both the cliConfig and the .environment file in the content folder
+     *
+     * @property runningEnvironment
+     * @type String
+     * @private
+     */
+    get runningEnvironment() {
+        if (!this._cachedRunningEnvironment) {
+            const envFilePath = path.join(this.dir, 'content/.environment');
+            let environment;
+
+            if (fs.existsSync(envFilePath)) {
+                environment = fs.readFileSync(envFilePath, {encoding: 'utf8'});
+            } else if (this.cliConfig.has('running')) {
+                environment = this.cliConfig.get('running');
+            }
+
+            if (environment !== 'production' && environment !== 'development') {
+                return null;
+            }
+
+            this._cachedRunningEnvironment = environment;
+        }
+
+        return this._cachedRunningEnvironment;
+    }
+
+    /**
      * Process manager for this instance & environment
      *
      * @property process
@@ -97,20 +125,15 @@ class Instance {
      * If no args specified, returns whether or not the instance is running
      * If arg specified, sets the running environment to the passed environment
      *
-     * @param {String} environment Environment to set
      * @return {Boolean} true if instance is running, otherwise false
      *
      * @method running
      * @public
      */
-    running(environment) {
-        if (environment !== undefined) {
-            // setter
-            this.cliConfig.set('running', environment).save();
-            return true;
-        }
+    running() {
+        const runningEnvironment = this.runningEnvironment;
 
-        if (!this.cliConfig.has('running')) {
+        if (!runningEnvironment) {
             return false;
         }
 
@@ -156,7 +179,7 @@ class Instance {
      * @public
      */
     loadRunningEnvironment(setNodeEnv) {
-        const env = this.cliConfig.get('running');
+        const env = this.runningEnvironment;
 
         if (!env) {
             throw new Error('This instance is not running.');


### PR DESCRIPTION
closes #463 [ci skip]
- output a .environment file into the content folder using `ghost run`, is cleaned up when ghost is stopped

todo:
- [ ] fix tests
- [ ] manual test the 💩 out of this