### PR TITLE
fix(config): shorten default database name

### DIFF
--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -120,11 +120,12 @@ class ConfigCommand extends Command {
 
             if (!argv.dbname) {
                 const sanitizedDirName = path.basename(process.cwd()).replace(/[^a-zA-Z0-9_]+/g, '_');
+                const shortenedEnv = this.system.development ? 'dev' : 'prod';
                 prompts.push({
                     type: 'input',
                     name: 'dbname',
                     message: 'Enter your Ghost database name:',
-                    default: this.instance.config.get('database.connection.database', `ghost_${this.system.environment}_${sanitizedDirName}`),
+                    default: this.instance.config.get('database.connection.database', `${sanitizedDirName}_${shortenedEnv}`),
                     validate: (val) => !/[^a-zA-Z0-9_]/.test(val) || 'MySQL database names may consist of only alphanumeric characters and underscores.'
                 });
             }


### PR DESCRIPTION
closes #508
- change default dbname format to `<folder>_<environment>` rather than `ghost_<environment>_<foldername>`