### PR TITLE
feat(update): add option to disable restart on update

### DIFF
--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -69,6 +69,7 @@ class UpdateCommand extends Command {
             task: migrate
         }, {
             title: 'Restarting Ghost',
+            skip: () => !argv.restart,
             task: this.restart.bind(this)
         }, {
             title: 'Removing old Ghost versions',
@@ -192,6 +193,11 @@ UpdateCommand.options = {
         alias: 'f',
         description: 'Force Ghost to update',
         type: 'boolean'
+    },
+    restart: {
+        description: '[--no-restart] Enable/Disable restarting Ghost after updating',
+        type: 'boolean',
+        default: true
     }
 };
 

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -169,7 +169,7 @@ describe('Unit: Commands > Update', function () {
             const removeOldVersionsStub = sinon.stub(cmdInstance, 'removeOldVersions');
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
 
-            return cmdInstance.run({version: '1.1.0', rollback: false, force: false}).then(() => {
+            return cmdInstance.run({version: '1.1.0', rollback: false, force: false, restart: true}).then(() => {
                 cwdStub.restore();
 
                 expect(runCommandStub.calledOnce).to.be.true;
@@ -225,7 +225,7 @@ describe('Unit: Commands > Update', function () {
             const removeOldVersionsStub = sinon.stub(cmdInstance, 'removeOldVersions');
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
 
-            return cmdInstance.run({rollback: true, force: false, zip: ''}).then(() => {
+            return cmdInstance.run({rollback: true, force: false, zip: '', restart: true}).then(() => {
                 cwdStub.restore();
 
                 const expectedCtx = {
@@ -290,7 +290,7 @@ describe('Unit: Commands > Update', function () {
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
 
 
-            return cmdInstance.run({rollback: true, force: false, zip: ''}).then(() => {
+            return cmdInstance.run({rollback: true, force: false, zip: '', restart: true}).then(() => {
                 cwdStub.restore();
                 const expectedCtx = {
                     version: '1.0.0',


### PR DESCRIPTION
closes #481
- add a --no-restart option to the update command that skips the restart task