### PR TITLE
fix(nginx): skip SSL setup if url is an IP address

### DIFF
--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 const os = require('os');
 const dns = require('dns');
 const url = require('url');
+const isIP = require('validator/lib/isIP');
 const path = require('path');
 const execa = require('execa');
 const Promise = require('bluebird');
@@ -77,6 +78,11 @@ class NginxExtension extends cli.Extension {
     setupSSL(argv, ctx, task) {
         const parsedUrl = url.parse(ctx.instance.config.get('url'));
         const confFile = `${parsedUrl.hostname}-ssl.conf`;
+
+        if (isIP(parsedUrl.hostname)) {
+            this.ui.log('SSL certs cannot be generated for IP addresses, skipping', 'yellow');
+            return task.skip();
+        }
 
         if (fs.existsSync(`/etc/nginx/sites-available/${confFile}`)) {
             this.ui.log('SSL has already been set up, skipping', 'yellow');

--- a/extensions/nginx/test/extension-spec.js
+++ b/extensions/nginx/test/extension-spec.js
@@ -226,6 +226,16 @@ describe('Unit: Extensions > Nginx', function () {
             ext = proxyNginx({'fs-extra': {existsSync: stubs.es}});
         });
 
+        it('skips if the url is an IP address', function () {
+            ctx = {instance: {config: {get: () => 'http://10.0.0.1'}}};
+            ext.setupSSL({}, ctx, task);
+
+            expect(stubs.es.calledOnce).to.be.false;
+            expect(ext.ui.log.calledOnce).to.be.true;
+            expect(ext.ui.log.getCall(0).args[0]).to.match(/SSL certs cannot be generated for IP addresses/);
+            expect(stubs.skip.calledOnce).to.be.true;
+        });
+
         it('Breaks if ssl config already exists', function () {
             const sslFile = '/etc/nginx/sites-available/ghost.dev-ssl.conf';
             const existsStub = sinon.stub().returns(true);


### PR DESCRIPTION
closes #301
- detect if the url is an IP address and skip if it is