### PR TITLE
feat(log): add --error flag to `ghost log`

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -40,7 +40,7 @@ class LogCommand extends Command {
             }));
         }
 
-        const logFileName = path.join(instance.dir, 'content/logs', `${instance.config.get('url').replace(/[^\w]/gi, '_')}_${this.system.environment}.log`);
+        const logFileName = path.join(instance.dir, 'content/logs', `${instance.config.get('url').replace(/[^\w]/gi, '_')}_${this.system.environment}${argv.error ? '.error' : ''}.log`);
         const prettyStream = new PrettyStream();
 
         if (!fs.existsSync(logFileName)) {
@@ -84,6 +84,11 @@ LogCommand.options = {
     follow: {
         alias: 'f',
         description: 'Follow the log file (similar to `tail -f`)',
+        type: 'boolean'
+    },
+    error: {
+        alias: 'e',
+        description: 'If provided, only show the error log',
         type: 'boolean'
     }
 };


### PR DESCRIPTION
closes #432
- add an error flag that loads the error log as opposed to the full access log

TODO:
- add tests for error flag