### PR TITLE
fix(ssl-migration): make the checks for migrating ssl more robust

### DIFF
--- a/extensions/nginx/test/fixtures/old-ssl-with-le.txt
+++ b/extensions/nginx/test/fixtures/old-ssl-with-le.txt
@@ -1,0 +1,25 @@
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name ghost.org;
+    root /var/www/ghost/system/nginx-root;
+
+    ssl_certificate /home/ghost/.acme.sh/ghost.org/fullchain.cer;
+    ssl_certificate_key /home/ghost/.acme.sh/ghost.org/ghost.org.key;
+    include /var/www/ghost/system/files/ssl-params.conf;
+
+    location / {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $http_host;
+        proxy_pass http://127.0.0.1:2368;
+    }
+
+    location ~ /.well-known {
+        allow all;
+    }
+
+    client_max_body_size 50m;
+}

--- a/extensions/nginx/test/fixtures/ssl-without-le.txt
+++ b/extensions/nginx/test/fixtures/ssl-without-le.txt
@@ -1,0 +1,25 @@
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name ghost.org;
+    root /var/www/ghost/system/nginx-root;
+
+    ssl_certificate /etc/ssl/comodo/ghost.org.cer;
+    ssl_certificate_key /etc/ssl/comodo/ghost.org.key;
+    include /var/www/ghost/system/files/ssl-params.conf;
+
+    location / {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $http_host;
+        proxy_pass http://127.0.0.1:2368;
+    }
+
+    location ~ /.well-known {
+        allow all;
+    }
+
+    client_max_body_size 50m;
+}


### PR DESCRIPTION
closes #552
- skip ssl migration in a couple more cases

TODO:
- [x] fix tests
- manual test all the things
  - [x] test 1/3
  - [x] test 2/3
  - [x] test 3/3