### PR TITLE
fix(migrate): only run as sudo for sqlite installations

### DIFF
--- a/lib/tasks/migrate.js
+++ b/lib/tasks/migrate.js
@@ -23,7 +23,7 @@ module.exports = function runMigrations(context) {
 
     // If we're using sqlite and the ghost user owns the content folder, then
     // we should run sudo, otherwise run normally
-    if (shouldUseGhostUser(contentDir)) {
+    if (config.get('database.client') === 'sqlite3' && shouldUseGhostUser(contentDir)) {
         const knexMigratorPath = path.resolve(context.instance.dir, 'current/node_modules/.bin/knex-migrator-migrate');
         knexMigratorPromise = context.ui.sudo(`${knexMigratorPath} ${args.join(' ')}`, {sudoArgs: '-E -u ghost'});
     } else {


### PR DESCRIPTION
The migration command needs to run with sudo only if the database is sqlite3 and if the content folder is owned by ghost - otherwise, it can be run as the current user because either the database is mysql, and the credentials are read from the config file, or the content folder is not owned by ghost and we trust the user to have permission to write to it