### PR TITLE
fix(update-check): only run update check on specific commands

### DIFF
--- a/bin/ghost
+++ b/bin/ghost
@@ -4,22 +4,6 @@
 // provide a title to the process
 process.title = 'ghost';
 
-function startup() {
-    const yargs = require('yargs');
-    const bootstrap = require('../lib/bootstrap');
-    bootstrap.run(process.argv.slice(2), yargs);
-}
-
-// Check for CLI updates if not running `ghost run`
-if (process.argv.length > 2 && process.argv[2] !== 'run') {
-    const updateCheck = require('../lib/utils/update-check');
-    updateCheck().then(startup).catch((error) => {
-        if (error) {
-            console.error(error);
-        }
-
-        process.exit(1);
-    });
-} else {
-    startup();
-}
+const yargs = require('yargs');
+const bootstrap = require('../lib/bootstrap');
+bootstrap.run(process.argv.slice(2), yargs);

--- a/lib/command.js
+++ b/lib/command.js
@@ -193,9 +193,18 @@ class Command {
                 .removeAllListeners('SIGTERM').on('SIGTERM', cleanup);
         }
 
-        debug(`running command ${commandName}`);
-        // Run ze command
-        return Promise.resolve(commandInstance.run(argv)).catch((error) => {
+        let precheck = Promise.resolve();
+
+        if (this.checkVersion) {
+            const updateCheck = require('./utils/update-check');
+            precheck = updateCheck(ui);
+        }
+
+        return precheck.then(() => {
+            // Run ze command
+            debug(`running command ${commandName}`);
+            return Promise.resolve(commandInstance.run(argv))
+        }).catch((error) => {
             debug(`command ${commandName} failed!`);
 
             // Handle an error

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -142,5 +142,6 @@ InstallCommand.options = {
         default: true
     }
 };
+InstallCommand.checkVersion = true;
 
 module.exports = InstallCommand;

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -34,5 +34,6 @@ class MigrateCommand extends Command {
 }
 
 MigrateCommand.description = 'Run system migrations on a Ghost instance';
+MigrateCommand.checkVersion = true;
 
 module.exports = MigrateCommand;

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -213,5 +213,6 @@ SetupCommand.options = {
         type: 'string'
     }
 };
+SetupCommand.checkVersion = true;
 
 module.exports = SetupCommand;

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -200,5 +200,6 @@ UpdateCommand.options = {
         default: true
     }
 };
+UpdateCommand.checkVersion = true;
 
 module.exports = UpdateCommand;

--- a/lib/utils/update-check.js
+++ b/lib/utils/update-check.js
@@ -1,43 +1,39 @@
 'use strict';
-const inquirer = require('inquirer');
+const Promise = require('bluebird');
 const updateNotifier = require('update-notifier');
 const pkg = require('../../package.json');
 
-module.exports = function updateCheck() {
-    return new Promise((resolve, reject) => {
-        updateNotifier({
-            pkg: pkg,
-            callback: (err, update) => {
-                if (err) {
-                    return reject(err);
-                }
+/**
+ * Checks if a version update is available
+ * @param {UI} ui ui instance
+ */
+module.exports = function updateCheck(ui) {
+    return Promise.fromCallback(cb => updateNotifier({pkg: pkg, callback: cb})).then((update) => {
+        if (update.type === 'latest') {
+            return Promise.resolve();
+        }
 
-                if (update.type === 'latest') {
-                    // we are on the latest version, continue
-                    return resolve();
-                }
+        const chalk = require('chalk');
+        const errors = require('../errors');
 
-                const chalk = require('chalk');
+        ui.log(
+            'You are running an outdated version of Ghost-CLI.\n' +
+            'It is recommended that you upgrade before continuing.\n' +
+            `Run ${chalk.cyan('`npm install -g ghost-cli@latest`')} to upgrade.\n`,
+            'yellow'
+        );
 
-                console.log(chalk.yellow(
-                    'You are running an outdated version of Ghost-CLI.\n' +
-                    'It is recommended that you upgrade before continuing.\n' +
-                    `Run ${chalk.cyan('`npm install -g ghost-cli@latest`')} to upgrade.\n`
-                ));
-
-                inquirer.prompt({
-                    type: 'confirm',
-                    message: 'Continue without upgrading?',
-                    default: false,
-                    name: 'yes'
-                }).then((answers) => {
-                    if (answers.yes) {
-                        return resolve();
-                    }
-
-                    reject();
-                }).catch(reject);
+        return ui.prompt({
+            type: 'confirm',
+            message: 'Continue without upgrading?',
+            default: false,
+            name: 'yes'
+        }).then((answers) => {
+            if (!answers.yes) {
+                return Promise.reject(new errors.SystemError('Ghost-CLI version is out-of-date'));
             }
+
+            return Promise.resolve();
         });
     });
 };


### PR DESCRIPTION
closes #565, #563
- move update check further into the stack behind a "checkVersion" command flag
- rewrite checkUpdate class to use UI instace
- update tests