### PR TITLE
modified DNS (resolver) to use Quad9 DNS Service for OCSP Stapling

### DIFF
--- a/extensions/nginx/templates/ssl-params.conf
+++ b/extensions/nginx/templates/ssl-params.conf
@@ -6,7 +6,7 @@ ssl_session_cache shared:SSL:10m;
 ssl_session_tickets off; # Requires nginx >= 1.5.9
 ssl_stapling on; # Requires nginx >= 1.3.7
 ssl_stapling_verify on; # Requires nginx => 1.3.7
-resolver 8.8.8.8 8.8.4.4 valid=300s;
+resolver 9.9.9.9 valid=300s;
 resolver_timeout 5s;
 add_header Strict-Transport-Security 'max-age=63072000; includeSubDomains; preload';
 add_header X-Frame-Options SAMEORIGIN;


### PR DESCRIPTION
Thought it might be worth considering changing the DNS server configured for OCSP stapling to Quad9 who's mission of "free, open, and private" aligns better with Ghost's non-profit and open ethos.

I have excluded a secondary DNS server as the 9.9.9.9 service is highly available.

From: https://www.quad9.net/#/about

> Quad9 is a free, recursive, anycast DNS platform that provides end users robust security protections, high-performance, and privacy. 
> 
> Security: Quad9 blocks against known malicious domains, preventing your computers and IoT devices from connecting malware or phishing sites. Whenever a Quad9 user clicks on a website link or types in an address into a web browser, Quad9 will check the site against the IBM X-Force threat intelligence database of over 40 billion analyzed web pages and images. Quad9 also taps feeds from 18 additional threat intelligence partners to block a large portion of the threats that present risk to end users and businesses alike. 
> 
> Performance: Quad9 systems are distributed worldwide in more than 100 locations at launch, with more than 160 locations in total on schedule for 2018. These servers are located primarily at Internet Exchange points, meaning that the distance and time required to get answers is lower than almost any other solution. These systems are distributed worldwide, not just in high-population areas, meaning users in less well-served areas can see significant improvements in speed on DNS lookups. The systems are “anycast” meaning that queries will automatically be routed to the closest operational system. 
> 
> Privacy: No personally-identifiable information is collected by the system. IP addresses of end users are not stored to disk or distributed outside of the equipment answering the query in the local data center. Quad9 is a nonprofit organization dedicated only to the operation of DNS services. There are no other secondary revenue streams for personally-identifiable data, and the core charter of the organization is to provide secure, fast, private DNS.