### PR TITLE
fix(update-check): remove prompt if version is out-of-date

### DIFF
--- a/lib/utils/update-check.js
+++ b/lib/utils/update-check.js
@@ -9,31 +9,17 @@ const pkg = require('../../package.json');
  */
 module.exports = function updateCheck(ui) {
     return Promise.fromCallback(cb => updateNotifier({pkg: pkg, callback: cb})).then((update) => {
-        if (update.type === 'latest') {
-            return Promise.resolve();
+        if (update.type !== 'latest') {
+            const chalk = require('chalk');
+
+            ui.log(
+                'You are running an outdated version of Ghost-CLI.\n' +
+                'It is recommended that you upgrade before continuing.\n' +
+                `Run ${chalk.cyan('`npm install -g ghost-cli@latest`')} to upgrade.\n`,
+                'yellow'
+            );
         }
 
-        const chalk = require('chalk');
-        const errors = require('../errors');
-
-        ui.log(
-            'You are running an outdated version of Ghost-CLI.\n' +
-            'It is recommended that you upgrade before continuing.\n' +
-            `Run ${chalk.cyan('`npm install -g ghost-cli@latest`')} to upgrade.\n`,
-            'yellow'
-        );
-
-        return ui.prompt({
-            type: 'confirm',
-            message: 'Continue without upgrading?',
-            default: false,
-            name: 'yes'
-        }).then((answers) => {
-            if (!answers.yes) {
-                return Promise.reject(new errors.SystemError('Ghost-CLI version is out-of-date'));
-            }
-
-            return Promise.resolve();
-        });
+        return Promise.resolve();
     });
 };

--- a/test/unit/utils/update-check-spec.js
+++ b/test/unit/utils/update-check-spec.js
@@ -3,7 +3,6 @@ const expect = require('chai').expect;
 const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 const stripAnsi = require('strip-ansi');
-const errors = require('../../../lib/errors');
 
 const modulePath = '../../../lib/utils/update-check';
 
@@ -38,20 +37,18 @@ describe('Unit: Utils > update-check', function () {
             options.callback(null, {type: 'latest'});
         });
         const logStub = sinon.stub();
-        const promptStub = sinon.stub().resolves({yes: false});
 
         const updateCheck = proxyquire(modulePath, {
             '../../package.json': pkg,
             'update-notifier': updateNotifer
         });
 
-        return updateCheck({log: logStub, prompt: promptStub}).then(() => {
+        return updateCheck({log: logStub}).then(() => {
             expect(logStub.called).to.be.false;
-            expect(promptStub.called).to.be.false;
         });
     });
 
-    it('prompts if an update is available, resolves if yes', function () {
+    it('logs a message if an update is available', function () {
         const pkg = {name: 'ghost', version: '1.0.0'};
         const updateNotifer = sinon.stub().callsFake((options) => {
             expect(options).to.exist;
@@ -60,59 +57,18 @@ describe('Unit: Utils > update-check', function () {
             options.callback(null, {type: 'minor'});
         });
         const logStub = sinon.stub();
-        const promptStub = sinon.stub().resolves({yes: true});
 
         const updateCheck = proxyquire(modulePath, {
             '../../package.json': pkg,
             'update-notifier': updateNotifer
         });
 
-        return updateCheck({log: logStub, prompt: promptStub}).then(() => {
+        return updateCheck({log: logStub}).then(() => {
             expect(logStub.calledOnce).to.be.true;
-            expect(promptStub.calledOnce).to.be.true;
 
             const log = logStub.args[0][0];
-            const prompt = promptStub.args[0][0];
 
             expect(stripAnsi(log)).to.match(/You are running an outdated version of Ghost-CLI/);
-            expect(prompt).to.exist;
-            expect(prompt.type).to.equal('confirm');
-            expect(prompt.default).to.be.false;
-        });
-    });
-
-    it('prompts if an update is available, rejects if no', function (done) {
-        const pkg = {name: 'ghost', version: '1.0.0'};
-        const updateNotifer = sinon.stub().callsFake((options) => {
-            expect(options).to.exist;
-            expect(options.pkg).to.deep.equal(pkg);
-            expect(options.callback).to.be.a('function');
-            options.callback(null, {type: 'minor'});
-        });
-        const logStub = sinon.stub();
-        const promptStub = sinon.stub().resolves({yes: false});
-
-        const updateCheck = proxyquire(modulePath, {
-            '../../package.json': pkg,
-            'update-notifier': updateNotifer
-        });
-
-        updateCheck({log: logStub, prompt: promptStub}).then(() => {
-            done(new Error('updateCheck should not have resolved'));
-        }).catch((error) => {
-            expect(error).to.be.an.instanceof(errors.SystemError);
-            expect(error.message).to.equal('Ghost-CLI version is out-of-date');
-            expect(logStub.calledOnce).to.be.true;
-            expect(promptStub.calledOnce).to.be.true;
-
-            const log = logStub.args[0][0];
-            const prompt = promptStub.args[0][0];
-
-            expect(stripAnsi(log)).to.match(/You are running an outdated version of Ghost-CLI/);
-            expect(prompt).to.exist;
-            expect(prompt.type).to.equal('confirm');
-            expect(prompt.default).to.be.false;
-            done();
         });
     });
 });


### PR DESCRIPTION
closes #563
- remove prompt on update-check because it was bad UX & broke docker