### PR TITLE
fix(setup): ensure --pname arg is sanitized

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -107,7 +107,7 @@ class SetupCommand extends Command {
             title: 'Setting up instance',
             task: (ctx) => {
                 ctx.instance = this.system.getInstance();
-                ctx.instance.name = argv.pname || url.parse(ctx.instance.config.get('url')).hostname.replace(/\./g, '-');
+                ctx.instance.name = (argv.pname || url.parse(ctx.instance.config.get('url')).hostname).replace(/\./g, '-');
                 this.system.addInstance(ctx.instance);
             }
         }];


### PR DESCRIPTION
closes #576
- the url was getting sanitized (e.g. swapping out `.` with `-`), but if --pname was passed it wasn't getting the same treatment. This fixes that issue.

TODO:
- [x] figure out why tests are failing locally on my machine (my guess is it has something to do with travis being a linux environment)