### PR TITLE
feat(ssl) improve error messages to log original error

### DIFF
--- a/extensions/nginx/acme.js
+++ b/extensions/nginx/acme.js
@@ -27,14 +27,13 @@ function install(ui, task) {
         ui.logVerbose('ssl: downloading acme.sh to temporary directory', 'green');
         return fs.emptyDir(acmeTmpDir)
     }).then(() => got(acmeApiUrl)).then((response) => {
-        if (response.statusCode !== 200) {
-            return Promise.reject(new cli.errors.CliError('Unable to query GitHub for ACME download URL'));
-        }
-
         try {
             response = JSON.parse(response.body).tarball_url;
         } catch (e) {
-            return Promise.reject(new cli.errors.CliError('Unable to parse Github api response for acme'));
+            return Promise.reject(new cli.errors.CliError({
+                message: 'Unable to parse Github api response for acme',
+                err: e
+            }));
         }
 
         return download(response, acmeTmpDir, {extract: true});
@@ -49,7 +48,21 @@ function install(ui, task) {
 
         // Installs acme.sh into /etc/letsencrypt
         return ui.sudo('./acme.sh --install --home /etc/letsencrypt', {cwd: acmeCodeDir});
-    }).catch((error) => Promise.reject(new cli.errors.ProcessError(error)));
+    }).catch((error) => {
+        // CASE: error is already a cli error, just pass it along
+        if (error instanceof cli.errors.CliError) {
+            return Promise.reject(error);
+        }
+
+        // catch any request errors first, which isn't a ProcessError
+        if (!error.stderr) {
+            return Promise.reject(new cli.errors.CliError({
+                message: 'Unable to query GitHub for ACME download URL',
+                err: error
+            }));
+        }
+        return Promise.reject(new cli.errors.ProcessError(error));
+    });
 }
 
 function generateCert(ui, domain, webroot, email, staging) {
@@ -64,9 +77,7 @@ function generateCert(ui, domain, webroot, email, staging) {
 
         if (error.stderr.match(/Verify error:(Fetching|Invalid Response)/)) {
             // Domain verification failed
-            return Promise.reject(new cli.errors.SystemError(
-                'Your domain name is not pointing to the correct IP address of your server, please update it and run `ghost setup ssl` again'
-            ));
+            return Promise.reject(new cli.errors.SystemError('Your domain name is not pointing to the correct IP address of your server, please update it and run `ghost setup ssl` again'));
         }
 
         // It's not an error we expect might happen, throw a ProcessError instead.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -10,6 +10,8 @@ const chalk = require('chalk');
  */
 class CliError extends Error {
     constructor(options) {
+        const originalError = {};
+
         options = options || {};
 
         if (typeof options === 'string') {
@@ -24,7 +26,28 @@ class CliError extends Error {
 
         this.context = options.context || {};
         this.options = options;
+
         this.help = 'Please refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.'
+
+        if (options.err) {
+            if (typeof options.err === 'string') {
+                options.err = new Error(options.err);
+            }
+
+            Object.getOwnPropertyNames(options.err).forEach((property) => {
+                if (['response', 'headers'].indexOf(property) !== -1) {
+                    return;
+                }
+
+                // TODO: we receive all possible properties now, except the excluded ones above
+                // Currently we're logging only the message and the stack property.
+                // This part of the code could probably be simplyfied if we won't need other
+                // properties in the future
+                originalError[property] = options.err[property];
+            });
+        }
+
+        this.err = originalError;
     }
 
     /**
@@ -52,7 +75,15 @@ class CliError extends Error {
         let output = `${chalk.yellow('Message:')} ${this.message}\n`;
 
         if (verbose) {
-            output += `${chalk.yellow('Stack:')} ${this.stack}\n`;
+            output += `${chalk.yellow('Stack:')} ${this.stack}\n\n`;
+
+            if (this.err && this.err.message) {
+                output += `${chalk.green('Original Error Message:')}\n`
+                output += `${chalk.gray('Message:')} ${this.err.message}\n`
+                if (this.err.stack) {
+                    output += `${chalk.gray('Stack:')} ${this.err.stack}\n`
+                }
+            }
         }
 
         if (this.options.help) {
@@ -83,11 +114,16 @@ class ProcessError extends CliError {
             output += chalk.yellow(`Exit code: ${this.options.code}\n\n`);
         }
 
-        if (verbose && this.options.stdout) {
-            output += chalk.grey('--------------- stdout ---------------\n') +
-                `${this.options.stdout}\n\n` +
-                chalk.grey('--------------- stderr ---------------\n') +
-                `${this.options.stderr}\n`;
+        if (verbose) {
+            if (this.options.stdout) {
+                output += chalk.grey('--------------- stdout ---------------\n') +
+                    `${this.options.stdout}\n\n`;
+            }
+
+            if (this.options.stderr) {
+                output += chalk.grey('--------------- stderr ---------------\n') +
+                    `${this.options.stderr}\n`;
+            }
         }
 
         return output;

--- a/test/unit/errors-spec.js
+++ b/test/unit/errors-spec.js
@@ -46,6 +46,35 @@ describe('Unit: Errors', function () {
             expect(errorOutput).to.match(/Message: some error/);
             expect(errorOutput).to.match(/Help: some help message/);
         });
+
+        it('logs original error message and stack trace if verbose is set', function () {
+            const originalError = new Error('something aweful happened here');
+            originalError.response = 'very long response';
+
+            const verboseError = new errors.CliError({
+                message: 'some error',
+                err: originalError
+            });
+
+            const errorOutput = stripAnsi(verboseError.toString(true));
+            expect(errorOutput).to.match(/Message: some error/);
+            expect(errorOutput).to.match(/Original Error Message:/);
+            expect(errorOutput).to.match(/Message: something aweful happened here/);
+            expect(errorOutput.indexOf(verboseError.stack)).to.not.equal(-1);
+        });
+
+        it('logs original error message and stack trace in verbose when error is a string', function () {
+            const verboseError = new errors.CliError({
+                message: 'some error',
+                err: 'something aweful happened here'
+            });
+
+            const errorOutput = stripAnsi(verboseError.toString(true));
+            expect(errorOutput).to.match(/Message: some error/);
+            expect(errorOutput).to.match(/Original Error Message:/);
+            expect(errorOutput).to.match(/Message: something aweful happened here/);
+            expect(errorOutput.indexOf(verboseError.stack)).to.not.equal(-1);
+        });
     });
 
     describe('ProcessError', function () {


### PR DESCRIPTION
refs #587

- fixes an issue, where failed requests with `got` wouldn't get catched properly
- differentiates between `ProcessError` for `stderr` and `CliError` for everything else
- `CliError` can be passed the original error and will log the `message` and `stack` to the log file, or log in the UI when in verbose mode
- Adds `err` property with original error whereever we have it so it'll be passed along and printed in the log file