### PR TITLE
feat(doctor) prevent root user from installing

### DIFF
--- a/lib/commands/doctor/checks/install.js
+++ b/lib/commands/doctor/checks/install.js
@@ -68,6 +68,19 @@ const tasks = {
             return tasks.checkDirectoryAndAbove(process.cwd(), 'run `ghost install`');
         });
     },
+    currentUser: function currentUser() {
+        // Check if user is trying to install as `root`
+        if (process.getuid() === 0) {
+            return Promise.reject(new errors.SystemError(
+                `Can't install as 'root' user.${eol}` +
+                `Please create a new user with regular account privileges to install Ghost.${eol}` +
+                `See ${chalk.underline.blue('https://docs.ghost.org/docs/install#section-create-a-new-user')} ` +
+                'for more information'
+            ));
+        } else {
+            return Promise.resolve();
+        }
+    },
     systemStack: function systemStack(ctx) {
         let promise;
 
@@ -145,6 +158,10 @@ module.exports = [{
 }, {
     title: 'Checking current folder permissions',
     task: tasks.folderPermissions
+}, {
+    title: 'Checking current user',
+    skip: (ctx) => ctx.local,
+    task: tasks.currentUser
 }, {
     title: 'Checking operating system',
     skip: (ctx) => ctx.local || (ctx.argv && !ctx.argv.stack),

--- a/test/unit/commands/doctor/install-spec.js
+++ b/test/unit/commands/doctor/install-spec.js
@@ -328,6 +328,45 @@ describe('Unit: Doctor Checks > Install', function () {
         });
     });
 
+    describe('currentUser check', function () {
+        let processStub;
+
+        beforeEach(function () {
+            processStub = sinon.stub(process, 'getuid');
+        });
+
+        afterEach(function () {
+            processStub.restore();
+        });
+
+        it('rejects if user is logged in as root', function () {
+            processStub.returns(0);
+
+            const currentUser = proxyquire(modulePath, {
+                process: {getuid: processStub}
+            }).tasks.currentUser;
+
+            return currentUser({}).then(() => {
+                expect(false, 'error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.an.instanceof(errors.SystemError);
+                expect(processStub.calledOnce).to.be.true;
+            });
+        });
+
+        it('does not reject if user not root', function () {
+            processStub.returns(501);
+
+            const currentUser = proxyquire(modulePath, {
+                process: {getuid: processStub}
+            }).tasks.currentUser;
+
+            return currentUser({}).then(() => {
+                expect(processStub.calledOnce).to.be.true;
+            });
+        });
+    });
+
     describe('system stack', function () {
         let logStub, confirmStub, execaStub;
 


### PR DESCRIPTION
refs #47

- adds a `currentUser` check, which detects if the user tries to install ghost as `root` and prevents if so
- the task will be skipped for a local install
- adds tests