### PR TITLE
feat(system) add os and version to System class

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -40,7 +40,7 @@ Paste log file here
 
 This is automatically output by Ghost-CLI if an error occurs, please copy & paste:
 
-* OS (add version):
+* OS:
 * Node Version:
 * Ghost-CLI Version:
 * Environment:

--- a/lib/commands/doctor/checks/system-stack.js
+++ b/lib/commands/doctor/checks/system-stack.js
@@ -12,6 +12,7 @@ function systemStack(ctx, task) {
     if (!ctx.system.platform.linux) {
         promise = Promise.reject({message: 'Operating system is not Linux'});
     } else {
+        // TODO: refactor to use ctx.system.operatingSystem
         promise = execa.shell('lsb_release -a').catch(
             () => Promise.reject({message: 'Linux version is not Ubuntu 16'})
         ).then((result) => {

--- a/lib/system.js
+++ b/lib/system.js
@@ -74,6 +74,24 @@ class System {
     }
 
     /**
+     * Returns the running operating system
+     *
+     * @property operatingSystem
+     * @type Object
+     * @public
+     */
+    get operatingSystem() {
+        if (!this._operatingSystem) {
+            const getOS = require('./utils/get-os');
+            this._operatingSystem = getOS(this.platform);
+
+            return this._operatingSystem;
+        }
+
+        return this._operatingSystem;
+    }
+
+    /**
      * Constructs the System class
      *
      * @param {UI} UI instance

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -400,7 +400,7 @@ class UI {
     /**
      * Helper method to format the debug information whenever an error occurs
      *
-     * @param {Syste} system System instance
+     * @param {System} system System instance
      * @return string Formated debug info
      *
      * @method _formatString
@@ -408,6 +408,7 @@ class UI {
      */
     _formatDebug(system) {
         return 'Debug Information:\n' +
+            `    OS: ${system.operatingSystem.os}, v${system.operatingSystem.version}\n` +
             `    Node Version: ${process.version}\n` +
             `    Ghost-CLI Version: ${system.cliVersion}\n` +
             `    Environment: ${system.environment}\n` +

--- a/lib/utils/get-os.js
+++ b/lib/utils/get-os.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const os = require('os');
+const execa = require('execa');
+
+module.exports = function getOS(platform) {
+    const osInfo = {
+        os: os.platform(),
+        version: os.release()
+    };
+
+    if (platform.linux) {
+        try {
+            osInfo.os = execa.shellSync('lsb_release -i -s').stdout;
+            osInfo.version = execa.shellSync('lsb_release -r -s').stdout;
+        } catch (e) {
+            return osInfo;
+        }
+    } else if (platform.macos) {
+        // Darwin is Mac OS, use `sw_vers`
+        try {
+            osInfo.os = execa.shellSync('sw_vers -productName').stdout;
+            osInfo.version = execa.shellSync('sw_vers -productVersion').stdout;
+        } catch (e) {
+            return osInfo;
+        }
+    } else if (platform.windows) {
+        // for windows run `ver`
+        // should output something like this: Microsoft Windows XP [Version 5.1.2600]
+        try {
+            const winOutput = execa.shellSync('ver').stdout.split(/\[/i);
+
+            osInfo.os = winOutput[0].trim();
+            osInfo.version = /[0-9]+\.[0-9]+\.[0-9]+/.exec(winOutput[1])[0];
+        } catch (e) {
+            return osInfo;
+        }
+    }
+
+    return osInfo;
+};

--- a/test/unit/system-spec.js
+++ b/test/unit/system-spec.js
@@ -2,7 +2,6 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
-
 const os = require('os');
 const modulePath = '../../lib/system';
 const Instance = require('../../lib/instance');
@@ -113,6 +112,42 @@ describe('Unit: System', function () {
                 macos: false,
                 windows: true
             });
+        });
+    });
+
+    describe('operatingSystem getter', function () {
+        const sandbox = sinon.sandbox.create();
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        it('caches and returns the correct OS', function () {
+            const getOsStub = sinon.stub().returns({
+                os: 'Ubuntu',
+                version: '16'
+            });
+            const System = proxyquire(modulePath, {
+                './utils/get-os': getOsStub
+            });
+
+            const instance = new System({}, []);
+            const platformStub = sandbox.stub(os, 'platform').returns('linux');
+            const operatingSystem = instance.operatingSystem;
+
+            expect(platformStub.calledOnce).to.be.true;
+            expect(getOsStub.calledOnce).to.be.true;
+            expect(operatingSystem).to.be.an('object');
+            expect(operatingSystem.os).to.equal('Ubuntu');
+            expect(operatingSystem.version).to.equal('16');
+
+            // do the second call to see that it gets cached
+            const newOperatingSystem = instance.operatingSystem;
+            expect(newOperatingSystem).to.be.an('object');
+            expect(newOperatingSystem.os).to.equal('Ubuntu');
+            expect(newOperatingSystem.version).to.equal('16');
+            expect(newOperatingSystem).to.deep.equal(operatingSystem);
+            expect(getOsStub.calledOnce).to.be.true;
         });
     });
 

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -678,12 +678,17 @@ describe('Unit: UI', function () {
     it('#_formatDebug returns a properly formatted value', function (done) {
         const system = {
             cliVersion: '0.9.1.8',
-            environment: 'Earth'
+            environment: 'Earth',
+            operatingSystem: {
+                os: 'Ubuntu',
+                version: '16'
+            }
         };
         const SPACES = '    ';
         const UI = require(modulePath);
         const ui = new UI();
         const expected = ['Debug Information:',
+            `${SPACES}OS: Ubuntu, v16`,
             `${SPACES}Node Version: ${process.version}`,
             `${SPACES}Ghost-CLI Version: 0.9.1.8`,
             `${SPACES}Environment: Earth`,

--- a/test/unit/utils/get-os-spec.js
+++ b/test/unit/utils/get-os-spec.js
@@ -1,0 +1,66 @@
+'use strict';
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const execa = require('execa');
+const os = require('os');
+const getOS = require('../../../lib/utils/get-os');
+
+describe('Unit: Utils > getOS', function () {
+    const sandbox = sinon.sandbox.create();
+    let platformStub, versionStub, execaStub;
+
+    beforeEach(function () {
+        versionStub = sandbox.stub(os, 'release');
+        execaStub = sandbox.stub(execa, 'shellSync');
+        platformStub = sandbox.stub(os, 'platform');
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('and returns correct Linux OS', function () {
+        platformStub.returns('linux');
+        execaStub.withArgs('lsb_release -i -s').returns({stdout: 'Ubuntu'});
+        execaStub.withArgs('lsb_release -r -s').returns({stdout: '16'});
+
+        const osResult = getOS({linux: true});
+        expect(osResult.os).to.equal('Ubuntu');
+        expect(osResult.version).to.equal('16');
+        expect(execaStub.calledTwice).to.be.true;
+    });
+
+    it('and returns correct mac OS', function () {
+        platformStub.returns('darwin');
+        execaStub.withArgs('sw_vers -productName').returns({stdout: 'Mac OS X'});
+        execaStub.withArgs('sw_vers -productVersion').returns({stdout: '10.13.3'});
+
+        const osResult = getOS({macos: true});
+        expect(osResult.os).to.equal('Mac OS X');
+        expect(osResult.version).to.equal('10.13.3');
+        expect(execaStub.calledTwice).to.be.true;
+    });
+
+    it('and returns correct Windows OS', function () {
+        platformStub.returns('win32');
+        execaStub.withArgs('ver').returns({stdout: 'Microsoft Windows XP [Version 5.1.2600]'});
+
+        const osResult = getOS({windows: true});
+        expect(osResult.os).to.equal('Microsoft Windows XP');
+        expect(osResult.version).to.equal('5.1.2600');
+        expect(execaStub.calledOnce).to.be.true;
+    });
+
+    it('and returns default os.platform if OS is not Mac, Linux, or Windows', function () {
+        platformStub.returns('freebsd');
+        versionStub.returns('1.0.0')
+        const osResult = getOS({
+            linux: false,
+            macos: false,
+            windows: false
+        });
+        expect(osResult.os).to.equal('freebsd');
+        expect(osResult.version).to.equal('1.0.0');
+        expect(execaStub.calledOnce).to.be.false;
+    });
+});


### PR DESCRIPTION
no issue

- added a new getter to the System class, that returns the operating system as well as the version
- works for linux, mac, and windows. Everything else falls back to the native `os.platform()` fn.
- prints the os and the version in the debug information
- added tests