### PR TITLE
fix(instance): query process managers in dev & prod if running not set

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -111,6 +111,30 @@ class Instance {
         }
 
         if (!this.cliConfig.has('running')) {
+            const currentEnvironment = this.system.development;
+
+            // Check production environment first
+            if (Config.exists(path.join(this.dir, 'config.production.json'))) {
+                this.system.setEnvironment(false);
+
+                if (this.process.isRunning(this.dir)) {
+                    this.cliConfig.set('running', 'production').save();
+                    return true;
+                }
+            }
+
+            // Check development next
+            if (Config.exists(path.join(this.dir, 'config.development.json'))) {
+                this.system.setEnvironment(true);
+
+                if (this.process.isRunning(this.dir)) {
+                    this.cliConfig.set('running', 'development').save();
+                    return true;
+                }
+            }
+
+            this.system.setEnvironment(currentEnvironment);
+
             return false;
         }
 


### PR DESCRIPTION
closes #463
- query each process manager if running is not set in cli config