### PR TITLE
fix(windows): don't check for root user on windows

### DIFF
--- a/lib/utils/check-root-user.js
+++ b/lib/utils/check-root-user.js
@@ -1,8 +1,14 @@
 'use strict';
 
+const os = require('os');
 const chalk = require('chalk');
 
 function checkRootUser() {
+    // Skip if we're on windows
+    if (os.platform() !== 'linux') {
+        return;
+    }
+
     if (process.getuid() === 0) {
         console.error(`${chalk.yellow('Can\'t run command as \'root\' user.')}
 Please create a new user with regular account privileges and use this user to run the command.

--- a/test/unit/utils/check-root-user-spec.js
+++ b/test/unit/utils/check-root-user-spec.js
@@ -2,6 +2,7 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
+const os = require('os');
 const checkRootUser = require('../../../lib/utils/check-root-user');
 
 describe('checkRootUser', function () {
@@ -9,9 +10,28 @@ describe('checkRootUser', function () {
 
     afterEach(() => {
         sandbox.restore();
-    })
+    });
+
+    it('skips check if run on windows', function () {
+        const osStub = sandbox.stub(os, 'platform').returns('win32');
+        const processStub = sandbox.stub(process, 'getuid').returns(0);
+
+        checkRootUser('test');
+        expect(osStub.calledOnce).to.be.true;
+        expect(processStub.called).to.be.false;
+    });
+
+    it('skips check if run on macos', function () {
+        const osStub = sandbox.stub(os, 'platform').returns('darwin');
+        const processStub = sandbox.stub(process, 'getuid').returns(0);
+
+        checkRootUser('test');
+        expect(osStub.calledOnce).to.be.true;
+        expect(processStub.called).to.be.false;
+    });
 
     it('throws error command run with root', function () {
+        const osStub = sandbox.stub(os, 'platform').returns('linux');
         const processStub = sandbox.stub(process, 'getuid').returns(0);
         const exitStub = sandbox.stub(process, 'exit').throws();
         const errorStub = sandbox.stub(console, 'error');
@@ -21,6 +41,7 @@ describe('checkRootUser', function () {
             throw new Error('should not be thrown');
         } catch (e) {
             expect(e.message).to.not.equal('should not be thrown');
+            expect(osStub.calledOnce).to.be.true;
             expect(processStub.calledOnce).to.be.true;
             expect(errorStub.calledOnce).to.be.true;
             expect(exitStub.calledOnce).to.be.true;
@@ -29,11 +50,13 @@ describe('checkRootUser', function () {
     });
 
     it('doesn\'t do anything if command run as non root user', function () {
+        const osStub = sandbox.stub(os, 'platform').returns('linux');
         const processStub = sandbox.stub(process, 'getuid').returns(501);
         const exitStub = sandbox.stub(process, 'exit').throws();
         const errorStub = sandbox.stub(console, 'error');
 
         checkRootUser('test');
+        expect(osStub.calledOnce).to.be.true;
         expect(processStub.calledOnce).to.be.true;
         expect(errorStub.calledOnce).to.be.false;
         expect(exitStub.calledOnce).to.be.false;


### PR DESCRIPTION
- windows doesn't have a getuid function, so we don't want to check it if we're on windows