### PR TITLE
fix(doctor) skip validate config check for running instances

### DIFF
--- a/lib/commands/doctor/checks/validate-config.js
+++ b/lib/commands/doctor/checks/validate-config.js
@@ -49,5 +49,6 @@ function validateConfig(ctx) {
 module.exports = {
     title: taskTitle,
     task: validateConfig,
+    skip: (ctx) => ctx.instance && ctx.instance.process.isRunning(ctx.instance.dir),
     category: ['start']
 }

--- a/test/unit/commands/doctor/checks/validate-config-spec.js
+++ b/test/unit/commands/doctor/checks/validate-config-spec.js
@@ -21,6 +21,11 @@ describe('Unit: Doctor Checks > validateConfig', function () {
         }
     });
 
+    it('skips check, when instance is currently running', function () {
+        const isRunningStub = sinon.stub().returns(true);
+        expect(validateConfig.skip({instance: {process: {isRunning: isRunningStub}}}), 'true if current instance is running').to.be.true;
+    });
+
     it('rejects if environment is passed and no config exists for that environment', function () {
         env = setupEnv();
         const cwdStub = sandbox.stub(process, 'cwd').returns(env.dir);

--- a/test/unit/utils/resolve-version-spec.js
+++ b/test/unit/utils/resolve-version-spec.js
@@ -46,7 +46,6 @@ describe('Unit: resolveVersion', function () {
         });
     });
 
-
     it('rejects if no versions are found', function () {
         stubYarn('{"data": []}');
 


### PR DESCRIPTION
no issue

- skips the validate config check when the tested instance is currently running, as it would fail for testing the server port