### PR TITLE
feat(doctor) show help message for install folder checks

### DIFF
--- a/lib/commands/doctor/checks/install-folder-permissions.js
+++ b/lib/commands/doctor/checks/install-folder-permissions.js
@@ -1,6 +1,7 @@
 'use strict';
 const fs = require('fs-extra');
 const constants = require('constants');
+const chalk = require('chalk');
 
 const errors = require('../../../errors');
 const checkDirectoryAndAbove = require('./check-directory');
@@ -10,8 +11,8 @@ const taskTitle = 'Checking current folder permissions';
 function installFolderPermissions(ctx) {
     return fs.access(process.cwd(), constants.R_OK | constants.W_OK).catch(() => {
         return Promise.reject(new errors.SystemError({
-            message: `The current directory is not writable.
-Please fix your directory permissions.`,
+            message: 'The current directory is not writable. Please fix the permissions of your install directory.',
+            help: `${chalk.green('https://docs.ghost.org/docs/install#section-your-user-must-own-this-directory')}`,
             task: taskTitle
         }));
     }).then(() => {


### PR DESCRIPTION
no issue

- show clearer error message and help link to the docs, when install directory doesn't have the right permissions