### PR TITLE
fix(update-check): don't warn for prerelease or build

### DIFF
--- a/lib/utils/update-check.js
+++ b/lib/utils/update-check.js
@@ -1,7 +1,23 @@
 'use strict';
 const Promise = require('bluebird');
+const includes = require('lodash/includes');
 const updateNotifier = require('update-notifier');
 const pkg = require('../../package.json');
+
+/*
+ * Update notifier sends several different types of updates,
+ * we want to make sure the only ones that trigger a warning are
+ * major, minor, and patch releases. This allows us to push prereleases
+ * & such in the future without those triggering a warning for users
+ *
+ * see https://github.com/yeoman/update-notifier#comprehensive for the different types
+ * of updates
+ */
+const typesToWarn = [
+    'major',
+    'minor',
+    'patch'
+];
 
 /**
  * Checks if a version update is available
@@ -9,7 +25,7 @@ const pkg = require('../../package.json');
  */
 module.exports = function updateCheck(ui) {
     return Promise.fromCallback(cb => updateNotifier({pkg: pkg, callback: cb})).then((update) => {
-        if (update.type !== 'latest') {
+        if (includes(typesToWarn, update.type)) {
             const chalk = require('chalk');
 
             ui.log(

--- a/test/unit/utils/update-check-spec.js
+++ b/test/unit/utils/update-check-spec.js
@@ -48,6 +48,26 @@ describe('Unit: Utils > update-check', function () {
         });
     });
 
+    it('doesn\'t log a message if the type of update is not major, minor, or patch', function () {
+        const pkg = {name: 'ghost', version: '1.0.0'};
+        const updateNotifer = sinon.stub().callsFake((options) => {
+            expect(options).to.exist;
+            expect(options.pkg).to.deep.equal(pkg);
+            expect(options.callback).to.be.a('function');
+            options.callback(null, {type: 'prerelease'});
+        });
+        const logStub = sinon.stub();
+
+        const updateCheck = proxyquire(modulePath, {
+            '../../package.json': pkg,
+            'update-notifier': updateNotifer
+        });
+
+        return updateCheck({log: logStub}).then(() => {
+            expect(logStub.called).to.be.false;
+        });
+    });
+
     it('logs a message if an update is available', function () {
         const pkg = {name: 'ghost', version: '1.0.0'};
         const updateNotifer = sinon.stub().callsFake((options) => {


### PR DESCRIPTION
no issue
- if we want to be able to push prereleases in the future, this is a necessary addition to the update check