### PR TITLE
chore(tests): use args[n][m] instead of getCall(n).args[m]

### DIFF
--- a/extensions/nginx/test/acme-spec.js
+++ b/extensions/nginx/test/acme-spec.js
@@ -64,9 +64,9 @@ describe('Unit: Extensions > Nginx > Acme', function () {
                 expect(emptyStub.calledOnce).to.be.true;
                 expect(gotStub.calledOnce).to.be.true;
                 expect(downloadStub.calledOnce).to.be.true;
-                expect(downloadStub.getCall(0).args[0]).to.equal(dwUrl);
-                expect(sudoStub.getCall(0).args[0]).to.match(/mkdir -p/);
-                expect(sudoStub.getCall(1).args[0]).to.match(/acme\.sh --install/);
+                expect(downloadStub.args[0][0]).to.equal(dwUrl);
+                expect(sudoStub.args[0][0]).to.match(/mkdir -p/);
+                expect(sudoStub.args[1][0]).to.match(/acme\.sh --install/);
             });
         });
 
@@ -175,12 +175,12 @@ describe('Unit: Extensions > Nginx > Acme', function () {
 
             return acme.generate({sudo: sudoStub}, 'domain', 'root', 'test@example.com').then(() => {
                 expect(sudoStub.calledOnce).to.be.true;
-                expect(sudoStub.getCall(0).args[0]).to.match(expectedSudo);
+                expect(sudoStub.args[0][0]).to.match(expectedSudo);
 
                 return acme.generate({sudo: sudoStub}, 'domain', 'root', 'test@example.com', true);
             }).then(() => {
                 expect(sudoStub.calledTwice).to.be.true;
-                expect(sudoStub.getCall(1).args[0]).to.match(/--issue .{0,} --staging/);
+                expect(sudoStub.args[1][0]).to.match(/--issue .{0,} --staging/);
             });
         });
 
@@ -232,7 +232,7 @@ describe('Unit: Extensions > Nginx > Acme', function () {
 
             return acme.remove('ghost.org', {sudo: sudoStub}).then(() => {
                 expect(sudoStub.calledOnce).to.be.true;
-                expect(sudoStub.getCall(0).args[0]).to.equal(
+                expect(sudoStub.args[0][0]).to.equal(
                     '/etc/letsencrypt/acme.sh --remove --home /etc/letsencrypt --domain ghost.org'
                 )
             });
@@ -248,7 +248,7 @@ describe('Unit: Extensions > Nginx > Acme', function () {
 
             return acme.remove('ghost.org', {sudo: sudoStub}, '/home/ghost/.acme.sh').then(() => {
                 expect(sudoStub.calledOnce).to.be.true;
-                expect(sudoStub.getCall(0).args[0]).to.equal(
+                expect(sudoStub.args[0][0]).to.equal(
                     '/home/ghost/.acme.sh/acme.sh --remove --home /home/ghost/.acme.sh --domain ghost.org'
                 )
             });

--- a/extensions/nginx/test/extension-spec.js
+++ b/extensions/nginx/test/extension-spec.js
@@ -108,9 +108,9 @@ describe('Unit: Extensions > Nginx', function () {
             ext.setup(cmd, {});
 
             expect(asStub.calledTwice).to.be.true;
-            expect(asStub.getCall(0).args[0]).to.equal('nginx');
-            expect(asStub.getCall(1).args[0]).to.equal('ssl');
-            expect(asStub.getCall(1).args[2]).to.equal('nginx');
+            expect(asStub.args[0][0]).to.equal('nginx');
+            expect(asStub.args[1][0]).to.equal('ssl');
+            expect(asStub.args[1][2]).to.equal('nginx');
         });
     });
 
@@ -139,7 +139,7 @@ describe('Unit: Extensions > Nginx', function () {
 
             expect(ext.isSupported.calledOnce).to.be.true;
             expect(ext.ui.log.calledOnce).to.be.true;
-            expect(ext.ui.log.getCall(0).args[0]).to.match(/not installed/);
+            expect(ext.ui.log.args[0][0]).to.match(/not installed/);
             expect(task.skip.calledOnce).to.be.true;
         });
 
@@ -151,7 +151,7 @@ describe('Unit: Extensions > Nginx', function () {
 
             expect(get.calledOnce).to.be.true;
             expect(log.calledOnce).to.be.true;
-            expect(log.getCall(0).args[0]).to.match(/contains a port/);
+            expect(log.args[0][0]).to.match(/contains a port/);
             expect(task.skip.calledOnce).to.be.true;
         });
 
@@ -165,9 +165,9 @@ describe('Unit: Extensions > Nginx', function () {
             const log = ext.ui.log;
 
             expect(existsStub.calledOnce).to.be.true;
-            expect(existsStub.getCall(0).args[0]).to.equal(expectedFile);
+            expect(existsStub.args[0][0]).to.equal(expectedFile);
             expect(log.calledOnce).to.be.true;
-            expect(log.getCall(0).args[0]).to.match(/configuration already found/);
+            expect(log.args[0][0]).to.match(/configuration already found/);
             expect(task.skip.calledOnce).to.be.true;
         });
 
@@ -197,9 +197,9 @@ describe('Unit: Extensions > Nginx', function () {
             return ext.setupNginx(null, ctx, task).then(() => {
                 expect(templateStub.calledOnce).to.be.true;
                 expect(loadStub.calledOnce).to.be.true;
-                expect(loadStub.getCall(0).args[0]).to.deep.equal(expectedConfig);
+                expect(loadStub.args[0][0]).to.deep.equal(expectedConfig);
                 expect(sudo.calledOnce).to.be.true;
-                expect(sudo.getCall(0).args[0]).to.match(lnExp);
+                expect(sudo.args[0][0]).to.match(lnExp);
                 expect(ext.restartNginx.calledOnce).to.be.true;
 
                 // Testing handling of subdirectory installations
@@ -216,7 +216,7 @@ describe('Unit: Extensions > Nginx', function () {
 
                 return ext.setupNginx(null, ctx, task).then(() => {
                     expect(loadStub.calledOnce).to.be.true;
-                    expect(loadStub.getCall(0).args[0]).to.deep.equal(expectedConfig);
+                    expect(loadStub.args[0][0]).to.deep.equal(expectedConfig);
                 });
             });
         });
@@ -244,7 +244,7 @@ describe('Unit: Extensions > Nginx', function () {
 
             expect(stubs.es.calledOnce).to.be.false;
             expect(ext.ui.log.calledOnce).to.be.true;
-            expect(ext.ui.log.getCall(0).args[0]).to.match(/SSL certs cannot be generated for IP addresses/);
+            expect(ext.ui.log.args[0][0]).to.match(/SSL certs cannot be generated for IP addresses/);
             expect(stubs.skip.calledOnce).to.be.true;
         });
 
@@ -256,9 +256,9 @@ describe('Unit: Extensions > Nginx', function () {
             const log = ext.ui.log;
 
             expect(existsStub.calledOnce).to.be.true;
-            expect(existsStub.getCall(0).args[0]).to.equal(sslFile);
+            expect(existsStub.args[0][0]).to.equal(sslFile);
             expect(log.calledOnce).to.be.true;
-            expect(log.getCall(0).args[0]).to.match(/SSL has /);
+            expect(log.args[0][0]).to.match(/SSL has /);
             expect(stubs.skip.calledOnce).to.be.true;
         });
 
@@ -267,7 +267,7 @@ describe('Unit: Extensions > Nginx', function () {
 
             expect(stubs.es.calledOnce).to.be.true;
             expect(ext.ui.log.calledOnce).to.be.true;
-            expect(ext.ui.log.getCall(0).args[0]).to.match(/SSL email must be provided/);
+            expect(ext.ui.log.args[0][0]).to.match(/SSL email must be provided/);
             expect(stubs.skip.calledOnce).to.be.true;
         });
 
@@ -287,7 +287,7 @@ describe('Unit: Extensions > Nginx', function () {
 
             expect(stubs.es.calledTwice, '1').to.be.true;
             expect(ext.ui.log.calledOnce, '2').to.be.true;
-            expect(ext.ui.log.getCall(0).args[0]).to.match(/Nginx config file/);
+            expect(ext.ui.log.args[0][0]).to.match(/Nginx config file/);
             expect(stubs.skip.calledOnce, '4').to.be.true;
         });
     });
@@ -307,7 +307,7 @@ describe('Unit: Extensions > Nginx', function () {
             expect(task.skip.called, 'getTasks: task.skip').to.be.false;
             expect(ext.ui.log.called, 'getTasks: ui.log').to.be.false;
             expect(ext.ui.listr.calledOnce, 'getTasks: ui.listr').to.be.true;
-            return ext.ui.listr.getCall(0).args[0];
+            return ext.ui.listr.args[0][0];
         }
 
         beforeEach(function () {
@@ -349,7 +349,7 @@ describe('Unit: Extensions > Nginx', function () {
 
                 return tasks[0].task(ctx).then(() => {
                     expect(log.called).to.be.true;
-                    expect(log.getCall(0).args[0]).to.match(/domain isn't set up correctly/);
+                    expect(log.args[0][0]).to.match(/domain isn't set up correctly/);
                     expect(ctx.dnsfail).to.be.true;
 
                     DNS.code = 'PEACHESARETASTY';
@@ -466,7 +466,7 @@ describe('Unit: Extensions > Nginx', function () {
 
                 return tasks[4].task().then(() => {
                     expect(ext.ui.sudo.calledOnce).to.be.true;
-                    expect(ext.ui.sudo.getCall(0).args[0]).to.match(/openssl dhparam/);
+                    expect(ext.ui.sudo.args[0][0]).to.match(/openssl dhparam/);
                 });
             });
 
@@ -496,7 +496,7 @@ describe('Unit: Extensions > Nginx', function () {
 
                 return tasks[5].task().then(() => {
                     expect(ext.ui.sudo.calledOnce).to.be.true;
-                    expect(ext.ui.sudo.getCall(0).args[0]).to.match(expectedSudo);
+                    expect(ext.ui.sudo.args[0][0]).to.match(expectedSudo);
                 });
             });
 
@@ -539,9 +539,9 @@ describe('Unit: Extensions > Nginx', function () {
                 return tasks[6].task(ctx).then(() => {
                     expect(stubs.template.calledTwice).to.be.true;
                     expect(stubs.templatify.calledOnce).to.be.true;
-                    expect(stubs.templatify.getCall(0).args[0]).to.deep.equal(expectedTemplate);
+                    expect(stubs.templatify.args[0][0]).to.deep.equal(expectedTemplate);
                     expect(ext.ui.sudo.calledOnce).to.be.true;
-                    expect(ext.ui.sudo.getCall(0).args[0]).to.match(expectedSudo);
+                    expect(ext.ui.sudo.args[0][0]).to.match(expectedSudo);
                 });
             });
 
@@ -554,7 +554,7 @@ describe('Unit: Extensions > Nginx', function () {
                 return tasks[6].task(ctx).then(() => {
                     expect(stubs.template.calledTwice).to.be.true;
                     expect(stubs.templatify.calledOnce).to.be.true;
-                    expect(stubs.templatify.getCall(0).args[0]).to.deep.equal(expectedTemplate);
+                    expect(stubs.templatify.args[0][0]).to.deep.equal(expectedTemplate);
                 });
             });
         });
@@ -590,8 +590,8 @@ describe('Unit: Extensions > Nginx', function () {
 
             return ext.uninstall(instance).then(() => {
                 expect(ext.ui.sudo.calledTwice).to.be.true;
-                expect(ext.ui.sudo.getCall(0).args[0]).to.match(sudoExp);
-                expect(ext.ui.sudo.getCall(1).args[0]).to.match(sudoExp);
+                expect(ext.ui.sudo.args[0][0]).to.match(sudoExp);
+                expect(ext.ui.sudo.args[1][0]).to.match(sudoExp);
                 expect(ext.restartNginx.calledOnce).to.be.true;
             });
         });
@@ -603,8 +603,8 @@ describe('Unit: Extensions > Nginx', function () {
 
             return ext.uninstall(instance).then(() => {
                 expect(ext.ui.sudo.calledTwice).to.be.true;
-                expect(ext.ui.sudo.getCall(0).args[0]).to.match(sudoExp);
-                expect(ext.ui.sudo.getCall(1).args[0]).to.match(sudoExp);
+                expect(ext.ui.sudo.args[0][0]).to.match(sudoExp);
+                expect(ext.ui.sudo.args[1][0]).to.match(sudoExp);
                 expect(ext.restartNginx.calledOnce).to.be.true;
             });
         });
@@ -641,7 +641,7 @@ describe('Unit: Extensions > Nginx', function () {
             ext.restartNginx();
 
             expect(sudo.calledOnce).to.be.true;
-            expect(sudo.getCall(0).args[0]).to.match(/nginx -s reload/);
+            expect(sudo.args[0][0]).to.match(/nginx -s reload/);
         });
 
         it('Throws an Error when nginx does', function () {
@@ -652,7 +652,7 @@ describe('Unit: Extensions > Nginx', function () {
                 expect(false, 'An error should have been thrown').to.be.true;
             }).catch(function (err) {
                 expect(sudo.calledOnce).to.be.true;
-                expect(sudo.getCall(0).args[0]).to.match(/nginx -s reload/);
+                expect(sudo.args[0][0]).to.match(/nginx -s reload/);
                 expect(err).to.be.ok;
                 const expectedError = require('../../../lib/errors');
                 expect(err).to.be.instanceof(expectedError.ProcessError);
@@ -669,7 +669,7 @@ describe('Unit: Extensions > Nginx', function () {
             ext.isSupported();
 
             expect(shellStub.calledOnce).to.be.true;
-            expect(shellStub.getCall(0).args[0]).to.match(/dpkg -l \| grep nginx/);
+            expect(shellStub.args[0][0]).to.match(/dpkg -l \| grep nginx/);
         });
 
         it('Returns false when dpkg fails', function () {

--- a/extensions/nginx/test/migrations-spec.js
+++ b/extensions/nginx/test/migrations-spec.js
@@ -142,7 +142,7 @@ describe('Unit: Extensions > Nginx > Migrations', function () {
             expect(readFileSync.calledTwice).to.be.true;
             expect(ui.listr.calledOnce).to.be.true;
 
-            const tasks = ui.listr.getCall(0).args[0];
+            const tasks = ui.listr.args[0][0];
             expect(tasks).to.have.length(5);
 
             return tasks[0].task(null).then(() => {

--- a/extensions/systemd/test/systemd-spec.js
+++ b/extensions/systemd/test/systemd-spec.js
@@ -47,7 +47,7 @@ describe('Unit: Systemd > Process Manager', function () {
             ext.start().then(() => {
                 const expectedCmd = 'systemctl start ghost_ghost_org';
                 expect(ui.sudo.calledOnce).to.be.true;
-                expect(ui.sudo.getCall(0).args[0]).to.equal(expectedCmd);
+                expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
             });
         });
 
@@ -95,7 +95,7 @@ describe('Unit: Systemd > Process Manager', function () {
             ext.stop().then(() => {
                 const expectedCmd = 'systemctl stop ghost_ghost_org';
                 expect(ui.sudo.calledOnce).to.be.true;
-                expect(ui.sudo.getCall(0).args[0]).to.equal(expectedCmd);
+                expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
             });
         });
 
@@ -132,7 +132,7 @@ describe('Unit: Systemd > Process Manager', function () {
             ext.restart().then(() => {
                 const expectedCmd = 'systemctl restart ghost_ghost_org';
                 expect(ui.sudo.calledOnce).to.be.true;
-                expect(ui.sudo.getCall(0).args[0]).to.equal(expectedCmd);
+                expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
             });
         });
 
@@ -172,7 +172,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
             expect(ext.isEnabled()).to.be.true;
             expect(execaStub.calledOnce).to.be.true;
-            expect(execaStub.getCall(0).args[0]).to.equal(expectedCmd);
+            expect(execaStub.args[0][0]).to.equal(expectedCmd);
         });
 
         it('Passes bad errors through', function () {
@@ -209,7 +209,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const ext = makeSystemd(null, ui);
             ext.enable().then(() => {
                 expect(ui.sudo.calledOnce).to.be.true;
-                expect(ui.sudo.getCall(0).args[0]).to.equal(expectedCmd);
+                expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
             })
         });
 
@@ -233,7 +233,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const ext = makeSystemd(null, ui);
             ext.disable().then(() => {
                 expect(ui.sudo.calledOnce).to.be.true;
-                expect(ui.sudo.getCall(0).args[0]).to.equal(expectedCmd);
+                expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
             })
         });
 
@@ -263,7 +263,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
             expect(ext.isRunning()).to.be.true;
             expect(execaStub.calledOnce).to.be.true;
-            expect(execaStub.getCall(0).args[0]).to.equal(expectedCmd);
+            expect(execaStub.args[0][0]).to.equal(expectedCmd);
         });
 
         it('Passes bad errors through', function () {
@@ -323,7 +323,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
             ext._precheck();
             expect(fsStub.calledOnce).to.be.true;
-            expect(fsStub.getCall(0).args[0]).to.equal(expectedFile);
+            expect(fsStub.args[0][0]).to.equal(expectedFile);
         });
 
         it('Errors if unit file doesn\'t exist', function () {
@@ -358,7 +358,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
             expect(Systemd.willRun()).to.be.true;
             expect(execaStub.calledOnce).to.be.true;
-            expect(execaStub.getCall(0).args[0]).to.equal(expectedCmd);
+            expect(execaStub.args[0][0]).to.equal(expectedCmd);
         });
 
         it('Always fails', function () {

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -260,12 +260,12 @@ describe('Unit: Command > Config', function () {
 
             config.getConfigPrompts.call(ctx, argv);
             expect(getStub.calledOnce).to.be.true;
-            expect(getStub.getCall(0).args[1]).to.match(/_prod/);
+            expect(getStub.args[0][1]).to.match(/_prod/);
 
             ctx.system.development = true;
             config.getConfigPrompts.call(ctx, argv);
             expect(getStub.calledTwice).to.be.true;
-            expect(getStub.getCall(1).args[1]).to.match(/_dev/);
+            expect(getStub.args[1][1]).to.match(/_dev/);
         });
     });
 

--- a/test/unit/commands/log-spec.js
+++ b/test/unit/commands/log-spec.js
@@ -59,7 +59,7 @@ describe('Unit: Commands > Log', function () {
             } catch (error) {
                 expect(error).to.be.ok;
                 expect(stubs.cvi.calledOnce).to.be.true;
-                expect(stubs.cvi.getCall(0).args[0]).to.equal('log');
+                expect(stubs.cvi.args[0][0]).to.equal('log');
             }
         });
 
@@ -74,7 +74,7 @@ describe('Unit: Commands > Log', function () {
                 expect(error).to.be.ok;
                 expect(error).to.be.instanceOf(Errors.SystemError);
                 expect(stubs.gi.calledOnce).to.be.true;
-                expect(stubs.gi.getCall(0).args[0]).to.equal('ghost_org');
+                expect(stubs.gi.args[0][0]).to.equal('ghost_org');
             });
         });
 
@@ -156,7 +156,7 @@ describe('Unit: Commands > Log', function () {
                 expect(error.message).to.equal('SHORT_CIRCUIT');
 
                 expect(stubs.es.calledOnce).to.be.true;
-                expect(stubs.es.getCall(0).args[0]).to.equal(expectedFilePath);
+                expect(stubs.es.args[0][0]).to.equal(expectedFilePath);
             }
         });
 
@@ -180,7 +180,7 @@ describe('Unit: Commands > Log', function () {
             return ext.run({name: 'ghost_org', follow: true}).then(() => {
                 expect(stubs.es.calledOnce).to.be.true;
                 expect(stubs.log.calledOnce).to.be.true;
-                expect(stubs.log.getCall(0).args[0]).to.match(/not been created yet/);
+                expect(stubs.log.args[0][0]).to.match(/not been created yet/);
             });
         });
 
@@ -251,9 +251,9 @@ describe('Unit: Commands > Log', function () {
             return ext.run({name: 'ghost_org'}).then(() => {
                 expect(stubs.ll.calledOnce).to.be.true;
                 expect(stubs.write.calledThrice).to.be.true;
-                expect(stubs.write.getCall(0).args[0]).to.equal('a  cat');
-                expect(stubs.write.getCall(1).args[0]).to.equal(' in the hat ate');
-                expect(stubs.write.getCall(2).args[0]).to.equal(' bananas');
+                expect(stubs.write.args[0][0]).to.equal('a  cat');
+                expect(stubs.write.args[1][0]).to.equal(' in the hat ate');
+                expect(stubs.write.args[2][0]).to.equal(' bananas');
             });
         });
 
@@ -281,10 +281,10 @@ describe('Unit: Commands > Log', function () {
             ext.ui = {stdout: true};
             return ext.run({name: 'ghost_org', follow: true}).then(() => {
                 expect(stubs.write.calledThrice).to.be.true;
-                expect(stubs.write.getCall(1).args[0]).to.equal('cherry');
-                expect(stubs.write.getCall(1).args[1]).to.equal('utf8');
-                expect(stubs.write.getCall(2).args[0]).to.equal('Mango');
-                expect(stubs.write.getCall(2).args[1]).to.equal('utf8');
+                expect(stubs.write.args[1][0]).to.equal('cherry');
+                expect(stubs.write.args[1][1]).to.equal('utf8');
+                expect(stubs.write.args[2][0]).to.equal('Mango');
+                expect(stubs.write.args[2][1]).to.equal('utf8');
             });
         });
     });

--- a/test/unit/commands/setup-spec.js
+++ b/test/unit/commands/setup-spec.js
@@ -184,7 +184,7 @@ describe('Unit: Commands > Setup', function () {
 
                 return setup.run({stages: ['linux-user']}).then(() => {
                     expect(ui.log.calledOnce).to.be.true;
-                    expect(ui.log.getCall(0).args[0]).to.match(/is not Linux/);
+                    expect(ui.log.args[0][0]).to.match(/is not Linux/);
                 });
             });
 
@@ -206,7 +206,7 @@ describe('Unit: Commands > Setup', function () {
 
                 return setup.run({stages: ['linux-user']}).then(() => {
                     expect(ui.log.calledOnce).to.be.true;
-                    expect(ui.log.getCall(0).args[0]).to.match(/is not Linux/);
+                    expect(ui.log.args[0][0]).to.match(/is not Linux/);
                 });
             });
         });
@@ -239,7 +239,7 @@ describe('Unit: Commands > Setup', function () {
             const setup = new SetupCommand(ui, system);
             return setup.run(argv).then(() => {
                 expect(listr.calledOnce).to.be.true;
-                const tasks = listr.getCall(0).args[0];
+                const tasks = listr.args[0][0];
                 expect(tasks[0].title).to.equal('Setting up instance');
                 tasks.forEach(function (task) {
                     expect(task.title).to.not.match(/database migrations/);
@@ -252,7 +252,7 @@ describe('Unit: Commands > Setup', function () {
                 expect(ctx.instance.apples).to.be.true;
                 expect(ctx.instance.name).to.equal('ghost-org');
                 expect(aIstub.calledOnce).to.be.true;
-                expect(aIstub.getCall(0).args[0]).to.deep.equal(ctx.instance);
+                expect(aIstub.args[0][0]).to.deep.equal(ctx.instance);
             });
         });
 
@@ -285,7 +285,7 @@ describe('Unit: Commands > Setup', function () {
             const setup = new SetupCommand(ui, system);
             return setup.run(argv).then(() => {
                 expect(listr.calledOnce).to.be.true;
-                const tasks = listr.getCall(0).args[0];
+                const tasks = listr.args[0][0];
                 expect(tasks[0].title).to.equal('Setting up instance');
                 tasks.forEach(function (task) {
                     expect(task.title).to.not.match(/database migrations/);
@@ -298,7 +298,7 @@ describe('Unit: Commands > Setup', function () {
                 expect(ctx.instance.apples).to.be.true;
                 expect(ctx.instance.name).to.equal('example-com');
                 expect(aIstub.calledOnce).to.be.true;
-                expect(aIstub.getCall(0).args[0]).to.deep.equal(ctx.instance);
+                expect(aIstub.args[0][0]).to.deep.equal(ctx.instance);
             });
         });
 
@@ -335,7 +335,7 @@ describe('Unit: Commands > Setup', function () {
                 return setup.run({prompt: false}).then(() => {
                     expect(stubs.listr.calledOnce).to.be.true;
 
-                    const tasks = stubs.listr.getCall(0).args[0];
+                    const tasks = stubs.listr.args[0][0];
 
                     expect(tasks[2].title).to.match(/Test/);
                     expect(tasks[3].title).to.match(/Zesty/);
@@ -356,7 +356,7 @@ describe('Unit: Commands > Setup', function () {
 
                 return setup.run({prompt: false}).then(() => {
                     expect(stubs.listr.calledOnce).to.be.true;
-                    const tasks = stubs.listr.getCall(0).args[0];
+                    const tasks = stubs.listr.args[0][0];
 
                     expect(tasks[2].title).to.match(/Zesty/);
                     tasks[2].task({}, {skip: stubs.skip});
@@ -364,7 +364,7 @@ describe('Unit: Commands > Setup', function () {
                     expect(stubs.zest.calledOnce).to.be.false;
                     expect(stubs.skip.calledOnce).to.be.true;
                     expect(stubs.log.calledOnce).to.be.true;
-                    expect(stubs.log.getCall(0).args[0]).to.match(expectLog);
+                    expect(stubs.log.args[0][0]).to.match(expectLog);
                 });
             });
 
@@ -379,7 +379,7 @@ describe('Unit: Commands > Setup', function () {
 
                 return setup.run({prompt: false}).then(() => {
                     expect(stubs.listr.calledOnce).to.be.true;
-                    const tasks = stubs.listr.getCall(0).args[0];
+                    const tasks = stubs.listr.args[0][0];
 
                     expect(tasks[2].title).to.match(/Test/);
                     expect(tasks[3].title).to.match(/Zesty/);
@@ -392,7 +392,7 @@ describe('Unit: Commands > Setup', function () {
                     expect(stubs.zest.calledOnce).to.be.false;
                     expect(stubs.skip.calledOnce).to.be.true;
                     expect(stubs.log.calledOnce).to.be.true;
-                    expect(stubs.log.getCall(0).args[0]).to.match(expectLog);
+                    expect(stubs.log.args[0][0]).to.match(expectLog);
                 });
             });
 
@@ -404,7 +404,7 @@ describe('Unit: Commands > Setup', function () {
 
                 return setup.run({prompt: false}).then(() => {
                     expect(stubs.listr.calledOnce).to.be.true;
-                    const tasks = stubs.listr.getCall(0).args[0];
+                    const tasks = stubs.listr.args[0][0];
 
                     expect(tasks[2].title).to.match(/Zesty/);
                     tasks[2].task({}, {skip: stubs.skip});
@@ -412,7 +412,7 @@ describe('Unit: Commands > Setup', function () {
 
                     expect(stubs.skip.calledOnce).to.be.true;
                     expect(stubs.log.calledOnce).to.be.true;
-                    expect(stubs.log.getCall(0).args[0]).to.match(expectLog);
+                    expect(stubs.log.args[0][0]).to.match(expectLog);
                 });
             });
         });
@@ -430,7 +430,7 @@ describe('Unit: Commands > Setup', function () {
 
             return setup.run({prompt: false, 'setup-zest': false}).then(() => {
                 expect(ui.listr.calledOnce).to.be.true;
-                const tasks = ui.listr.getCall(0).args[0];
+                const tasks = ui.listr.args[0][0];
 
                 expect(tasks[2].title).to.match(/Zesty/);
                 tasks[2].task({}, {skip: skipStub});
@@ -459,7 +459,7 @@ describe('Unit: Commands > Setup', function () {
 
             return setup.run({prompt: true, start: false}).then(() => {
                 expect(ui.listr.calledOnce).to.be.true;
-                tasks = ui.listr.getCall(0).args[0];
+                tasks = ui.listr.args[0][0];
 
                 expect(tasks[2].title).to.match(/Zesty/);
                 expect(tasks[3].title).to.match(/Test/);
@@ -468,8 +468,8 @@ describe('Unit: Commands > Setup', function () {
             }).then(() => tasks[3].task({}, {})).then(() => {
                 expect(skipStub.calledOnce).to.be.true;
                 expect(ui.confirm.calledTwice).to.be.true;
-                expect(ui.confirm.getCall(0).args[0]).to.match(/Zesty/);
-                expect(ui.confirm.getCall(1).args[0]).to.match(/Test/);
+                expect(ui.confirm.args[0][0]).to.match(/Zesty/);
+                expect(ui.confirm.args[1][0]).to.match(/Test/);
             });
         });
     });
@@ -484,6 +484,6 @@ describe('Unit: Commands > Setup', function () {
         yargs.option.returns(yargs);
         SetupCommand.configureOptions.call({options: {}}, 'Test', yargs, extensions, true);
         expect(yargs.option.called).to.be.true;
-        expect(yargs.option.getCall(0).args[0]).to.equal('test');
+        expect(yargs.option.args[0][0]).to.equal('test');
     });
 });

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -79,14 +79,14 @@ describe('Unit: Commands > Start', function () {
                 const proces = myInstance.process.start;
 
                 expect(ui.run.calledOnce).to.be.true;
-                return ui.run.getCall(0).args[0]().then(() => {
+                return ui.run.args[0][0]().then(() => {
                     expect(running.calledTwice).to.be.true;
-                    expect(running.getCall(0).args).to.be.empty;
-                    expect(running.getCall(1).args[0]).to.equal('Ghost');
+                    expect(running.args[0]).to.be.empty;
+                    expect(running.args[1][0]).to.equal('Ghost');
 
                     expect(proces.calledOnce).to.be.true;
-                    expect(proces.getCall(0).args[0]).to.equal(process.cwd());
-                    expect(proces.getCall(0).args[1]).to.equal('Ghost');
+                    expect(proces.args[0][0]).to.equal(process.cwd());
+                    expect(proces.args[0][1]).to.equal('Ghost');
                 });
             });
         });
@@ -171,7 +171,7 @@ describe('Unit: Commands > Start', function () {
             return start.run({enable: false}).then(() => {
                 expect(runCommandStub.calledOnce).to.be.true;
                 expect(ui.log.calledOnce).to.be.true;
-                expect(ui.log.getCall(0).args[0]).to.match(/You can access your blog/);
+                expect(ui.log.args[0][0]).to.match(/You can access your blog/);
             });
         });
 
@@ -188,8 +188,8 @@ describe('Unit: Commands > Start', function () {
             return start.run({enable: false}).then(() => {
                 expect(runCommandStub.calledOnce).to.be.true;
                 expect(ui.log.calledThrice).to.be.true;
-                expect(ui.log.getCall(1).args[0]).to.match(/Ghost uses direct mail/);
-                expect(ui.log.getCall(2).args[0]).to.match(/alternative email method/);
+                expect(ui.log.args[1][0]).to.match(/Ghost uses direct mail/);
+                expect(ui.log.args[2][0]).to.match(/alternative email method/);
             });
         });
     });
@@ -204,6 +204,6 @@ describe('Unit: Commands > Start', function () {
         yargs.option.returns(yargs);
         StartCommand.configureOptions.call({options: {}}, 'Test', yargs, extensions, true);
         expect(yargs.option.called).to.be.true;
-        expect(yargs.option.getCall(0).args[0]).to.equal('test');
+        expect(yargs.option.args[0][0]).to.equal('test');
     });
 });

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -51,7 +51,7 @@ describe('Unit: Commands > Stop', function () {
                 expect(error).to.be.ok;
                 expect(error.message).to.equal('SHORT_CIRCUIT');
                 expect(pcss.calledOnce).to.be.true;
-                expect(pcss.getCall(0).args[0]).to.equal('../ghost');
+                expect(pcss.args[0][0]).to.equal('../ghost');
             }
         });
 
@@ -85,9 +85,9 @@ describe('Unit: Commands > Stop', function () {
                 expect(name).to.equal('Stopping Ghost');
                 return fn().then(() => {
                     expect(stopStub.calledOnce).to.be.true;
-                    expect(stopStub.getCall(0).args[0]).to.equal(process.cwd());
+                    expect(stopStub.args[0][0]).to.equal(process.cwd());
                     expect(runningStub.calledTwice).to.be.true;
-                    expect(runningStub.getCall(1).args[0]).to.equal(null);
+                    expect(runningStub.args[1][0]).to.equal(null);
                 });
             }
 
@@ -156,10 +156,10 @@ describe('Unit: Commands > Stop', function () {
 
             expect(runStub.callCount).to.equal(8);
             expect(context.run.callCount).to.equal(8);
-            expect(context.run.getCall(0).args[0].quiet).to.be.true;
+            expect(context.run.args[0][0].quiet).to.be.true;
             expect(pcss.callCount).to.equal(9);
-            expect(pcss.getCall(0).args[0]).to.equal('./a');
-            expect(pcss.getCall(8).args[0]).to.equal(process.cwd());
+            expect(pcss.args[0][0]).to.equal('./a');
+            expect(pcss.args[8][0]).to.equal(process.cwd());
         });
     });
 
@@ -173,6 +173,6 @@ describe('Unit: Commands > Stop', function () {
         yargs.option.returns(yargs);
         StopCommand.configureOptions.call({options: {}}, 'Test', yargs, extensions, true);
         expect(yargs.option.called).to.be.true;
-        expect(yargs.option.getCall(0).args[0]).to.equal('test');
+        expect(yargs.option.args[0][0]).to.equal('test');
     });
 });

--- a/test/unit/commands/uninstall-spec.js
+++ b/test/unit/commands/uninstall-spec.js
@@ -117,7 +117,7 @@ describe('Unit: Commands > Uninstall', function () {
 
                 return uninstall.run.call(context, argv).then(() => {
                     expect(stubs.listr.calledOnce).to.be.true;
-                    tasklist = stubs.listr.getCall(0).args[0];
+                    tasklist = stubs.listr.args[0][0];
                 });
             });
 
@@ -150,7 +150,7 @@ describe('Unit: Commands > Uninstall', function () {
 
                 expect(stubs.remove.called).to.be.false;
                 expect(stubs.sudo.calledOnce).to.be.true
-                expect(stubs.sudo.getCall(0).args[0]).to.equal(cmd);
+                expect(stubs.sudo.args[0][0]).to.equal(cmd);
             });
 
             // Todo: optimize if possible (because of beforeEach proxyUninstall is
@@ -165,7 +165,7 @@ describe('Unit: Commands > Uninstall', function () {
 
                 return uninstall.run.call(context, argv).then(() => {
                     expect(stubs.listr.calledOnce).to.be.true;
-                    return stubs.listr.getCall(0).args[0][1];
+                    return stubs.listr.args[0][0][1];
                 }).then((task) => {
                     expect(task.title).to.equal('Removing content folder');
                     task.task();

--- a/test/unit/tasks/yarn-install-spec.js
+++ b/test/unit/tasks/yarn-install-spec.js
@@ -52,7 +52,7 @@ describe('Unit: Tasks > yarn-install', function () {
             const ctx = {installPath: '/var/www/ghost'};
             expect(listrStub.calledOnce).to.be.true;
 
-            const tasks = listrStub.getCall(0).args[0];
+            const tasks = listrStub.args[0][0];
             expect(tasks).to.have.length(2);
 
             tasks[0].task(ctx);

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -168,8 +168,8 @@ describe('Unit: UI', function () {
         ui.confirm.bind(ctx)('Is ghost just a blogging platform');
 
         expect(ctx.prompt.calledTwice).to.be.true;
-        expect(ctx.prompt.getCall(0).args[0]).to.deep.equal(testA);
-        expect(ctx.prompt.getCall(1).args[0]).to.deep.equal(testB);
+        expect(ctx.prompt.args[0][0]).to.deep.equal(testA);
+        expect(ctx.prompt.args[1][0]).to.deep.equal(testB);
         done();
     });
 
@@ -283,7 +283,7 @@ describe('Unit: UI', function () {
 
         return ui.sudo('echo').then(() => {
             expect(shellStub.calledOnce).to.be.true;
-            expect(shellStub.getCall(0).args[0]).to.match(/#'[ ]{2}echo/);
+            expect(shellStub.args[0][0]).to.match(/#'[ ]{2}echo/);
         });
     });
 
@@ -476,15 +476,15 @@ describe('Unit: UI', function () {
                 expect(ctx.log.called).to.be.true;
                 expect(ctx._formatDebug.calledTwice).to.be.true;
                 expect(system.writeErrorLog.calledOnce).to.be.true;
-                expect(ctx.log.getCall(0).args[0]).to.match(/Config/);
-                expect(ctx.log.getCall(1).args[0]).to.equal(errs[0].toString(true));
-                expect(ctx.log.getCall(2).args[0]).to.equal('cherries');
-                expect(ctx.log.getCall(3).args[0]).to.match(/\nTry running \u001b\[36mghost doctor\u001b\[39m to check your system for known issues./);
-                expect(ctx.log.getCall(4).args[0]).to.match(/https:\/\/docs\.ghost\.org\//);
-                expect(ctx.log.getCall(5).args[0]).to.match(/Cli/);
-                expect(ctx.log.getCall(6).args[0]).to.equal(errs[1].toString(true));
-                expect(ctx.log.getCall(7).args[0]).to.equal('cherries');
-                expect(ctx.log.getCall(8).args[0]).to.match(/Additional log info/);
+                expect(ctx.log.args[0][0]).to.match(/Config/);
+                expect(ctx.log.args[1][0]).to.equal(errs[0].toString(true));
+                expect(ctx.log.args[2][0]).to.equal('cherries');
+                expect(ctx.log.args[3][0]).to.match(/\nTry running \u001b\[36mghost doctor\u001b\[39m to check your system for known issues./);
+                expect(ctx.log.args[4][0]).to.match(/https:\/\/docs\.ghost\.org\//);
+                expect(ctx.log.args[5][0]).to.match(/Cli/);
+                expect(ctx.log.args[6][0]).to.equal(errs[1].toString(true));
+                expect(ctx.log.args[7][0]).to.equal('cherries');
+                expect(ctx.log.args[8][0]).to.match(/Additional log info/);
 
                 done();
             });
@@ -508,15 +508,15 @@ describe('Unit: UI', function () {
                 sinon.assert.callCount(ctx.log,11);
                 expect(ctx._formatDebug.calledTwice).to.be.true;
                 expect(system.writeErrorLog.calledOnce).to.be.true;
-                expect(ctx.log.firstCall.args[0]).to.match(/Config/);
-                expect(ctx.log.secondCall.args[0]).to.equal(errs[0].toString(false));
-                expect(ctx.log.thirdCall.args[0]).to.equal('cherries');
-                expect(ctx.log.getCall(3).args[0]).to.match(/\nTry running \u001b\[36mghost doctor\u001b\[39m to check your system for known issues./);
-                expect(ctx.log.getCall(4).args[0]).to.match(/https:\/\/docs\.ghost\.org\//);
-                expect(ctx.log.getCall(5).args[0]).to.match(/Cli/);
-                expect(ctx.log.getCall(6).args[0]).to.equal(errs[1].toString(false));
-                expect(ctx.log.getCall(7).args[0]).to.equal('cherries');
-                expect(ctx.log.getCall(8).args[0]).to.match(/Additional log info/);
+                expect(ctx.log.args[0][0]).to.match(/Config/);
+                expect(ctx.log.args[1][0]).to.equal(errs[0].toString(false));
+                expect(ctx.log.args[2][0]).to.equal('cherries');
+                expect(ctx.log.args[3][0]).to.match(/\nTry running \u001b\[36mghost doctor\u001b\[39m to check your system for known issues./);
+                expect(ctx.log.args[4][0]).to.match(/https:\/\/docs\.ghost\.org\//);
+                expect(ctx.log.args[5][0]).to.match(/Cli/);
+                expect(ctx.log.args[6][0]).to.equal(errs[1].toString(false));
+                expect(ctx.log.args[7][0]).to.equal('cherries');
+                expect(ctx.log.args[8][0]).to.match(/Additional log info/);
 
                 done();
             });
@@ -548,14 +548,14 @@ describe('Unit: UI', function () {
                 expect(ctx.log.callCount).to.equal(8);
                 expect(ctx._formatDebug.calledOnce).to.be.true;
                 expect(system.writeErrorLog.called).to.be.false;
-                expect(ctx.log.getCall(0).args[0]).to.match(/One or more errors occurred/);
-                expect(ctx.log.getCall(1).args[0]).to.match(/1\) SystemError/);
-                expect(stripAnsi(ctx.log.getCall(2).args[0])).to.match(/Message: Error 1/);
-                expect(ctx.log.getCall(3).args[0]).to.match(/2\) Task 2/);
-                expect(stripAnsi(ctx.log.getCall(4).args[0])).to.match(/Message: Error 2/);
-                expect(ctx.log.getCall(5).args[0]).to.equal('cherries');
-                expect(stripAnsi(ctx.log.getCall(6).args[0])).to.match(/Try running ghost doctor to check your system for known issues./);
-                expect(ctx.log.getCall(7).args[0]).to.match(/Please refer to https:\/\/docs.ghost.org/);
+                expect(ctx.log.args[0][0]).to.match(/One or more errors occurred/);
+                expect(ctx.log.args[1][0]).to.match(/1\) SystemError/);
+                expect(stripAnsi(ctx.log.args[2][0])).to.match(/Message: Error 1/);
+                expect(ctx.log.args[3][0]).to.match(/2\) Task 2/);
+                expect(stripAnsi(ctx.log.args[4][0])).to.match(/Message: Error 2/);
+                expect(ctx.log.args[5][0]).to.equal('cherries');
+                expect(stripAnsi(ctx.log.args[6][0])).to.match(/Try running ghost doctor to check your system for known issues./);
+                expect(ctx.log.args[7][0]).to.match(/Please refer to https:\/\/docs.ghost.org/);
             });
 
             it('non-verbose with log output', function () {
@@ -580,15 +580,15 @@ describe('Unit: UI', function () {
                 expect(ctx.log.callCount).to.equal(9);
                 expect(ctx._formatDebug.calledOnce).to.be.true;
                 expect(system.writeErrorLog.called).to.be.true;
-                expect(ctx.log.getCall(0).args[0]).to.match(/One or more errors occurred/);
-                expect(ctx.log.getCall(1).args[0]).to.match(/1\) ProcessError/);
-                expect(stripAnsi(ctx.log.getCall(2).args[0])).to.match(/Message: Error 1/);
-                expect(ctx.log.getCall(3).args[0]).to.match(/2\) Task 2/);
-                expect(stripAnsi(ctx.log.getCall(4).args[0])).to.match(/Message: Error 2/);
-                expect(ctx.log.getCall(5).args[0]).to.equal('cherries');
-                expect(ctx.log.getCall(6).args[0]).to.match(/Additional log info available in/);
-                expect(stripAnsi(ctx.log.getCall(7).args[0])).to.match(/Try running ghost doctor to check your system for known issues./);
-                expect(ctx.log.getCall(8).args[0]).to.match(/Please refer to https:\/\/docs.ghost.org/);
+                expect(ctx.log.args[0][0]).to.match(/One or more errors occurred/);
+                expect(ctx.log.args[1][0]).to.match(/1\) ProcessError/);
+                expect(stripAnsi(ctx.log.args[2][0])).to.match(/Message: Error 1/);
+                expect(ctx.log.args[3][0]).to.match(/2\) Task 2/);
+                expect(stripAnsi(ctx.log.args[4][0])).to.match(/Message: Error 2/);
+                expect(ctx.log.args[5][0]).to.equal('cherries');
+                expect(ctx.log.args[6][0]).to.match(/Additional log info available in/);
+                expect(stripAnsi(ctx.log.args[7][0])).to.match(/Try running ghost doctor to check your system for known issues./);
+                expect(ctx.log.args[8][0]).to.match(/Please refer to https:\/\/docs.ghost.org/);
             });
         });
 
@@ -620,10 +620,10 @@ describe('Unit: UI', function () {
                 sinon.assert.callCount(ctx._formatDebug, 4);
                 sinon.assert.callCount(system.writeErrorLog, 4);
                 expectedErrors.forEach(function (err, i) {
-                    expect(ctx.log.getCall(i * 5 + 2).args[0]).to.match(/Additional log info/);
-                    expect(ctx.log.getCall(i * 5 + 3).args[0]).to.match(/Try running \u001b\[36mghost doctor\u001b\[39m to check your system for known issues./);
-                    expect(ctx.log.getCall(i * 5 + 4).args[0]).to.match(/Please refer to https:\/\/docs\.ghost\.org/);
-                    expect(stripAnsi(ctx.log.getCall(i * 5).args[0]).split(/\n/)).to.deep.equal(err);
+                    expect(ctx.log.args[i * 5 + 2][0]).to.match(/Additional log info/);
+                    expect(ctx.log.args[i * 5 + 3][0]).to.match(/Try running \u001b\[36mghost doctor\u001b\[39m to check your system for known issues./);
+                    expect(ctx.log.args[i * 5 + 4][0]).to.match(/Please refer to https:\/\/docs\.ghost\.org/);
+                    expect(stripAnsi(ctx.log.args[i * 5][0]).split(/\n/)).to.deep.equal(err);
                 });
                 done();
             });
@@ -643,10 +643,10 @@ describe('Unit: UI', function () {
                 sinon.assert.callCount(ctx.log, 5);
                 expect(ctx._formatDebug.calledOnce).to.be.true;
                 expect(system.writeErrorLog.calledOnce).to.be.true;
-                expect(ctx.log.getCall(2).args[0]).to.match(/Additional log info/);
-                // expect(ctx.log.getCall(3).args[0]).to.match(/Please refer to https:\/\/docs\.ghost\.org/);
-                expect(ctx.log.getCall(4).args[0]).to.match(/Please refer to https:\/\/docs\.ghost\.org/);
-                expect(stripAnsi(ctx.log.getCall(0).args[0]).split(/\n/)).to.deep.equal(expectedError);
+                expect(ctx.log.args[2][0]).to.match(/Additional log info/);
+                // expect(ctx.log.args[3][0]).to.match(/Please refer to https:\/\/docs\.ghost\.org/);
+                expect(ctx.log.args[4][0]).to.match(/Please refer to https:\/\/docs\.ghost\.org/);
+                expect(stripAnsi(ctx.log.args[0][0]).split(/\n/)).to.deep.equal(expectedError);
 
                 done();
             });
@@ -666,8 +666,8 @@ describe('Unit: UI', function () {
 
             expect(ctx._formatDebug.calledOnce).to.be.true;
             sinon.assert.callCount(ctx.log, 2);
-            expect(ctx.log.getCall(0).args[0]).to.deep.equal(expectedCall);
-            expect(ctx.log.getCall(0).args[2]).to.be.true;
+            expect(ctx.log.args[0][0]).to.deep.equal(expectedCall);
+            expect(ctx.log.args[0][2]).to.be.true;
 
             done();
         });
@@ -678,9 +678,9 @@ describe('Unit: UI', function () {
 
             expect(ctx._formatDebug.calledOnce).to.be.true;
             sinon.assert.callCount(ctx.log, 2);
-            expect(ctx.log.getCall(0).args[0]).to.match(/error occured/);
-            expect(ctx.log.getCall(1).args[0]).to.match(/Try running \u001b\[36mghost doctor\u001b\[39m to check your system for known issues./);
-            expect(ctx.log.getCall(0).args[2]).to.be.true;
+            expect(ctx.log.args[0][0]).to.match(/error occured/);
+            expect(ctx.log.args[1][0]).to.match(/Try running \u001b\[36mghost doctor\u001b\[39m to check your system for known issues./);
+            expect(ctx.log.args[0][2]).to.be.true;
 
             done();
         });

--- a/test/unit/utils/find-extensions-spec.js
+++ b/test/unit/utils/find-extensions-spec.js
@@ -37,7 +37,7 @@ describe('Unit: Utils > find-extensions', function () {
     it('calls find-plugins with proper args', function () {
         findExtensions();
         expect(findStub.calledOnce).to.be.true;
-        const args = findStub.getCall(0).args[0];
+        const args = findStub.args[0][0];
 
         const expected = {
             keyword: 'ghost-cli-extension',

--- a/test/unit/utils/yarn-spec.js
+++ b/test/unit/utils/yarn-spec.js
@@ -150,7 +150,7 @@ describe('Unit: yarn', function () {
             res.then(() => {
                 expect(stubs.observer.complete.called).to.be.false;
                 expect(stubs.observer.error.calledOnce).to.be.true;
-                expect(stubs.observer.error.getCall(0).args[0]).to.equal('test');
+                expect(stubs.observer.error.args[0][0]).to.equal('test');
             });
 
             stubs.proxy.resolve();
@@ -162,9 +162,9 @@ describe('Unit: yarn', function () {
             expect(stubs.proxy).to.be.an('Object');
             stubs.proxy.fn(stubs.observer);
             expect(stubs.stdout.calledOnce).to.be.true;
-            expect(stubs.stdout.getCall(0).args[0]).to.equal('data');
+            expect(stubs.stdout.args[0][0]).to.equal('data');
 
-            const onFn = stubs.stdout.getCall(0).args[1];
+            const onFn = stubs.stdout.args[0][1];
             onFn('\n\n\n');
             onFn('test\n');
             onFn('\nbest\n');
@@ -172,10 +172,10 @@ describe('Unit: yarn', function () {
 
             const next = stubs.observer.next
             expect(next.callCount).to.equal(4);
-            expect(next.getCall(0).args[0]).to.equal('\n\n');
-            expect(next.getCall(1).args[0]).to.equal('test');
-            expect(next.getCall(2).args[0]).to.equal('\nbest');
-            expect(next.getCall(3).args[0]).to.equal('run');
+            expect(next.args[0][0]).to.equal('\n\n');
+            expect(next.args[1][0]).to.equal('test');
+            expect(next.args[2][0]).to.equal('\nbest');
+            expect(next.args[3][0]).to.equal('run');
         });
 
         it('cleans up observer error', function () {


### PR DESCRIPTION
No issue

- Just standardizing the mechanism to retrieve a specific call