### PR TITLE
fix(root-user): only skip exiting inside root install

### DIFF
--- a/lib/utils/check-root-user.js
+++ b/lib/utils/check-root-user.js
@@ -25,20 +25,27 @@ function checkRootUser(command) {
         console.error(`${chalk.yellow('We discovered that you are using the Digitalocean One-Click install.')}
 You need to create a user with regular account privileges and migrate your installation to use this user.
 Please follow the steps here: ${chalk.underline.green('https://docs.ghost.org/docs/troubleshooting#section-fix-root-user')} to fix your setup.\n`);
+
+        // TODO: remove this 4 versions after 1.5.0
+        if (includes(allowedCommands, command)) {
+            return;
+        }
     } else if (isRootInstall()) {
         console.error(`${chalk.yellow('It seems Ghost was installed using the root user.')}
 You need to create a user with regular account privileges and migrate your installation to use this user.
 Please follow the steps here: ${chalk.underline.green('https://docs.ghost.org/docs/troubleshooting#section-fix-root-user')} to fix your setup.\n`);
+
+        // TODO: remove this 4 versions after 1.5.0
+        if (includes(allowedCommands, command)) {
+            return;
+        }
     } else {
         console.error(`${chalk.yellow('Can\'t run command as \'root\' user.')}
 Please use the user you set up in the installation process, or create a new user with regular account privileges and use this user to run 'ghost ${command}'.
 See ${chalk.underline.green('https://docs.ghost.org/docs/install#section-create-a-new-user')} for more information\n`);
     }
 
-    // TODO: remove this 4 versions after 1.5.0
-    if (!includes(allowedCommands, command)) {
-        process.exit(1);
-    }
+    process.exit(1);
 }
 
 module.exports = checkRootUser;

--- a/test/unit/utils/check-root-user-spec.js
+++ b/test/unit/utils/check-root-user-spec.js
@@ -167,28 +167,6 @@ describe('Unit: Utils > checkRootUser', function () {
         }
     });
 
-    it('throws error command run with root for non-root installs, but doesn\'t exit on `restart`', function () {
-        const osStub = sandbox.stub(os, 'platform').returns('linux');
-        const cwdStub = sandbox.stub(process, 'cwd').returns('/var/www/ghost');
-        const fsStub = sandbox.stub(fs, 'existsSync');
-        const fsStatStub = sandbox.stub(fs, 'statSync').returns({uid: 501});
-        const processStub = sandbox.stub(process, 'getuid').returns(0);
-        const exitStub = sandbox.stub(process, 'exit').throws();
-        const errorStub = sandbox.stub(console, 'error');
-
-        fsStub.withArgs('/root/.digitalocean_password').returns(false);
-        fsStub.withArgs('/var/www/ghost/.ghost-cli').returns(true);
-
-        checkRootUser('restart');
-        expect(cwdStub.calledOnce).to.be.true;
-        expect(fsStatStub.calledWithExactly('/var/www/ghost/.ghost-cli')).to.be.true;
-        expect(osStub.calledOnce).to.be.true;
-        expect(processStub.calledOnce).to.be.true;
-        expect(errorStub.calledOnce).to.be.true;
-        expect(exitStub.calledOnce).to.be.false;
-        expect(errorStub.args[0][0]).to.match(/Can't run command as 'root' user/);
-    });
-
     it('throws error command run with root outside of valid ghost installation', function () {
         const osStub = sandbox.stub(os, 'platform').returns('linux');
         const cwdStub = sandbox.stub(process, 'cwd').returns('/var/www/');
@@ -215,28 +193,5 @@ describe('Unit: Utils > checkRootUser', function () {
             expect(exitStub.calledOnce).to.be.true;
             expect(errorStub.args[0][0]).to.match(/Can't run command as 'root' user/);
         }
-    });
-
-    it('throws error command run with root outside of valid ghost installation, but doesn\'t exit on `restart`', function () {
-        const osStub = sandbox.stub(os, 'platform').returns('linux');
-        const cwdStub = sandbox.stub(process, 'cwd').returns('/var/www/');
-        const fsStub = sandbox.stub(fs, 'existsSync');
-        const fsStatStub = sandbox.stub(fs, 'statSync').returns({uid: 501});
-        const processStub = sandbox.stub(process, 'getuid').returns(0);
-        const exitStub = sandbox.stub(process, 'exit').throws();
-        const errorStub = sandbox.stub(console, 'error');
-
-        fsStub.withArgs('/root/.digitalocean_password').returns(false);
-        fsStub.withArgs('/var/www/.ghost-cli').returns(false);
-
-        checkRootUser('restart');
-        expect(cwdStub.calledOnce).to.be.true;
-        expect(fsStub.calledWithExactly('/var/www/.ghost-cli')).to.be.true;
-        expect(fsStatStub.calledOnce).to.be.false;
-        expect(osStub.calledOnce).to.be.true;
-        expect(processStub.calledOnce).to.be.true;
-        expect(errorStub.calledOnce).to.be.true;
-        expect(exitStub.calledOnce).to.be.false;
-        expect(errorStub.args[0][0]).to.match(/Can't run command as 'root' user/);
     });
 });


### PR DESCRIPTION
no issue
- if outside of a root install (or a root install has been fixed),
commands will still fail as root