### PR TITLE
fix(uninstall): only use sudo to remove content folder when needed

### DIFF
--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -4,9 +4,10 @@ const Command = require('../command');
 class UninstallCommand extends Command {
     run(argv) {
         const fs = require('fs-extra');
-        const os = require('os');
         const path = require('path');
+
         const StopCommand = require('./stop');
+        const shouldUseGhostUser = require('../utils/use-ghost-user');
 
         if (!argv.force) {
             this.ui.log('WARNING: Running this command will delete all of your themes, images, data, any files related to this Ghost instance, and the contents of this folder!\n' +
@@ -31,14 +32,8 @@ class UninstallCommand extends Command {
                 }
             }, {
                 title: 'Removing content folder',
-                task: () => {
-                    const contentDir = path.join(instance.dir, 'content');
-
-                    if (os.platform() === 'linux') {
-                        return this.ui.sudo(`rm -rf ${contentDir}`);
-                    }
-                    return fs.remove(contentDir);
-                }
+                enabled: () => shouldUseGhostUser(path.join(instance.dir, 'content')),
+                task: () => this.ui.sudo(`rm -rf ${path.join(instance.dir, 'content')}`)
             }, {
                 title: 'Removing related configuration',
                 task: () => {


### PR DESCRIPTION
closes #577
- cleanup uninstall tests
- disable remove content folder step if ghost user doesn't own content folder