### PR TITLE
Improve error messages in extensions

### DIFF
--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -76,7 +76,7 @@ class MySQLExtension extends cli.Extension {
             }
 
             return Promise.reject(new cli.errors.CliError({
-                message: 'Error trying to connenct to the MySQL database.',
+                message: 'Error trying to connect to the MySQL database.',
                 help: 'You can run `ghost config` to re-enter the correct credentials. Alternatively you can run `ghost setup` again.',
                 err: error
             }));

--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -75,7 +75,11 @@ class MySQLExtension extends cli.Extension {
                 }));
             }
 
-            return Promise.reject(error);
+            return Promise.reject(new cli.errors.CliError({
+                message: 'Error trying to connenct to the MySQL database.',
+                help: 'You can run `ghost config` to re-enter the correct credentials. Alternatively you can run `ghost setup` again.',
+                err: error
+            }));
         });
     }
 
@@ -120,7 +124,10 @@ class MySQLExtension extends cli.Extension {
                         return tryCreateUser();
                     }
 
-                    return Promise.reject(error);
+                    return Promise.reject(new cli.errors.CliError({
+                        message: `Creating new MySQL user errored with message: ${error.message}`,
+                        err: error
+                    }));
                 });
             };
 
@@ -136,7 +143,14 @@ class MySQLExtension extends cli.Extension {
         }).catch((error) => {
             this.ui.logVerbose('MySQL: Unable to create custom Ghost user', 'red');
             this.connection.end(); // Ensure we end the connection
-            return Promise.reject(new cli.errors.SystemError(`Creating new mysql user errored with message: ${error.message}`));
+            if (error instanceof cli.errors.CliError) {
+                return Promise.reject(error);
+            }
+
+            return Promise.reject(new cli.errors.CliError({
+                message: `MySQL user creation errored with message: ${error.message}`,
+                err: error
+            }));
         });
     }
 
@@ -149,7 +163,10 @@ class MySQLExtension extends cli.Extension {
         }).catch((error) => {
             this.ui.logVerbose('MySQL: Unable either to grant permissions or flush privileges', 'red');
             this.connection.end();
-            return Promise.reject(new cli.errors.SystemError(`Granting database permissions errored with message: ${error.message}`));
+            return Promise.reject(new cli.errors.CliError({
+                message: `Granting database permissions errored with message: ${error.message}`,
+                err: error
+            }));
         });
     }
 

--- a/extensions/mysql/test/extension-spec.js
+++ b/extensions/mysql/test/extension-spec.js
@@ -172,7 +172,7 @@ describe('Unit: Mysql extension', function () {
                 expect(false, 'error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.an.instanceof(errors.CliError);
-                expect(error.message).to.equal('Error trying to connenct to the MySQL database.');
+                expect(error.message).to.equal('Error trying to connect to the MySQL database.');
                 expect(error.options.help).to.equal('You can run `ghost config` to re-enter the correct credentials. Alternatively you can run `ghost setup` again.');
                 expect(error.options.err.message).to.equal('ack');
                 expect(createConnectionStub.calledOnce).to.be.true;

--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -126,7 +126,7 @@ class NginxExtension extends cli.Extension {
                     if (error.code !== 'ENOTFOUND') {
                         // Some other error
                         return Promise.reject(new cli.errors.CliError({
-                            message: `Error trying to looking DNS for '${parsedUrl.hostname}'`,
+                            message: `Error trying to lookup DNS for '${parsedUrl.hostname}'`,
                             err: error
                         }));
                     }

--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -238,7 +238,7 @@ class NginxExtension extends cli.Extension {
                     this.ui.sudo(`rm -f /etc/nginx/sites-enabled/${confFile}`)
                 ]).catch(
                     (error) => Promise.reject(new cli.errors.CliError({
-                        message: `Nginx config file link could not be removed, you will need to do this manually for ${confFile}.`,
+                        message: `Nginx config file link could not be removed, you will need to do this manually for /etc/nginx/sites-available/${confFile}.`,
                         help: `Try running 'rm -f /etc/nginx/sites-available/${confFile} && rm -f /etc/nginx/sites-enabled/${confFile}'`,
                         err: error
                     }))
@@ -254,7 +254,7 @@ class NginxExtension extends cli.Extension {
                     this.ui.sudo(`rm -f /etc/nginx/sites-enabled/${sslConfFile}`)
                 ]).catch(
                     (error) => Promise.reject(new cli.errors.CliError({
-                        message: `SSL config file link could not be removed, you will need to do this manually for ${sslConfFile}.`,
+                        message: `SSL config file link could not be removed, you will need to do this manually for /etc/nginx/sites-available/${sslConfFile}.`,
                         help: `Try running 'rm -f /etc/nginx/sites-available/${sslConfFile} && rm -f /etc/nginx/sites-enabled/${sslConfFile}'`,
                         err: error
                     }))

--- a/extensions/nginx/test/extension-spec.js
+++ b/extensions/nginx/test/extension-spec.js
@@ -425,7 +425,7 @@ describe('Unit: Extensions > Nginx', function () {
                 }).catch((err) => {
                     expect(firstSet, `ENOTFOUND Failed: ${err}`).to.be.true;
                     expect(err).to.exist;
-                    expect(err.options.message).to.match(/Error trying to looking DNS for 'ghost.dev'/);
+                    expect(err.options.message).to.match(/Error trying to lookup DNS for 'ghost.dev'/);
                     expect(err.options.err.code).to.equal(DNS.code);
                     expect(log.called).to.be.false;
                     expect(ctx.dnsfail).to.not.exist;

--- a/extensions/systemd/get-uid.js
+++ b/extensions/systemd/get-uid.js
@@ -23,7 +23,9 @@ module.exports = function getUid(dir) {
         return uid;
     } catch (e) {
         if (!e.message.match(/no such user/i)) {
-            throw e;
+            const errors = require('../../lib').errors;
+            // throw the error here so it'll be logged
+            throw new errors.ProcessError(e);
         }
 
         return null;

--- a/extensions/systemd/get-uid.js
+++ b/extensions/systemd/get-uid.js
@@ -22,12 +22,10 @@ module.exports = function getUid(dir) {
 
         return uid;
     } catch (e) {
-        if (!e.message.match(/no such user/i)) {
-            const errors = require('../../lib').errors;
-            // throw the error here so it'll be logged
-            throw new errors.ProcessError(e);
-        }
-
+        // CASE: the ghost user doesn't exist, hence can't be used
+        // We just return null and not doing anything with the error,
+        // as it would either mean, that the user doesn't exist (this
+        // is exactly what we want to know), or the command is not by the OS
         return null;
     }
 };

--- a/extensions/systemd/index.js
+++ b/extensions/systemd/index.js
@@ -17,16 +17,9 @@ class SystemdExtension extends cli.Extension {
     }
 
     _setup(argv, ctx, task) {
-        let uid;
+        const uid = getUid(ctx.instance.dir);
 
-        // getUid returns either the uid or null, but can also throw an error
-        try {
-            uid = getUid(ctx.instance.dir);
-        } catch (e) {
-            this.ui.log('The "ghost" user has not been created, please run `ghost setup linux-user` first', 'yellow');
-            return task.skip();
-        }
-
+        // getUid returns either the uid or null
         if (!uid) {
             this.ui.log('The "ghost" user has not been created, please run `ghost setup linux-user` first', 'yellow');
             return task.skip();

--- a/extensions/systemd/systemd.js
+++ b/extensions/systemd/systemd.js
@@ -96,18 +96,9 @@ class SystemdProcessManager extends cli.ProcessManager {
     }
 
     _precheck() {
-        let uid;
+        const uid = getUid(this.instance.dir);
 
-        // getUid returns either the uid or null, but can also throw an error
-        try {
-            uid = getUid(this.instance.dir);
-        } catch (e) {
-            // getuid throws a ProcessError, we add a message and help and just throw it
-            e.message = 'Systemd process manager has not been set up or is corrupted.';
-            e.options.help = `Run ${chalk.green('ghost setup linux-user systemd')} and try again.`
-            throw e;
-        }
-
+        // getUid returns either the uid or null
         if (!uid) {
             throw new cli.errors.SystemError({
                 message: 'Systemd process manager has not been set up or is corrupted.',

--- a/extensions/systemd/test/extension-spec.js
+++ b/extensions/systemd/test/extension-spec.js
@@ -53,25 +53,6 @@ describe('Unit: Systemd > Extension', function () {
     });
 
     describe('setup stage', function () {
-        it('can handle getUid error', function () {
-            const uidStub = sinon.stub().throws(new errors.ProcessError({stderr: 'something went wrong'}));
-
-            const SystemdExtension = proxyquire(modulePath, {
-                './get-uid': uidStub
-            });
-
-            const logStub = sinon.stub();
-            const skipStub = sinon.stub();
-            const testInstance = new SystemdExtension({log: logStub}, {}, {}, path.join(__dirname, '..'));
-
-            testInstance._setup({}, {instance: {dir: '/some/dir'}}, {skip: skipStub});
-            expect(uidStub.calledOnce).to.be.true;
-            expect(uidStub.calledWithExactly('/some/dir')).to.be.true;
-            expect(logStub.calledOnce).to.be.true;
-            expect(logStub.args[0][0]).to.match(/"ghost" user has not been created/);
-            expect(skipStub.calledOnce).to.be.true;
-        });
-
         it('skips stage if ghost user hasn\'t been set up', function () {
             const uidStub = sinon.stub().returns(false);
 

--- a/extensions/systemd/test/get-uid-spec.js
+++ b/extensions/systemd/test/get-uid-spec.js
@@ -6,21 +6,15 @@ const proxyquire = require('proxyquire').noCallThru();
 const modulePath = '../get-uid';
 
 describe('Unit: Systemd > get-uid util', function () {
-    it('throws ProcessError if execa error is not an expected one, but is stderr', function () {
+    it('catches error but returns null', function () {
         const shellStub = sinon.stub().throws(new Error('some error'));
         const getUid = proxyquire(modulePath, {
             execa: {shellSync: shellStub}
         });
 
-        try {
-            getUid('/some/dir');
-            expect(false, 'error should have been thrown').to.be.true;
-        } catch (e) {
-            const errors = require('../../../lib/errors');
-            expect(e).to.be.an.instanceof(errors.ProcessError);
-            expect(e.message).to.equal('some error');
-            expect(shellStub.calledOnce).to.be.true;
-        }
+        const result = getUid('/some/dir');
+        expect(result).to.be.null;
+        expect(shellStub.calledOnce).to.be.true;
     });
 
     it('returns null if ghost user doesn\'t exist', function () {

--- a/extensions/systemd/test/get-uid-spec.js
+++ b/extensions/systemd/test/get-uid-spec.js
@@ -6,7 +6,7 @@ const proxyquire = require('proxyquire').noCallThru();
 const modulePath = '../get-uid';
 
 describe('Unit: Systemd > get-uid util', function () {
-    it('throws error if execa error is not an expected one', function () {
+    it('throws ProcessError if execa error is not an expected one, but is stderr', function () {
         const shellStub = sinon.stub().throws(new Error('some error'));
         const getUid = proxyquire(modulePath, {
             execa: {shellSync: shellStub}
@@ -16,7 +16,8 @@ describe('Unit: Systemd > get-uid util', function () {
             getUid('/some/dir');
             expect(false, 'error should have been thrown').to.be.true;
         } catch (e) {
-            expect(e).to.be.an.instanceof(Error);
+            const errors = require('../../../lib/errors');
+            expect(e).to.be.an.instanceof(errors.ProcessError);
             expect(e.message).to.equal('some error');
             expect(shellStub.calledOnce).to.be.true;
         }

--- a/extensions/systemd/test/systemd-spec.js
+++ b/extensions/systemd/test/systemd-spec.js
@@ -295,23 +295,7 @@ describe('Unit: Systemd > Process Manager', function () {
             proxyOpts = {'./get-uid': sinon.stub().returns(true)};
         });
 
-        it('can handle when uid throws error', function () {
-            proxyOpts['./get-uid'] = sinon.stub().throws(new errors.ProcessError({stderr: 'something went wrong'}));
-            const ext = makeSystemd(proxyOpts);
-            try {
-                ext._precheck();
-                expect(false, 'An error should have been thrown').to.be.true;
-            } catch (error) {
-                expect(proxyOpts['./get-uid'].calledOnce).to.be.true;
-                expect(error).to.be.ok;
-                expect(error).to.be.instanceOf(errors.ProcessError);
-                expect(error.message).to.match(/Systemd process manager has not been set up or is corrupted./);
-                expect(error.options.help).to.match(/ghost setup linux-user systemd/);
-                expect(error.options.stderr).to.match(/something went wrong/);
-            }
-        });
-
-        it('Errors if uid doesn\'t been set', function () {
+        it('Errors if uid hasn\'t been set', function () {
             proxyOpts['./get-uid'] = sinon.stub().returns(null);
             const ext = makeSystemd(proxyOpts);
             try {


### PR DESCRIPTION
refs #587 

Trying to get a better error handling for our extensions. Catches an error whenever there was no catch, but one needed, creates proper errors when they were just thrown.