### PR TITLE
Update port-polling.js to allow Ghost-CLI to work on slower devices (Raspberry Pi et al).

### DIFF
--- a/lib/utils/port-polling.js
+++ b/lib/utils/port-polling.js
@@ -5,11 +5,11 @@ const errors = require('../errors');
 
 module.exports = function portPolling(options) {
     options = Object.assign({
-        timeoutInMS: 1000,
+        timeoutInMS: 2000,
         maxTries: 20,
-        delayOnConnectInMS: 3 * 1000,
+        delayOnConnectInMS: 3 * 2000,
         logSuggestion: 'ghost log',
-        socketTimeoutInMS: 1000 * 30
+        socketTimeoutInMS: 1000 * 60
     }, options || {});
 
     if (!options.port) {


### PR DESCRIPTION
Doubled timeout to allow the CLI tool to run on slower devices, like the Raspberry Pi. Whilst not officially supported, Raspbian Stretch does work with the new Ghost CLI tool with a few tweaks. Recent changes to the CLI tool (this check) caused the install / update process to fail due to the timeout check. Discussed with Vilkas Potluri in the Slack Help channel (under my username GhostPi) and this works. Tested on 4 blogs hosted on my own Raspberry Pi. Linked to issue opened (and subsequently closed) found here: https://github.com/TryGhost/Ghost/issues/9447#event-1465916582