### PR TITLE
fix(port-polling): connect over custom host if custom host is specified

### DIFF
--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -73,7 +73,8 @@ class ProcessManager {
 
         options = Object.assign({
             stopOnError: true,
-            port: this.instance.config.get('server.port')
+            port: this.instance.config.get('server.port'),
+            host: this.instance.config.get('server.host', 'localhost')
         }, options || {});
 
         return portPolling(options).catch((err) => {

--- a/lib/utils/port-polling.js
+++ b/lib/utils/port-polling.js
@@ -20,7 +20,9 @@ module.exports = function portPolling(options) {
 
     const connectToGhostSocket = (() => {
         return new Promise((resolve, reject) => {
-            const ghostSocket = net.connect(options.port);
+            // if host is specified and is *not* 0.0.0.0 (listen on all ips), use the custom host
+            const host = options.host && options.host !== '0.0.0.0' ? options.host : 'localhost';
+            const ghostSocket = net.connect(options.port, host);
             let delayOnConnectTimeout;
 
             // inactivity timeout

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -71,6 +71,7 @@ describe('Unit: Process Manager', function () {
         it('calls portPolling with options', function () {
             const config = getConfigStub();
             config.get.withArgs('server.port').returns(2368);
+            config.get.withArgs('server.host').returns('10.0.1.0');
             portPollingStub.resolves();
 
             const instance = new ProcessManager({}, {}, {config: config});
@@ -78,11 +79,12 @@ describe('Unit: Process Manager', function () {
 
             return instance.ensureStarted({logSuggestion: 'test'}).then(() => {
                 expect(portPollingStub.calledOnce).to.be.true;
-                expect(config.get.calledOnce).to.be.true;
+                expect(config.get.calledTwice).to.be.true;
                 expect(portPollingStub.calledWithExactly({
                     logSuggestion: 'test',
                     stopOnError: true,
-                    port: 2368
+                    port: 2368,
+                    host: '10.0.1.0'
                 })).to.be.true;
                 expect(stopStub.called).to.be.false;
             });
@@ -91,6 +93,7 @@ describe('Unit: Process Manager', function () {
         it('throws error without stopping if stopOnError is false', function () {
             const config = getConfigStub();
             config.get.withArgs('server.port').returns(2368);
+            config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
             const instance = new ProcessManager({}, {}, {config: config});
@@ -103,7 +106,8 @@ describe('Unit: Process Manager', function () {
                 expect(portPollingStub.calledOnce).to.be.true;
                 expect(portPollingStub.calledWithExactly({
                     stopOnError: false,
-                    port: 2368
+                    port: 2368,
+                    host: 'localhost'
                 })).to.be.true;
                 expect(stopStub.called).to.be.false;
             });
@@ -112,6 +116,7 @@ describe('Unit: Process Manager', function () {
         it('throws error and calls stop if stopOnError is true', function () {
             const config = getConfigStub();
             config.get.withArgs('server.port').returns(2368);
+            config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
             const instance = new ProcessManager({}, {}, {config: config});
@@ -121,11 +126,12 @@ describe('Unit: Process Manager', function () {
                 expect(false, 'Error should have been thrown').to.be.true;
             }).catch((err) => {
                 expect(err.message).to.equal('test error');
-                expect(config.get.calledOnce).to.be.true;
+                expect(config.get.calledTwice).to.be.true;
                 expect(portPollingStub.calledOnce).to.be.true;
                 expect(portPollingStub.calledWithExactly({
                     stopOnError: true,
-                    port: 2368
+                    port: 2368,
+                    host: 'localhost'
                 })).to.be.true;
                 expect(stopStub.calledOnce).to.be.true;
             });
@@ -134,6 +140,7 @@ describe('Unit: Process Manager', function () {
         it('throws error and calls stop (swallows stop error) if stopOnError is true', function () {
             const config = getConfigStub();
             config.get.withArgs('server.port').returns(2368);
+            config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
             const instance = new ProcessManager({}, {}, {config: config});
@@ -143,11 +150,12 @@ describe('Unit: Process Manager', function () {
                 expect(false, 'Error should have been thrown').to.be.true;
             }).catch((err) => {
                 expect(err.message).to.equal('test error');
-                expect(config.get.calledOnce).to.be.true;
+                expect(config.get.calledTwice).to.be.true;
                 expect(portPollingStub.calledOnce).to.be.true;
                 expect(portPollingStub.calledWithExactly({
                     stopOnError: true,
-                    port: 2368
+                    port: 2368,
+                    host: 'localhost'
                 })).to.be.true;
                 expect(stopStub.calledOnce).to.be.true;
             });

--- a/test/unit/utils/port-polling-spec.js
+++ b/test/unit/utils/port-polling-spec.js
@@ -32,7 +32,7 @@ describe('Unit: Utils > portPolling', function () {
             }
         };
 
-        sandbox.stub(net, 'connect').returns(netStub);
+        const connectStub = sandbox.stub(net, 'connect').returns(netStub);
 
         return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100})
             .then(() => {
@@ -42,6 +42,8 @@ describe('Unit: Utils > portPolling', function () {
                 expect(err.options.suggestion).to.exist;
                 expect(err.message).to.eql('Ghost did not start.');
                 expect(err.err.message).to.eql('whoops');
+                expect(connectStub.callCount).to.equal(4);
+                expect(connectStub.calledWithExactly(1111, 'localhost'), 'uses localhost by default').to.be.true;
                 expect(netStub.destroy.callCount).to.eql(4);
             });
     });
@@ -65,15 +67,17 @@ describe('Unit: Utils > portPolling', function () {
             }
         };
 
-        sandbox.stub(net, 'connect').returns(netStub);
+        const connectStub = sandbox.stub(net, 'connect').returns(netStub);
 
-        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100, delayOnConnectInMS: 150})
+        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100, delayOnConnectInMS: 150, host: '0.0.0.0'})
             .then(() => {
                 throw new Error('Expected error');
             })
             .catch((err) => {
                 expect(err.options.suggestion).to.exist;
                 expect(err.message).to.eql('Ghost did not start.');
+                expect(connectStub.calledTwice).to.be.true;
+                expect(connectStub.calledWithExactly(1111, 'localhost'), 'uses localhost if host is 0.0.0.0').to.be.true;
                 expect(netStub.destroy.callCount).to.eql(2);
             });
     });
@@ -97,10 +101,12 @@ describe('Unit: Utils > portPolling', function () {
             }
         };
 
-        sandbox.stub(net, 'connect').returns(netStub);
+        const connectStub = sandbox.stub(net, 'connect').returns(netStub);
 
-        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100, delayOnConnectInMS: 150})
+        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100, delayOnConnectInMS: 150, host: '10.0.1.0'})
             .then(() => {
+                expect(connectStub.calledTwice).to.be.true;
+                expect(connectStub.calledWithExactly(1111, '10.0.1.0'), 'uses custom host').to.be.true;
                 expect(netStub.destroy.callCount).to.eql(2);
             })
             .catch((err) => {


### PR DESCRIPTION
closes #643
- if the host is specified and isn't 0.0.0.0, use the custom host, otherwise use localhost