### PR TITLE
perf(bootstrap): swap out `npm root` call for global-modules dep

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -92,6 +92,7 @@ const bootstrap = {
      * @param Yargs yargs instance
      */
     run: function run(argv, yargs) {
+        debug('Starting bootstrap process');
         // Look for any available extensions, including ones built-in to the CLI itself
         const extensions = findExtensions();
         debug(`Found ${extensions.length} extensions: ${extensions.map((ext) => ext.pkg.name).join(', ')}`);

--- a/lib/utils/find-extensions.js
+++ b/lib/utils/find-extensions.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const findPlugins = require('find-plugins');
 const createDebug = require('debug');
-const execa = require('execa');
 
 const debug = createDebug('ghost-cli:find-extensions');
 
@@ -19,8 +18,8 @@ const localExtensions = [
  * @return Array array containing the package.json and dir of any found extensions
  */
 module.exports = function findExtensions() {
-    const npmRoot = execa.shellSync('npm root -g').stdout;
-    debug('searching for extensions');
+    const npmRoot = require('global-modules');
+    debug(`searching for extensions in ${npmRoot}`);
 
     return findPlugins({
         keyword: 'ghost-cli-extension',

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "fs-extra": "5.0.0",
     "generate-password": "1.3.0",
     "ghost-ignition": "2.8.18",
+    "global-modules": "1.0.0",
     "got": "8.0.2",
     "inquirer": "3.3.0",
     "is-running": "2.1.0",

--- a/test/unit/utils/find-extensions-spec.js
+++ b/test/unit/utils/find-extensions-spec.js
@@ -30,7 +30,7 @@ describe('Unit: Utils > find-extensions', function () {
 
         findExtensions = proxyquire(modulePath, {
             'find-plugins': findStub,
-            execa: {shellSync: () => ({stdout: '.'})}
+            'global-modules': '.'
         });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,6 +1268,12 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 ext-list@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/ext-list/-/ext-list-2.2.2.tgz#0b98e64ed82f5acf0f2931babf69212ef52ddd37"
@@ -1667,6 +1673,24 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
+global-modules@1.0.0, global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
+
 globals@^11.0.1:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
@@ -1831,6 +1855,12 @@ he@1.1.1:
 hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
+
+homedir-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
+  dependencies:
+    parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
   version "2.4.2"
@@ -2114,6 +2144,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -2978,6 +3012,10 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -3313,6 +3351,13 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+resolve-dir@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -4019,15 +4064,15 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.8, which@^1.2.9:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+which@^1.2.14, which@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
 
-which@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+which@^1.2.8, which@^1.2.9:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
no issue
- increase startup perf time by not shelling out to npm and instead using 'global-modules'
- add extra bootstrap cli debug statement to see startup times more accurately

Came across this as I was doing some work on the command loading section - this should make startup times a _bit_ quicker. Here are some results based on some initial testing I did (2017 mbp - 16gb ram):

Before this change:
```
acburdine@Austins-MacBook-Pro ~/Projects/Ghost/cli  (master *) $ DEBUG=ghost-cli:* ghost -v
  ghost-cli:bootstrap Starting bootstrap process +0ms
  ghost-cli:find-extensions searching for extensions +0ms
  ghost-cli:bootstrap Found 4 extensions: ... +454ms
  ghost-cli:bootstrap loading built-in commands +1ms
  ghost-cli:bootstrap loading commands from extensions +0ms
  ghost-cli:bootstrap discovered commands: buster, config, doctor, install, log, ls, migrate, restart, run, setup, start, stop, uninstall, update, version, adapter +1ms
  ghost-cli:command adding configuration for version +0ms
  ghost-cli:command building options for version +26ms
  ghost-cli:command running command version +28ms
Ghost-CLI version: 1.5.2
```
^ we can see a delay of about 500ms - in testing I saw it go up as high as 900ms.

After this change:
```
acburdine@Austins-MacBook-Pro ~/Projects/Ghost/cli  (master *) $ DEBUG=ghost-cli:* ghost -v
  ghost-cli:bootstrap Starting bootstrap process +0ms
  ghost-cli:find-extensions searching for extensions +0ms
  ghost-cli:bootstrap Found 4 extensions: ... +55ms
  ghost-cli:bootstrap loading built-in commands +0ms
  ghost-cli:bootstrap loading commands from extensions +1ms
  ghost-cli:bootstrap discovered commands: buster, config, doctor, install, log, ls, migrate, restart, run, setup, start, stop, uninstall, update, version, adapter +0ms
  ghost-cli:command adding configuration for version +0ms
  ghost-cli:command building options for version +16ms
  ghost-cli:command running command version +31ms
Ghost-CLI version: 1.5.2
```
^ there is now only a 55ms delay 🎉 