### PR TITLE
feat: make ghost (stop | start |  restart) more graceful

### DIFF
--- a/lib/commands/restart.js
+++ b/lib/commands/restart.js
@@ -6,11 +6,12 @@ class RestartCommand extends Command {
         const instance = this.system.getInstance();
 
         if (!instance.running()) {
-            return Promise.reject(new Error('Ghost instance is not currently running.'));
+            const StartCommand = require('./start');
+            this.ui.log('Ghost instance is not running! Starting...', 'yellow');
+            return this.runCommand(StartCommand);
         }
 
         instance.loadRunningEnvironment(true);
-
         return this.ui.run(instance.process.restart(process.cwd(), this.system.environment), 'Restarting Ghost');
     }
 }

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -26,7 +26,8 @@ class StartCommand extends Command {
         const runOptions = {quiet: argv.quiet};
 
         if (instance.running()) {
-            return Promise.reject(new Error('Ghost is already running. Use `ghost ls` to see details.'));
+            this.ui.log('Ghost is already running! Run `ghost ls` for more information', 'green');
+            return Promise.resolve();
         }
 
         instance.checkEnvironment();

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -42,7 +42,8 @@ class StopCommand extends Command {
         checkValidInstall('stop');
 
         if (!instance.running()) {
-            return Promise.reject(new errors.SystemError('No running Ghost instance found here.'));
+            this.ui.log('Ghost is already stopped! Nothing to do here.', 'green');
+            return Promise.resolve();
         }
 
         instance.loadRunningEnvironment();

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -22,17 +22,17 @@ describe('Unit: Commands > Start', function () {
             };
         });
 
-        it('doesn\'t start a running instance', function () {
+        it('gracefully notifies of already running instance', function () {
             const runningStub = sinon.stub().returns(true)
+            const logStub = sinon.stub();
+            const ui = {log: logStub};
+            const start = new StartCommand(ui, mySystem);
             myInstance.running = runningStub;
-            const start = new StartCommand({}, mySystem);
 
             return start.run({}).then(() => {
-                expect(false, 'Promise should have rejected').to.be.true;
-            }).catch((error) => {
-                expect(error).to.be.ok;
-                expect(error.message).to.match(/^Ghost is already running/);
                 expect(runningStub.calledOnce).to.be.true;
+                expect(logStub.calledOnce).to.be.true;
+                expect(logStub.args[0][0]).to.match(/Ghost is already running!/);
             });
         });
 

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -55,18 +55,19 @@ describe('Unit: Commands > Stop', function () {
             }
         });
 
-        it('doesn\'t stop stopped instances', function () {
-            const runningStub = sinon.stub().returns(false);
-            const gIstub = sinon.stub().returns({running: runningStub});
-            const context = {system: {getInstance: gIstub}};
+        it('gracefully notifies of already stopped instance', function () {
+            const runningFake = () => false;
+            const gIfake = () => ({running: runningFake});
+            const logStub = sinon.stub();
             const stop = proxiedCommand();
+            const context = {
+                system: {getInstance: gIfake},
+                ui: {log: logStub}
+            };
 
             return stop.run.call(context, {}).then(() => {
-                expect(false, 'Promise should have rejected').to.be.true;
-            }).catch((error) => {
-                expect(error).to.be.ok;
-                expect(error instanceof errors.SystemError).to.be.true;
-                expect(error.message).to.match(/No running Ghost instance/);
+                expect(logStub.calledOnce).to.be.true;
+                expect(logStub.args[0][0]).to.match(/Ghost is already stopped!/);
             });
         });
 


### PR DESCRIPTION
closes #649 

- `ghost stop` notifies user and exits if instance is already stopped
- `ghost start` notifies user and informs of `ghost ls` command for more information
- `ghost restart` notifies user and runs start command if instance is not running already

There's another PR coming up to finish the minor refactor of the restart command!