### PR TITLE
fix(utils): differentiate root command error messages for DO

### DIFF
--- a/lib/utils/check-root-user.js
+++ b/lib/utils/check-root-user.js
@@ -22,9 +22,19 @@ function checkRootUser(command) {
 
     if (isOneClickInstall) {
         // We have a Digitalocean one click installation
-        console.error(`${chalk.yellow('We discovered that you are using the Digitalocean One-Click install.')}
+        if (!isRootInstall()) {
+            // CASE: the user uses either the new DO image, where installations are following our setup guid (aka not-root),
+            // or the user followed the fix root user guide already, but the user uses root to run the command
+            console.error(`${chalk.yellow('Can\'t run command as \'root\' user.')}
+Please use the user you set up in the installation process, or create a new user with regular account privileges and use this user to run 'ghost ${command}'.
+See ${chalk.underline.green('https://docs.ghost.org/docs/install#section-create-a-new-user')} for more information\n`);
+        } else {
+            // CASE: the ghost installation folder is owned by root. The user needs to migrate the installation
+            // to a non-root and follow the instructions.
+            console.error(`${chalk.yellow('We discovered that you are using the Digitalocean One-Click install.')}
 You need to create a user with regular account privileges and migrate your installation to use this user.
 Please follow the steps here: ${chalk.underline.green('https://docs.ghost.org/docs/troubleshooting#section-fix-root-user')} to fix your setup.\n`);
+        }
 
         // TODO: remove this 4 versions after 1.5.0
         if (includes(allowedCommands, command)) {


### PR DESCRIPTION
no issue

Fixes an issue for DigitalOcean One-Click installs, that already moved their installation (or are using the updated image) and in both cases have the ghost folder not owned by `root`, where they would be shown the message to follow the 'fix root install' guide, rather than the normal message to not use `root` and switch to the already existing user.