### PR TITLE
feat(doctor): prevent installations with ghost user

### DIFF
--- a/lib/commands/doctor/checks/index.js
+++ b/lib/commands/doctor/checks/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const nodeVersion = require('./node-version');
+const loggedInUser = require('./logged-in-user');
 const loggedInGhostUser = require('./logged-in-ghost-user');
 const loggedInUserOwner = require('./logged-in-user-owner');
 const installFolderPermissions = require('./install-folder-permissions');
@@ -13,6 +14,7 @@ const checkMemory = require('./check-memory');
 
 module.exports = [
     nodeVersion,
+    loggedInUser,
     loggedInGhostUser,
     loggedInUserOwner,
     installFolderPermissions,

--- a/lib/commands/doctor/checks/logged-in-user.js
+++ b/lib/commands/doctor/checks/logged-in-user.js
@@ -1,0 +1,28 @@
+'use strict';
+const errors = require('../../../errors');
+const chalk = require('chalk');
+const ghostUser = require('../../../utils/use-ghost-user');
+
+const taskTitle = 'Checking logged in user';
+
+function loggedInUser() {
+    const uid = process.getuid();
+    const ghostStats = ghostUser.getGhostUid();
+
+    if (ghostStats && ghostStats.uid === uid) {
+        throw new errors.SystemError({
+            message: 'You can\'t install Ghost with a user called `ghost`. Please use a different user(name).',
+            help: `${chalk.green('https://docs.ghost.org/docs/install#section-create-a-new-user')}`,
+            task: taskTitle
+        });
+    }
+
+    return;
+}
+
+module.exports = {
+    title: taskTitle,
+    task: loggedInUser,
+    enabled: (ctx) => !ctx.local && !(ctx.instance && ctx.instance.process.name === 'local') && ctx.system.platform.linux && !(ctx.argv && ctx.argv.process === 'local'),
+    category: ['install']
+};

--- a/test/unit/commands/doctor/checks/logged-in-user-spec.js
+++ b/test/unit/commands/doctor/checks/logged-in-user-spec.js
@@ -1,0 +1,84 @@
+'use strict';
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const errors = require('../../../../../lib/errors');
+const ghostUser = require('../../../../../lib/utils/use-ghost-user');
+
+const loggedInUser = require('../../../../../lib/commands/doctor/checks/logged-in-user');
+
+describe('Unit: Doctor Checks > loggedInUser', function () {
+    const sandbox = sinon.sandbox.create();
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it('enabled works', function () {
+        expect(loggedInUser.enabled({
+            local: true,
+            system: {platform: {linux: true}},
+            argv: {}
+        }), 'false if local is true').to.be.false;
+        expect(loggedInUser.enabled({
+            local: false,
+            instance: {process: {name: 'local'}},
+            system: {platform: {linux: false}}
+        }), 'false if local is false and process name is local').to.be.false;
+        expect(loggedInUser.enabled({
+            local: false,
+            instance: {process: {name: 'systemd'}},
+            system: {platform: {linux: false}}
+        }), 'false if local is false and process name is not local and platform is not linux').to.be.false;
+        expect(loggedInUser.enabled({
+            local: false,
+            instance: {process: {name: 'systemd'}},
+            system: {platform: {linux: true}}
+        }), 'true if local is false and process name is not local and platform is linux').to.be.true;
+        expect(loggedInUser.enabled({
+            local: false,
+            instance: {process: {name: 'systemd'}},
+            system: {platform: {linux: true}},
+            argv: {process: 'local'}
+        }), 'false if local is false and process name is not local and platform is linux, but argv local is given').to.be.false;
+    });
+
+    it('rejects if user name is ghost', function () {
+        const processStub = sandbox.stub(process, 'getuid').returns(501);
+        const ghostUserStub = sandbox.stub(ghostUser, 'getGhostUid').returns({uid: 501, guid: 501});
+
+        try {
+            loggedInUser.task();
+        } catch (error) {
+            expect(error).to.exist;
+            expect(error).to.be.an.instanceof(errors.SystemError);
+            expect(processStub.calledOnce).to.be.true;
+            expect(ghostUserStub.calledOnce).to.be.true;
+        }
+    });
+
+    it('passes if user name is not ghost', function () {
+        const processStub = sandbox.stub(process, 'getuid').returns(1000);
+        const ghostUserStub = sandbox.stub(ghostUser, 'getGhostUid').returns(false);
+
+        try {
+            loggedInUser.task();
+            expect(processStub.calledOnce).to.be.true;
+            expect(ghostUserStub.calledOnce).to.be.true;
+        } catch (error) {
+            expect(error).to.not.exist;
+        }
+    });
+
+    it('passes if ghost user exists but not currently used', function () {
+        const processStub = sandbox.stub(process, 'getuid').returns(1000);
+        const ghostUserStub = sandbox.stub(ghostUser, 'getGhostUid').returns({uid: 501, guid: 501});
+
+        try {
+            loggedInUser.task();
+            expect(processStub.calledOnce).to.be.true;
+            expect(ghostUserStub.calledOnce).to.be.true;
+        } catch (error) {
+            expect(error).to.not.exist;
+        }
+    });
+});


### PR DESCRIPTION
refs #47

- Adds a check to the `install` category
- Check is disabled for local installs and platforms that are not linux
- Check will prevent user from installation, if the `ghost` user exists and user is logged in as such
- Adds tests. Still 💯

Outcome:
![image](https://user-images.githubusercontent.com/8037602/36526788-1ed56bc6-17e2-11e8-914d-ca7a30177eb2.png)
