### PR TITLE
feat(process-manager): allow process isRunning to return a promise

### DIFF
--- a/lib/commands/doctor/checks/validate-config.js
+++ b/lib/commands/doctor/checks/validate-config.js
@@ -10,38 +10,48 @@ const advancedOptions = require('../../config/advanced');
 
 const taskTitle = 'Validating config';
 
-function validateConfig(ctx) {
-    const config = Config.exists(path.join(process.cwd(), `config.${ctx.system.environment}.json`));
-
-    if (config === false) {
-        return Promise.reject(new errors.ConfigError({
-            environment: ctx.system.environment,
-            message: 'Config file is not valid JSON',
-            task: taskTitle
-        }));
+function validateConfig(ctx, task) {
+    if (!ctx.instance) {
+        return task.skip('Instance not set');
     }
 
-    const configValidations = filter(advancedOptions, cfg => cfg.validate);
-
-    return Promise.each(configValidations, (configItem) => {
-        const key = configItem.configPath || configItem.name
-        const value = get(config, key);
-
-        if (!value) {
-            return;
+    return ctx.instance.running().then((isRunning) => {
+        if (isRunning) {
+            return task.skip('Instance is currently running');
         }
 
-        return Promise.resolve(configItem.validate(value)).then((validated) => {
-            if (validated !== true) {
-                return Promise.reject(new errors.ConfigError({
-                    config: {
-                        [key]: value
-                    },
-                    message: validated,
-                    environment: ctx.system.environment,
-                    task: taskTitle
-                }));
+        const config = Config.exists(path.join(process.cwd(), `config.${ctx.system.environment}.json`));
+
+        if (config === false) {
+            return Promise.reject(new errors.ConfigError({
+                environment: ctx.system.environment,
+                message: 'Config file is not valid JSON',
+                task: taskTitle
+            }));
+        }
+
+        const configValidations = filter(advancedOptions, cfg => cfg.validate);
+
+        return Promise.each(configValidations, (configItem) => {
+            const key = configItem.configPath || configItem.name
+            const value = get(config, key);
+
+            if (!value) {
+                return;
             }
+
+            return Promise.resolve(configItem.validate(value)).then((validated) => {
+                if (validated !== true) {
+                    return Promise.reject(new errors.ConfigError({
+                        config: {
+                            [key]: value
+                        },
+                        message: validated,
+                        environment: ctx.system.environment,
+                        task: taskTitle
+                    }));
+                }
+            });
         });
     });
 }
@@ -49,6 +59,5 @@ function validateConfig(ctx) {
 module.exports = {
     title: taskTitle,
     task: validateConfig,
-    skip: (ctx) => ctx.instance && ctx.instance.process.isRunning(ctx.instance.dir),
     category: ['start']
 }

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -22,53 +22,53 @@ class LogCommand extends Command {
             return Promise.reject(new errors.SystemError(`Ghost instance '${argv.name}' does not exist`));
         }
 
-        if (instance.running()) {
-            instance.loadRunningEnvironment();
-        } else {
-            instance.checkEnvironment();
-        }
-
-        // Check if logging file transport is set in config
-        if (!includes(instance.config.get('logging.transports', []), 'file')) {
-            // TODO: fallback to process manager log retrieval?
-            return Promise.reject(new errors.ConfigError({
-                config: {
-                    'logging.transports': instance.config.get('logging.transports').join(', ')
-                },
-                message: 'You have excluded file logging in your ghost config.' +
-                    'Please add it to your transport config to use this command.',
-                environment: this.system.environment
-            }));
-        }
-
-        const logFileName = path.join(instance.dir, 'content/logs', `${instance.config.get('url').replace(/[^\w]/gi, '_')}_${this.system.environment}${argv.error ? '.error' : ''}.log`);
-        const prettyStream = new PrettyStream();
-
-        if (!fs.existsSync(logFileName)) {
-            if (argv.follow) {
-                this.ui.log('Log file has not been created yet, `--follow` only works on existing files', 'yellow');
+        return instance.running().then((running) => {
+            if (!running) {
+                instance.checkEnvironment();
             }
 
-            return Promise.resolve();
-        }
-
-        prettyStream.on('error', (error) => {
-            if (!(error instanceof SyntaxError)) {
-                throw error;
+            // Check if logging file transport is set in config
+            if (!includes(instance.config.get('logging.transports', []), 'file')) {
+                // TODO: fallback to process manager log retrieval?
+                return Promise.reject(new errors.ConfigError({
+                    config: {
+                        'logging.transports': instance.config.get('logging.transports').join(', ')
+                    },
+                    message: 'You have excluded file logging in your ghost config.' +
+                        'Please add it to your transport config to use this command.',
+                    environment: this.system.environment
+                }));
             }
-        });
 
-        prettyStream.pipe(this.ui.stdout);
+            const logFileName = path.join(instance.dir, 'content/logs', `${instance.config.get('url').replace(/[^\w]/gi, '_')}_${this.system.environment}${argv.error ? '.error' : ''}.log`);
+            const prettyStream = new PrettyStream();
 
-        return lastLines.read(logFileName, argv.number).then((lines) => {
-            lines.trim().split('\n').forEach(line => prettyStream.write(line));
+            if (!fs.existsSync(logFileName)) {
+                if (argv.follow) {
+                    this.ui.log('Log file has not been created yet, `--follow` only works on existing files', 'yellow');
+                }
 
-            if (argv.follow) {
-                const Tail = require('tail').Tail;
-
-                const tail = new Tail(logFileName);
-                tail.on('line', (line) => prettyStream.write(line, 'utf8'));
+                return Promise.resolve();
             }
+
+            prettyStream.on('error', (error) => {
+                if (!(error instanceof SyntaxError)) {
+                    throw error;
+                }
+            });
+
+            prettyStream.pipe(this.ui.stdout);
+
+            return lastLines.read(logFileName, argv.number).then((lines) => {
+                lines.trim().split('\n').forEach(line => prettyStream.write(line));
+
+                if (argv.follow) {
+                    const Tail = require('tail').Tail;
+
+                    const tail = new Tail(logFileName);
+                    tail.on('line', (line) => prettyStream.write(line, 'utf8'));
+                }
+            });
         });
     }
 }

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -4,20 +4,22 @@ const Command = require('../command');
 class LsCommand extends Command {
     run() {
         const chalk = require('chalk');
+        const Promise = require('bluebird');
 
-        const instances = this.system.getAllInstances();
-        const rows = instances.map((instance) => {
-            const summary = instance.summary();
+        return this.system.getAllInstances().then((instances) => {
+            return Promise.map(instances, (instance) => {
+                return instance.summary().then((summary) => {
+                    if (!summary.running) {
+                        return [summary.name, summary.dir, summary.version, chalk.red('stopped'), chalk.red('n/a'), chalk.red('n/a'), chalk.red('n/a')];
+                    }
 
-            if (!summary.running) {
-                return [summary.name, summary.dir, summary.version, chalk.red('stopped'), chalk.red('n/a'), chalk.red('n/a'), chalk.red('n/a')];
-            }
-
-            return [summary.name, summary.dir, summary.version, `${chalk.green('running')} (${summary.mode})`, summary.url, summary.port, summary.process];
-        });
-
-        this.ui.table(['Name', 'Location', 'Version', 'Status', 'URL', 'Port', 'Process Manager'], rows, {
-            style: {head: ['cyan']}
+                    return [summary.name, summary.dir, summary.version, `${chalk.green('running')} (${summary.mode})`, summary.url, summary.port, summary.process];
+                });
+            });
+        }).then((rows) => {
+            this.ui.table(['Name', 'Location', 'Version', 'Status', 'URL', 'Port', 'Process Manager'], rows, {
+                style: {head: ['cyan']}
+            });
         });
     }
 }

--- a/lib/commands/restart.js
+++ b/lib/commands/restart.js
@@ -5,14 +5,16 @@ class RestartCommand extends Command {
     run() {
         const instance = this.system.getInstance();
 
-        if (!instance.running()) {
-            const StartCommand = require('./start');
-            this.ui.log('Ghost instance is not running! Starting...', 'yellow');
-            return this.runCommand(StartCommand);
-        }
+        return instance.running().then((isRunning) => {
+            if (!isRunning) {
+                const StartCommand = require('./start');
+                this.ui.log('Ghost instance is not running! Starting...', 'yellow');
+                return this.runCommand(StartCommand);
+            }
 
-        instance.loadRunningEnvironment(true);
-        return this.ui.run(instance.process.restart(process.cwd(), this.system.environment), 'Restarting Ghost');
+            instance.loadRunningEnvironment(true);
+            return this.ui.run(instance.process.restart(process.cwd(), this.system.environment), 'Restarting Ghost');
+        });
     }
 }
 

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -25,44 +25,46 @@ class StartCommand extends Command {
         const instance = this.system.getInstance();
         const runOptions = {quiet: argv.quiet};
 
-        if (instance.running()) {
-            this.ui.log('Ghost is already running! Run `ghost ls` for more information', 'green');
-            return Promise.resolve();
-        }
+        return instance.running().then((isRunning) => {
+            if (isRunning) {
+                this.ui.log('Ghost is already running! Run `ghost ls` for more information', 'green');
+                return Promise.resolve();
+            }
 
-        instance.checkEnvironment();
+            instance.checkEnvironment();
 
-        return this.runCommand(DoctorCommand, Object.assign({
-            categories: ['start'],
-            quiet: true
-        }, argv)).then(() => {
-            const processInstance = instance.process;
+            return this.runCommand(DoctorCommand, Object.assign({
+                categories: ['start'],
+                quiet: true
+            }, argv)).then(() => {
+                const processInstance = instance.process;
 
-            const start = () => {
-                return Promise.resolve(processInstance.start(process.cwd(), this.system.environment))
-                    .then(() => { instance.running(this.system.environment); });
-            };
+                const start = () => {
+                    return Promise.resolve(processInstance.start(process.cwd(), this.system.environment))
+                        .then(() => { instance.running(this.system.environment); });
+                };
 
-            return this.ui.run(start, 'Starting Ghost', runOptions).then(() => {
-                // If process manager doesn't support enable behavior OR it's already enabled, don't try to enable
-                if (!ProcessManager.supportsEnableBehavior(processInstance) || processInstance.isEnabled()) {
-                    argv.enable = false;
-                }
-
-                if (!argv.enable) {
-                    return Promise.resolve();
-                }
-
-                return this.ui.run(processInstance.enable(), 'Enabling Ghost instance startup on server boot', runOptions);
-            }).then(() => {
-                if (!argv.quiet) {
-                    this.ui.log(`You can access your blog at ${instance.config.get('url')}`, 'cyan');
-
-                    if (instance.config.get('mail.transport') === 'Direct') {
-                        this.ui.log('\nGhost uses direct mail by default', 'green');
-                        this.ui.log('To set up an alternative email method read our docs at https://docs.ghost.org/docs/mail-config', 'green');
+                return this.ui.run(start, 'Starting Ghost', runOptions).then(() => {
+                    // If process manager doesn't support enable behavior OR it's already enabled, don't try to enable
+                    if (!ProcessManager.supportsEnableBehavior(processInstance) || processInstance.isEnabled()) {
+                        argv.enable = false;
                     }
-                }
+
+                    if (!argv.enable) {
+                        return Promise.resolve();
+                    }
+
+                    return this.ui.run(processInstance.enable(), 'Enabling Ghost instance startup on server boot', runOptions);
+                }).then(() => {
+                    if (!argv.quiet) {
+                        this.ui.log(`You can access your blog at ${instance.config.get('url')}`, 'cyan');
+
+                        if (instance.config.get('mail.transport') === 'Direct') {
+                            this.ui.log('\nGhost uses direct mail by default', 'green');
+                            this.ui.log('To set up an alternative email method read our docs at https://docs.ghost.org/docs/mail-config', 'green');
+                        }
+                    }
+                });
             });
         });
     }

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -41,18 +41,18 @@ class StopCommand extends Command {
 
         checkValidInstall('stop');
 
-        if (!instance.running()) {
-            this.ui.log('Ghost is already stopped! Nothing to do here.', 'green');
-            return Promise.resolve();
-        }
+        return instance.running().then((isRunning) => {
+            if (!isRunning) {
+                this.ui.log('Ghost is already stopped! Nothing to do here.', 'green');
+                return Promise.resolve();
+            }
 
-        instance.loadRunningEnvironment();
+            const stop = () => Promise.resolve(instance.process.stop(process.cwd())).then(() => {
+                instance.running(null);
+            });
 
-        const stop = () => Promise.resolve(instance.process.stop(process.cwd())).then(() => {
-            instance.running(null);
-        });
-
-        return this.ui.run(stop, 'Stopping Ghost', runOptions).then(() => {
+            return this.ui.run(stop, 'Stopping Ghost', runOptions);
+        }).then(() => {
             if (
                 argv.disable &&
                 ProcessManager.supportsEnableBehavior(instance.process) &&

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -23,12 +23,17 @@ class UninstallCommand extends Command {
 
             return this.ui.listr([{
                 title: 'Stopping Ghost',
-                skip: () => !instance.running(),
-                task: () => {
-                    instance.loadRunningEnvironment(true);
-                    // If the instance is currently running we need to make sure
-                    // it gets stopped and disabled if possible
-                    return this.runCommand(StopCommand, {quiet: true, disable: true});
+                task: (_, task) => {
+                    return instance.running().then((isRunning) => {
+                        if (!isRunning) {
+                            return task.skip('Instance is not running');
+                        }
+
+                        instance.loadRunningEnvironment(true);
+                        // If the instance is currently running we need to make sure
+                        // it gets stopped and disabled if possible
+                        return this.runCommand(StopCommand, {quiet: true, disable: true});
+                    });
                 }
             }, {
                 title: 'Removing content folder',

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -46,52 +46,54 @@ class UpdateCommand extends Command {
             context.installPath = path.join(process.cwd(), 'versions', context.version);
         }
 
-        if (instance.running()) {
-            instance.loadRunningEnvironment(true);
-        }
-
-        instance.checkEnvironment();
-
-        // TODO: add meaningful update checks after this task
-        const tasks = [{
-            title: 'Downloading and updating Ghost',
-            skip: (ctx) => ctx.rollback,
-            task: this.downloadAndUpdate
-        }, {
-            title: 'Stopping Ghost',
-            skip: (ctx) => !ctx.instance.running(),
-            task: this.stop.bind(this)
-        }, {
-            title: 'Linking latest Ghost and recording versions',
-            task: this.link
-        }, {
-            title: 'Running database migrations',
-            skip: (ctx) => ctx.rollback,
-            task: migrate
-        }, {
-            title: 'Restarting Ghost',
-            skip: () => !argv.restart,
-            task: this.restart.bind(this)
-        }, {
-            title: 'Removing old Ghost versions',
-            skip: (ctx) => ctx.rollback,
-            task: this.removeOldVersions
-        }];
-
-        return this.runCommand(DoctorCommand, Object.assign(
-            {quiet: true, categories: ['update']},
-            argv
-        )).then(() => {
-            return this.runCommand(MigrateCommand, {quiet: true})
-        }).then(() => {
-            return this.ui.run(() => this.version(context), 'Checking for latest Ghost version');
-        }).then((result) => {
-            if (!result) {
-                this.ui.log('All up to date!', 'cyan');
-                return;
+        return instance.running().then((isRunning) => {
+            if (isRunning) {
+                instance.loadRunningEnvironment(true);
             }
 
-            return this.ui.listr(tasks, context);
+            instance.checkEnvironment();
+
+            // TODO: add meaningful update checks after this task
+            const tasks = [{
+                title: 'Downloading and updating Ghost',
+                skip: (ctx) => ctx.rollback,
+                task: this.downloadAndUpdate
+            }, {
+                title: 'Stopping Ghost',
+                enabled: () => isRunning,
+                task: this.stop.bind(this)
+            }, {
+                title: 'Linking latest Ghost and recording versions',
+                task: this.link
+            }, {
+                title: 'Running database migrations',
+                skip: (ctx) => ctx.rollback,
+                task: migrate
+            }, {
+                title: 'Restarting Ghost',
+                skip: () => !argv.restart,
+                task: this.restart.bind(this)
+            }, {
+                title: 'Removing old Ghost versions',
+                skip: (ctx) => ctx.rollback,
+                task: this.removeOldVersions
+            }];
+
+            return this.runCommand(DoctorCommand, Object.assign(
+                {quiet: true, categories: ['update']},
+                argv
+            )).then(() => {
+                return this.runCommand(MigrateCommand, {quiet: true})
+            }).then(() => {
+                return this.ui.run(() => this.version(context), 'Checking for latest Ghost version');
+            }).then((result) => {
+                if (!result) {
+                    this.ui.log('All up to date!', 'cyan');
+                    return;
+                }
+
+                return this.ui.listr(tasks, context);
+            });
         });
     }
 

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -98,7 +98,7 @@ class Instance {
      * If arg specified, sets the running environment to the passed environment
      *
      * @param {String} environment Environment to set
-     * @return {Boolean} true if instance is running, otherwise false
+     * @return {Promise<Boolean>} true if instance is running, otherwise false
      *
      * @method running
      * @public
@@ -107,45 +107,54 @@ class Instance {
         if (environment !== undefined) {
             // setter
             this.cliConfig.set('running', environment).save();
-            return true;
+            return Promise.resolve(true);
         }
 
         if (!this.cliConfig.has('running')) {
             const currentEnvironment = this.system.development;
 
+            const envIsRunning = (environment) => {
+                if (!Config.exists(path.join(this.dir, `config.${environment}.json`))) {
+                    return Promise.resolve(false);
+                }
+
+                this.system.setEnvironment(environment === 'development');
+                return Promise.resolve(this.process.isRunning(this.dir)).then((running) => {
+                    if (running) {
+                        this.cliConfig.set('running', environment).save();
+                    }
+
+                    return running;
+                });
+            };
+
             // Check production environment first
-            if (Config.exists(path.join(this.dir, 'config.production.json'))) {
-                this.system.setEnvironment(false);
-
-                if (this.process.isRunning(this.dir)) {
-                    this.cliConfig.set('running', 'production').save();
+            return envIsRunning('production').then((production) => {
+                if (production) {
                     return true;
                 }
-            }
 
-            // Check development next
-            if (Config.exists(path.join(this.dir, 'config.development.json'))) {
-                this.system.setEnvironment(true);
+                // Check development next
+                return envIsRunning('development').then((development) => {
+                    if (development) {
+                        return true;
+                    }
 
-                if (this.process.isRunning(this.dir)) {
-                    this.cliConfig.set('running', 'development').save();
-                    return true;
-                }
-            }
-
-            this.system.setEnvironment(currentEnvironment);
-
-            return false;
+                    this.system.setEnvironment(currentEnvironment);
+                    return false;
+                });
+            });
         }
 
         this.loadRunningEnvironment();
 
-        if (!this.process.isRunning(this.dir)) {
-            this.cliConfig.set('running', null).save();
-            return false;
-        }
+        return Promise.resolve(this.process.isRunning(this.dir)).then((running) => {
+            if (!running) {
+                this.cliConfig.set('running', null).save();
+            }
 
-        return true;
+            return running;
+        });
     }
 
     /**
@@ -193,32 +202,32 @@ class Instance {
      * Gets a summary of this instance, comprised of various values from
      * the cliConfig and the ghost config
      *
-     * @return Object
+     * @return {Promise<Object>}
      * @method summary
      * @public
      */
     summary() {
-        if (!this.running()) {
+        return this.running().then((running) => {
+            if (!running) {
+                return {
+                    name: this.name,
+                    dir: this.dir.replace(os.homedir(), '~'),
+                    version: this.cliConfig.get('active-version'),
+                    running: false
+                };
+            }
+
             return {
                 name: this.name,
                 dir: this.dir.replace(os.homedir(), '~'),
+                running: true,
                 version: this.cliConfig.get('active-version'),
-                running: false
+                mode: this.system.environment,
+                url: this.config.get('url'),
+                port: this.config.get('server.port'),
+                process: this.process.name
             };
-        }
-
-        this.loadRunningEnvironment();
-
-        return {
-            name: this.name,
-            dir: this.dir.replace(os.homedir(), '~'),
-            running: true,
-            version: this.cliConfig.get('active-version'),
-            mode: this.system.environment,
-            url: this.config.get('url'),
-            port: this.config.get('server.port'),
-            process: this.process.name
-        };
+        });
     }
 
     /**

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -58,9 +58,9 @@ class ProcessManager {
         throw error;
     }
 
-    /* istanbul ignore next */
     isRunning() {
-        // Base Implementation
+        // Base Implementation - noop
+        return Promise.resolve(false);
     }
 
     /**

--- a/lib/system.js
+++ b/lib/system.js
@@ -213,6 +213,7 @@ class System {
      * Also removes any instances that no longer exist
      *
      * @param {Boolean} running If true, returns only running instances
+     * @return {Promise<Instance>} instances
      * @method getAllInstances
      * @public
      */
@@ -230,14 +231,20 @@ class System {
             }
 
             return this.getInstance(name);
-        }).filter((instance) => instance && (!running || instance.running()));
+        }).filter(Boolean);
 
         if (namesToRemove.length) {
             namesToRemove.forEach((name) => delete instances[name]);
             this.globalConfig.set('instances', instances).save();
         }
 
-        return result;
+        // If we're not filtering out stopped instances, just return the result
+        if (!running) {
+            return Promise.resolve(result);
+        }
+
+        // Return the result filtered by whether or not the instance is running
+        return Promise.filter(result, (instance) => instance.running());
     }
 
     /**

--- a/test/unit/commands/doctor/checks/validate-config-spec.js
+++ b/test/unit/commands/doctor/checks/validate-config-spec.js
@@ -6,7 +6,8 @@ const errors = require('../../../../../lib/errors');
 const setupEnv = require('../../../../utils/env');
 const advancedOpts = require('../../../../../lib/commands/config/advanced');
 
-const validateConfig = require('../../../../../lib/commands/doctor/checks/validate-config');
+const check = require('../../../../../lib/commands/doctor/checks/validate-config');
+const validateConfig = check.task;
 
 describe('Unit: Doctor Checks > validateConfig', function () {
     const sandbox = sinon.sandbox.create();
@@ -21,36 +22,58 @@ describe('Unit: Doctor Checks > validateConfig', function () {
         }
     });
 
+    it('skips if instance not set', function () {
+        const skipStub = sandbox.stub();
+
+        validateConfig({instance: null}, {skip: skipStub});
+        expect(skipStub.calledOnce).to.be.true;
+    });
+
     it('skips check, when instance is currently running', function () {
-        const isRunningStub = sinon.stub().returns(true);
-        expect(validateConfig.skip({instance: {process: {isRunning: isRunningStub}}}), 'true if current instance is running').to.be.true;
+        const runningStub = sandbox.stub().resolves(true);
+        const skipStub = sandbox.stub();
+
+        return validateConfig({instance: {running: runningStub}}, {skip: skipStub}).then(() => {
+            expect(runningStub.calledOnce).to.be.true;
+            expect(skipStub.calledOnce).to.be.true;
+        });
     });
 
     it('rejects if environment is passed and no config exists for that environment', function () {
         env = setupEnv();
         const cwdStub = sandbox.stub(process, 'cwd').returns(env.dir);
+        const runningStub = sandbox.stub().resolves(false);
 
-        return validateConfig.task({system: {environment: 'testing'}}).then(() => {
+        return validateConfig({
+            system: {environment: 'testing'},
+            instance: {running: runningStub}
+        }).then(() => {
             expect(false, 'error should have been thrown').to.be.true;
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.ConfigError);
             expect(error.message).to.match(/Config file is not valid JSON/);
             expect(error.options.environment).to.equal('testing');
             expect(cwdStub.calledOnce).to.be.true;
+            expect(runningStub.calledOnce).to.be.true;
         });
     });
 
     it('rejects if environment is passed and the config file is not valid json', function () {
         env = setupEnv({files: [{path: 'config.testing.json', contents: 'not json'}]});
         const cwdStub = sandbox.stub(process, 'cwd').returns(env.dir);
+        const runningStub = sandbox.stub().resolves(false);
 
-        return validateConfig.task({system: {environment: 'testing'}}).then(() => {
+        return validateConfig({
+            system: {environment: 'testing'},
+            instance: {running: runningStub}
+        }).then(() => {
             expect(false, 'error should have been thrown').to.be.true;
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.ConfigError);
             expect(error.message).to.match(/Config file is not valid JSON/);
             expect(error.options.environment).to.equal('testing');
             expect(cwdStub.calledOnce).to.be.true;
+            expect(runningStub.calledOnce).to.be.true;
         });
     });
 
@@ -60,8 +83,12 @@ describe('Unit: Doctor Checks > validateConfig', function () {
         const urlStub = sandbox.stub(advancedOpts.url, 'validate').returns('Invalid URL');
         const portStub = sandbox.stub(advancedOpts.port, 'validate').returns('Port is in use');
         sandbox.stub(process, 'cwd').returns(env.dir);
+        const runningStub = sandbox.stub().resolves(false);
 
-        return validateConfig.task({system: {environment: 'testing'}}).then(() => {
+        return validateConfig({
+            system: {environment: 'testing'},
+            instance: {running: runningStub}
+        }).then(() => {
             expect(false, 'error should have been thrown').to.be.true;
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.ConfigError);
@@ -79,8 +106,12 @@ describe('Unit: Doctor Checks > validateConfig', function () {
         const urlStub = sandbox.stub(advancedOpts.url, 'validate').returns(true);
         const portStub = sandbox.stub(advancedOpts.port, 'validate').returns(true);
         sandbox.stub(process, 'cwd').returns(env.dir);
+        const runningStub = sandbox.stub().resolves(false);
 
-        return validateConfig.task({system: {environment: 'testing'}}).then(() => {
+        return validateConfig({
+            system: {environment: 'testing'},
+            instance: {running: runningStub}
+        }).then(() => {
             expect(urlStub.called).to.be.false;
             expect(portStub.calledOnce).to.be.true;
             expect(portStub.calledWithExactly(2368)).to.be.true;

--- a/test/unit/commands/ls-spec.js
+++ b/test/unit/commands/ls-spec.js
@@ -8,13 +8,13 @@ const LsCommand = require('../../../lib/commands/ls');
 describe('Unit: Commands > ls', function () {
     it('outputs the correct data for instances that are running and not running', function () {
         const summaryStub = sinon.stub();
-        summaryStub.onFirstCall().returns({
+        summaryStub.onFirstCall().resolves({
             name: 'testa',
             dir: '/var/www/testa',
             version: '1.5.0',
             running: false
         });
-        summaryStub.onSecondCall().returns({
+        summaryStub.onSecondCall().resolves({
             name: 'testb',
             dir: '/var/www/testb',
             version: '1.2.0',
@@ -24,7 +24,7 @@ describe('Unit: Commands > ls', function () {
             port: 2369,
             process: 'systemd'
         });
-        summaryStub.onThirdCall().returns({
+        summaryStub.onThirdCall().resolves({
             name: 'testc',
             dir: '/var/www/testc',
             version: '1.3.0',
@@ -34,7 +34,7 @@ describe('Unit: Commands > ls', function () {
             port: 2370,
             process: 'local'
         });
-        const getAllInstancesStub = sinon.stub().returns([
+        const getAllInstancesStub = sinon.stub().resolves([
             {summary: summaryStub},
             {summary: summaryStub},
             {summary: summaryStub}
@@ -43,24 +43,25 @@ describe('Unit: Commands > ls', function () {
 
         const instance = new LsCommand({table: tableStub}, {getAllInstances: getAllInstancesStub});
 
-        instance.run();
-        expect(summaryStub.calledThrice).to.be.true;
-        expect(tableStub.calledOnce).to.be.true;
-        expect(tableStub.args[0][0]).to.deep
-            .equal(['Name', 'Location', 'Version', 'Status', 'URL', 'Port', 'Process Manager']);
-        const rows = tableStub.args[0][1];
-        expect(rows).to.be.an.instanceof(Array);
-        expect(rows).to.have.length(3);
+        return instance.run().then(() => {
+            expect(summaryStub.calledThrice).to.be.true;
+            expect(tableStub.calledOnce).to.be.true;
+            expect(tableStub.args[0][0]).to.deep
+                .equal(['Name', 'Location', 'Version', 'Status', 'URL', 'Port', 'Process Manager']);
+            const rows = tableStub.args[0][1];
+            expect(rows).to.be.an.instanceof(Array);
+            expect(rows).to.have.length(3);
 
-        const expected = [
-            ['testa', '/var/www/testa', '1.5.0', 'stopped', 'n/a', 'n/a', 'n/a'],
-            ['testb', '/var/www/testb', '1.2.0', 'running (production)', 'https://testa.com', 2369, 'systemd'],
-            ['testc', '/var/www/testc', '1.3.0', 'running (development)', 'http://localhost:2370', 2370, 'local']
-        ];
+            const expected = [
+                ['testa', '/var/www/testa', '1.5.0', 'stopped', 'n/a', 'n/a', 'n/a'],
+                ['testb', '/var/www/testb', '1.2.0', 'running (production)', 'https://testa.com', 2369, 'systemd'],
+                ['testc', '/var/www/testc', '1.3.0', 'running (development)', 'http://localhost:2370', 2370, 'local']
+            ];
 
-        expected.forEach((row, i) => {
-            row.forEach((prop, j) => {
-                expect(stripAnsi(rows[i][j])).to.equal(prop);
+            expected.forEach((row, i) => {
+                row.forEach((prop, j) => {
+                    expect(stripAnsi(rows[i][j])).to.equal(prop);
+                });
             });
         });
     });

--- a/test/unit/commands/restart-spec.js
+++ b/test/unit/commands/restart-spec.js
@@ -7,7 +7,7 @@ const RestartCommand = require(modulePath);
 
 describe('Unit: Command > Restart', function () {
     it('warns of stopped instance and starts instead', function () {
-        const instance = {running: () => false};
+        const instance = {running: () => Promise.resolve(false)};
         const logStub = sinon.stub();
         const ctx = {
             ui: {log: logStub},
@@ -31,7 +31,7 @@ describe('Unit: Command > Restart', function () {
         const instance = {
             process: {restart: restartStub},
             loadRunningEnvironment: lreStub,
-            running: () => 1
+            running: () => Promise.resolve(true)
         };
 
         const command = new RestartCommand({run: runStub}, {

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -13,7 +13,7 @@ describe('Unit: Commands > Start', function () {
         beforeEach(function () {
             myInstance = {
                 checkEnvironment: () => true,
-                running: () => false
+                running: () => Promise.resolve(false)
             };
 
             mySystem = {
@@ -23,7 +23,7 @@ describe('Unit: Commands > Start', function () {
         });
 
         it('gracefully notifies of already running instance', function () {
-            const runningStub = sinon.stub().returns(true)
+            const runningStub = sinon.stub().resolves(true)
             const logStub = sinon.stub();
             const ui = {log: logStub};
             const start = new StartCommand(ui, mySystem);
@@ -59,7 +59,7 @@ describe('Unit: Commands > Start', function () {
         });
 
         it('runs instance start', function () {
-            myInstance.running = sinon.stub();
+            myInstance.running = sinon.stub().resolves(false);
             myInstance.process = {start: sinon.stub()};
             mySystem.environment = 'Ghost';
             const ui = {

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -56,7 +56,7 @@ describe('Unit: Commands > Stop', function () {
         });
 
         it('gracefully notifies of already stopped instance', function () {
-            const runningFake = () => false;
+            const runningFake = () => Promise.resolve(false);
             const gIfake = () => ({running: runningFake});
             const logStub = sinon.stub();
             const stop = proxiedCommand();
@@ -74,7 +74,7 @@ describe('Unit: Commands > Stop', function () {
         it('calls process manger stop', function () {
             const stop = proxiedCommand();
             const stopStub = sinon.stub().resolves();
-            const runningStub = sinon.stub().returns(true);
+            const runningStub = sinon.stub().resolves(true);
             const gIstub = sinon.stub().returns({
                 running: runningStub,
                 process: {stop: stopStub},
@@ -105,7 +105,7 @@ describe('Unit: Commands > Stop', function () {
             const sEBstub = sinon.stub().returns(true);
             const disableStub = sinon.stub().resolves();
             const gIstub = sinon.stub().returns({
-                running: () => true,
+                running: () => Promise.resolve(true),
                 process: {
                     disable: disableStub,
                     stop: () => true,

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -28,7 +28,7 @@ describe('Unit: Commands > Update', function () {
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
-            fakeInstance.running.returns(true);
+            fakeInstance.running.resolves(true);
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(false);
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
@@ -69,7 +69,7 @@ describe('Unit: Commands > Update', function () {
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
-            fakeInstance.running.returns(true);
+            fakeInstance.running.resolves(true);
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(false);
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
@@ -102,7 +102,7 @@ describe('Unit: Commands > Update', function () {
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
-            fakeInstance.running.returns(false);
+            fakeInstance.running.resolves(false);
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(false);
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
@@ -158,7 +158,7 @@ describe('Unit: Commands > Update', function () {
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
-            fakeInstance.running.returns(true);
+            fakeInstance.running.resolves(true);
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(true);
             const stopStub = sinon.stub(cmdInstance, 'stop').resolves();
@@ -214,7 +214,7 @@ describe('Unit: Commands > Update', function () {
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
-            fakeInstance.running.returns(false);
+            fakeInstance.running.resolves(false);
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(true);
             sinon.stub(cmdInstance, 'stop').resolves();
@@ -265,7 +265,7 @@ describe('Unit: Commands > Update', function () {
             ui.run.callsFake(fn => fn());
             ui.listr.callsFake((tasks, ctx) => {
                 return Promise.each(tasks, (task) => {
-                    if (task.skip && task.skip(ctx)) {
+                    if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
                         return;
                     }
 
@@ -278,7 +278,7 @@ describe('Unit: Commands > Update', function () {
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
-            fakeInstance.running.returns(false);
+            fakeInstance.running.resolves(false);
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(true);
             const stopStub = sinon.stub(cmdInstance, 'stop').resolves();

--- a/test/unit/instance-spec.js
+++ b/test/unit/instance-spec.js
@@ -177,10 +177,11 @@ describe('Unit: Instance', function () {
                 get cliConfig() { return {set: setStub, save: saveStub}; }
             }
             const testInstance = new TestInstance({}, {}, '');
-            testInstance.running('testing');
 
-            expect(setStub.calledOnce).to.be.true;
-            expect(saveStub.calledOnce).to.be.true;
+            return testInstance.running('testing').then(() => {
+                expect(setStub.calledOnce).to.be.true;
+                expect(saveStub.calledOnce).to.be.true;
+            });
         });
 
         it('returns false if running property not set in config & neither config exists', function () {
@@ -192,12 +193,13 @@ describe('Unit: Instance', function () {
             const testInstance = new TestInstance({}, {development: true, setEnvironment: setEnvironmentStub}, '');
             const existsStub = sandbox.stub(Config, 'exists').returns(false);
 
-            const running = testInstance.running();
-            expect(running).to.be.false;
-            expect(hasStub.calledOnce).to.be.true;
-            expect(existsStub.calledTwice).to.be.true;
-            expect(setEnvironmentStub.calledOnce).to.be.true;
-            expect(setEnvironmentStub.calledWithExactly(true)).to.be.true;
+            return testInstance.running().then((running) => {
+                expect(running).to.be.false;
+                expect(hasStub.calledOnce).to.be.true;
+                expect(existsStub.calledTwice).to.be.true;
+                expect(setEnvironmentStub.calledOnce).to.be.true;
+                expect(setEnvironmentStub.calledWithExactly(true)).to.be.true;
+            });
         });
 
         it('queries process manager in production if running not set and prod config exists', function () {
@@ -212,16 +214,16 @@ describe('Unit: Instance', function () {
             const setEnvironmentStub = sandbox.stub();
             const testInstance = new TestInstance({}, {setEnvironment: setEnvironmentStub}, '/var/www/ghost');
 
-            const running = testInstance.running();
-
-            expect(running).to.be.true;
-            expect(configStub.has.calledOnce).to.be.true;
-            expect(existsStub.calledOnce).to.be.true;
-            expect(existsStub.calledWithExactly('/var/www/ghost/config.production.json')).to.be.true;
-            expect(isRunningStub.calledOnce).to.be.true;
-            expect(configStub.set.calledOnce).to.be.true;
-            expect(configStub.set.calledWithExactly('running', 'production')).to.be.true;
-            expect(configStub.save.calledOnce).to.be.true;
+            return testInstance.running().then((running) => {
+                expect(running).to.be.true;
+                expect(configStub.has.calledOnce).to.be.true;
+                expect(existsStub.calledOnce).to.be.true;
+                expect(existsStub.calledWithExactly('/var/www/ghost/config.production.json')).to.be.true;
+                expect(isRunningStub.calledOnce).to.be.true;
+                expect(configStub.set.calledOnce).to.be.true;
+                expect(configStub.set.calledWithExactly('running', 'production')).to.be.true;
+                expect(configStub.save.calledOnce).to.be.true;
+            });
         });
 
         it('queries process manager in dev if prod config not exists and dev config does', function () {
@@ -239,17 +241,17 @@ describe('Unit: Instance', function () {
             existsStub.onFirstCall().returns(false);
             existsStub.onSecondCall().returns(true);
 
-            const running = testInstance.running();
-
-            expect(running).to.be.true;
-            expect(configStub.has.calledOnce).to.be.true;
-            expect(existsStub.calledTwice).to.be.true;
-            expect(existsStub.calledWithExactly('/var/www/ghost/config.production.json')).to.be.true;
-            expect(existsStub.calledWithExactly('/var/www/ghost/config.development.json')).to.be.true;
-            expect(isRunningStub.calledOnce).to.be.true;
-            expect(configStub.set.calledOnce).to.be.true;
-            expect(configStub.set.calledWithExactly('running', 'development')).to.be.true;
-            expect(configStub.save.calledOnce).to.be.true;
+            return testInstance.running().then((running) => {
+                expect(running).to.be.true;
+                expect(configStub.has.calledOnce).to.be.true;
+                expect(existsStub.calledTwice).to.be.true;
+                expect(existsStub.calledWithExactly('/var/www/ghost/config.production.json')).to.be.true;
+                expect(existsStub.calledWithExactly('/var/www/ghost/config.development.json')).to.be.true;
+                expect(isRunningStub.calledOnce).to.be.true;
+                expect(configStub.set.calledOnce).to.be.true;
+                expect(configStub.set.calledWithExactly('running', 'development')).to.be.true;
+                expect(configStub.save.calledOnce).to.be.true;
+            });
         });
 
         it('queries process manager in dev if not running in prod and dev config exists', function () {
@@ -266,17 +268,17 @@ describe('Unit: Instance', function () {
             const setEnvironmentStub = sandbox.stub();
             const testInstance = new TestInstance({}, {setEnvironment: setEnvironmentStub}, '/var/www/ghost');
 
-            const running = testInstance.running();
-
-            expect(running).to.be.true;
-            expect(configStub.has.calledOnce).to.be.true;
-            expect(existsStub.calledTwice).to.be.true;
-            expect(existsStub.calledWithExactly('/var/www/ghost/config.production.json')).to.be.true;
-            expect(existsStub.calledWithExactly('/var/www/ghost/config.development.json')).to.be.true;
-            expect(isRunningStub.calledTwice).to.be.true;
-            expect(configStub.set.calledOnce).to.be.true;
-            expect(configStub.set.calledWithExactly('running', 'development')).to.be.true;
-            expect(configStub.save.calledOnce).to.be.true;
+            return testInstance.running().then((running) => {
+                expect(running).to.be.true;
+                expect(configStub.has.calledOnce).to.be.true;
+                expect(existsStub.calledTwice).to.be.true;
+                expect(existsStub.calledWithExactly('/var/www/ghost/config.production.json')).to.be.true;
+                expect(existsStub.calledWithExactly('/var/www/ghost/config.development.json')).to.be.true;
+                expect(isRunningStub.calledTwice).to.be.true;
+                expect(configStub.set.calledOnce).to.be.true;
+                expect(configStub.set.calledWithExactly('running', 'development')).to.be.true;
+                expect(configStub.save.calledOnce).to.be.true;
+            });
         });
 
         it('returns false if ghost isn\'t running in either environment', function () {
@@ -291,18 +293,18 @@ describe('Unit: Instance', function () {
             const setEnvironmentStub = sandbox.stub();
             const testInstance = new TestInstance({}, {setEnvironment: setEnvironmentStub, development: false}, '/var/www/ghost');
 
-            const running = testInstance.running();
-
-            expect(running).to.be.false;
-            expect(configStub.has.calledOnce).to.be.true;
-            expect(existsStub.calledTwice).to.be.true;
-            expect(existsStub.calledWithExactly('/var/www/ghost/config.production.json')).to.be.true;
-            expect(existsStub.calledWithExactly('/var/www/ghost/config.development.json')).to.be.true;
-            expect(isRunningStub.calledTwice).to.be.true;
-            expect(configStub.set.called).to.be.false;
-            expect(configStub.save.called).to.be.false;
-            expect(setEnvironmentStub.calledThrice).to.be.true;
-            expect(setEnvironmentStub.args[2][0]).to.be.false;
+            return testInstance.running().then((running) => {
+                expect(running).to.be.false;
+                expect(configStub.has.calledOnce).to.be.true;
+                expect(existsStub.calledTwice).to.be.true;
+                expect(existsStub.calledWithExactly('/var/www/ghost/config.production.json')).to.be.true;
+                expect(existsStub.calledWithExactly('/var/www/ghost/config.development.json')).to.be.true;
+                expect(isRunningStub.calledTwice).to.be.true;
+                expect(configStub.set.called).to.be.false;
+                expect(configStub.save.called).to.be.false;
+                expect(setEnvironmentStub.calledThrice).to.be.true;
+                expect(setEnvironmentStub.args[2][0]).to.be.false;
+            });
         });
 
         it('loads running environment and checks if process manager returns false', function () {
@@ -315,11 +317,12 @@ describe('Unit: Instance', function () {
             const testInstance = new TestInstance({}, {}, '');
             const loadRunEnvStub = sandbox.stub(testInstance, 'loadRunningEnvironment');
 
-            const running = testInstance.running();
-            expect(running).to.be.true;
-            expect(hasStub.calledOnce).to.be.true;
-            expect(isRunningStub.calledOnce).to.be.true;
-            expect(loadRunEnvStub.calledOnce).to.be.true;
+            return testInstance.running().then((running) => {
+                expect(running).to.be.true;
+                expect(hasStub.calledOnce).to.be.true;
+                expect(isRunningStub.calledOnce).to.be.true;
+                expect(loadRunEnvStub.calledOnce).to.be.true;
+            });
         });
 
         it('sets running to null in cliConfig if process manager\'s isRunning method returns false', function () {
@@ -334,13 +337,14 @@ describe('Unit: Instance', function () {
             const testInstance = new TestInstance({}, {}, '');
             const loadRunEnvStub = sandbox.stub(testInstance, 'loadRunningEnvironment');
 
-            const running = testInstance.running();
-            expect(running).to.be.false;
-            expect(hasStub.calledOnce).to.be.true;
-            expect(setStub.calledOnce).to.be.true;
-            expect(saveStub.calledOnce).to.be.true;
-            expect(isRunningStub.calledOnce).to.be.true;
-            expect(loadRunEnvStub.calledOnce).to.be.true;
+            return testInstance.running().then((running) => {
+                expect(running).to.be.false;
+                expect(hasStub.calledOnce).to.be.true;
+                expect(setStub.calledOnce).to.be.true;
+                expect(saveStub.calledOnce).to.be.true;
+                expect(isRunningStub.calledOnce).to.be.true;
+                expect(loadRunEnvStub.calledOnce).to.be.true;
+            });
         });
     });
 
@@ -437,15 +441,16 @@ describe('Unit: Instance', function () {
             class TestInstance extends Instance {
                 get name() { return 'testing'; }
                 get cliConfig() { return {get: getStub}; }
-                running() { return false; }
+                running() { return Promise.resolve(false); }
             }
             const testInstance = new TestInstance({}, {}, '');
-            const result = testInstance.summary();
 
-            expect(result.running).to.be.false;
-            expect(result.name).to.equal('testing');
-            expect(result.version).to.equal('1.0.0');
-            expect(result.mode).to.be.undefined;
+            return testInstance.summary().then((result) => {
+                expect(result.running).to.be.false;
+                expect(result.name).to.equal('testing');
+                expect(result.version).to.equal('1.0.0');
+                expect(result.mode).to.be.undefined;
+            });
         });
 
         it('loads running environment and returns full object if running is true', function () {
@@ -459,17 +464,16 @@ describe('Unit: Instance', function () {
                 get cliConfig() { return {get: cliGetStub}; }
                 get config() { return {get: getStub}; }
                 get process() { return {name: 'local'}; }
-                running() { return true; }
+                running() { return Promise.resolve(true); }
             }
             const testInstance = new TestInstance({}, {environment: 'testing'}, '');
-            const loadRunEnvStub = sandbox.stub(testInstance, 'loadRunningEnvironment');
 
-            const result = testInstance.summary();
-            expect(loadRunEnvStub.calledOnce).to.be.true;
-            expect(result.running).to.be.true;
-            expect(result.name).to.equal('testing');
-            expect(result.mode).to.equal('testing');
-            expect(result.url).to.equal('localhost');
+            return testInstance.summary().then((result) => {
+                expect(result.running).to.be.true;
+                expect(result.name).to.equal('testing');
+                expect(result.mode).to.equal('testing');
+                expect(result.url).to.equal('localhost');
+            });
         });
     });
 

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -193,6 +193,15 @@ describe('Unit: Process Manager', function () {
         return stop;
     });
 
+    it('base isRunning implementation returns a promise', function () {
+        const ProcessManager = require(modulePath);
+        const instance = new ProcessManager({}, {}, {});
+
+        return instance.isRunning().then((result) => {
+            expect(result).to.be.false;
+        });
+    });
+
     it('base willRun method returns true', function () {
         const ProcessManager = require(modulePath);
         expect(ProcessManager.willRun()).to.be.true;

--- a/test/unit/system-spec.js
+++ b/test/unit/system-spec.js
@@ -327,25 +327,25 @@ describe('Unit: System', function () {
             const systemInstance = stubGlobalConfig(System, {get: () => instances, set: setStub});
             const getInstanceStub = sinon.stub(systemInstance, 'getInstance');
 
-            const instanceA = {running: () => true, cwd: '/dir/a', name: 'testa'};
-            const instanceB = {running: () => false, cwd: '/dir/b', name: 'testb'};
+            const instanceA = {running: () => Promise.resolve(true), cwd: '/dir/a', name: 'testa'};
+            const instanceB = {running: () => Promise.resolve(false), cwd: '/dir/b', name: 'testb'};
 
             getInstanceStub.withArgs('testa').returns(instanceA);
             getInstanceStub.withArgs('testb').returns(instanceB);
 
-            const result = systemInstance.getAllInstances(true);
-
-            expect(result).to.deep.equal([instanceA]);
-            expect(fsStub.calledThrice).to.be.true;
-            expect(getInstanceStub.calledTwice).to.be.true;
-            expect(setStub.calledOnce).to.be.true;
-            expect(setStub.args[0]).to.deep.equal([
-                'instances',
-                {
-                    testa: {cwd: '/dir/a'},
-                    testb: {cwd: '/dir/b'}
-                }
-            ]);
+            return systemInstance.getAllInstances(true).then((result) => {
+                expect(result).to.deep.equal([instanceA]);
+                expect(fsStub.calledThrice).to.be.true;
+                expect(getInstanceStub.calledTwice).to.be.true;
+                expect(setStub.calledOnce).to.be.true;
+                expect(setStub.args[0]).to.deep.equal([
+                    'instances',
+                    {
+                        testa: {cwd: '/dir/a'},
+                        testb: {cwd: '/dir/b'}
+                    }
+                ]);
+            });
         });
 
         it('loads all instances with running false', function () {
@@ -365,18 +365,18 @@ describe('Unit: System', function () {
             const systemInstance = stubGlobalConfig(System, {get: () => instances, set: setStub});
             const getInstanceStub = sinon.stub(systemInstance, 'getInstance');
 
-            const instanceA = {running: () => true, cwd: '/dir/a', name: 'testa'};
-            const instanceB = {running: () => false, cwd: '/dir/b', name: 'testb'};
+            const instanceA = {running: () => Promise.resolve(true), cwd: '/dir/a', name: 'testa'};
+            const instanceB = {running: () => Promise.resolve(false), cwd: '/dir/b', name: 'testb'};
 
             getInstanceStub.withArgs('testa').returns(instanceA);
             getInstanceStub.withArgs('testb').returns(instanceB);
 
-            const result = systemInstance.getAllInstances(false);
-
-            expect(result).to.deep.equal([instanceA, instanceB]);
-            expect(fsStub.calledTwice).to.be.true;
-            expect(getInstanceStub.calledTwice).to.be.true;
-            expect(setStub.called).to.be.false;
+            return systemInstance.getAllInstances(false).then((result) => {
+                expect(result).to.deep.equal([instanceA, instanceB]);
+                expect(fsStub.calledTwice).to.be.true;
+                expect(getInstanceStub.calledTwice).to.be.true;
+                expect(setStub.called).to.be.false;
+            });
         });
     });
 


### PR DESCRIPTION
refs #668 
- update instance.running() to handle process.isRunning promise
- update everywhere that uses instance.running to handle the promise

TODO:
- [x] tests

## Reasoning
- See #668 - it would be useful to allow process.isRunning to return a promise.