### PR TITLE
Run `isRunning` and `isEnabled` as sudo

### DIFF
--- a/extensions/systemd/systemd.js
+++ b/extensions/systemd/systemd.js
@@ -84,18 +84,16 @@ class SystemdProcessManager extends cli.ProcessManager {
     }
 
     isRunning() {
-        try {
-            execa.shellSync(`systemctl is-active ${this.systemdName}`);
-            return true;
-        } catch (e) {
-            // Systemd prints out "inactive" if service isn't running
-            // or "activating" if service hasn't completely started yet
-            if (!e.message.match(/inactive|activating/)) {
-                throw e;
-            }
-
-            return false;
-        }
+        return this.ui.sudo(`systemctl is-active ${this.systemdName}`)
+            .then(() => Promise.resolve(true))
+            .catch ((error) => {
+                // Systemd prints out "inactive" if service isn't running
+                // or "activating" if service hasn't completely started yet
+                if (!error.message.match(/inactive|activating/)) {
+                    return Promise.reject(error);
+                }
+                return Promise.resolve(false);
+            });
     }
 
     _precheck() {

--- a/extensions/systemd/systemd.js
+++ b/extensions/systemd/systemd.js
@@ -59,18 +59,17 @@ class SystemdProcessManager extends cli.ProcessManager {
     }
 
     isEnabled() {
-        try {
-            execa.shellSync(`systemctl is-enabled ${this.systemdName}`);
-            return true;
-        } catch (e) {
-            // Systemd prints out "disabled" if service isn't enabled
-            // or "failed to get unit file state" if something else goes wrong
-            if (!e.message.match(/disabled|Failed to get unit file state/)) {
-                throw e;
-            }
+        return this.ui.sudo(`systemctl is-enabled ${this.systemdName}`)
+            .then(() => Promise.resolve(true))
+            .catch((error) => {
+                // Systemd prints out "disabled" if service isn't enabled
+                // or "failed to get unit file state" if something else goes wrong
+                if (!error.message.match(/disabled|Failed to get unit file state/)) {
+                    return Promise.reject(error);
+                }
 
-            return false;
-        }
+                return Promise.resolve(false);
+            });
     }
 
     enable() {


### PR DESCRIPTION
closes #660 
refs #414

Recently there were many users reporting issues when the CLI is running the command `systemctl is-active`. With the changes in #669 we are now able to run the `isRunning` and `isEnabled` methods in our systemd extension, as those were the only commands that weren't executed as `sudo`.

Manual tests worked fine for me. I can't say if it'll fix all the issues, as I wasn't able to reproduce the issues on the recommended stack. Nevertheless, there were enough reports of this issue actually happening *on* the recommended stack.