### PR TITLE
fix(help): don't show aliases on help output

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -122,8 +122,8 @@ const bootstrap = {
             debug('running help command, requiring and configuring every command');
 
             each(commands, (commandPath, commandName) => {
-                const aliases = Object.keys(abbreviations).filter((key) => abbreviations[key] === commandName);
-                bootstrap.loadCommand(commandName, commandPath, yargs, aliases, extensions);
+                // Don't fetch aliases for help commands to keep the output clean.
+                bootstrap.loadCommand(commandName, commandPath, yargs, [], extensions);
             });
             argv.unshift('help');
         } else if (abbreviations[firstArg]) {


### PR DESCRIPTION
no issue
- this helps keep the output clean, most of the aliases are either abbreviations or recognized typo commands