### PR TITLE
Ensure `content/settings` folder

### DIFF
--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -1,3 +1,15 @@
 'use strict';
 
-module.exports = [];
+function ensureSettingsFolder() {
+    const cwd = process.cwd();
+    const fs = require('fs-extra');
+    const path = require('path');
+
+    fs.ensureDirSync(path.resolve(cwd, 'content', 'settings'));
+}
+
+module.exports = [{
+    before: '1.7.0',
+    title: 'Create content/settings directory',
+    task: ensureSettingsFolder
+}];

--- a/lib/tasks/ensure-structure.js
+++ b/lib/tasks/ensure-structure.js
@@ -16,4 +16,5 @@ module.exports = function ensureStructure() {
     fs.ensureDirSync(path.resolve(cwd, 'content', 'data'));
     fs.ensureDirSync(path.resolve(cwd, 'content', 'images'));
     fs.ensureDirSync(path.resolve(cwd, 'content', 'logs'));
+    fs.ensureDirSync(path.resolve(cwd, 'content', 'settings'));
 };

--- a/test/unit/migrations-spec.js
+++ b/test/unit/migrations-spec.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const migrations = require('../../lib/migrations');
+
+describe('Unit: Migrations', function () {
+    describe('ensureSettingsFolder', function () {
+        const setupEnv = require('../utils/env');
+        const path = require('path');
+        const fs = require('fs');
+
+        it('creates settings folder if not existent', function () {
+            const env = setupEnv();
+            const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
+            const ensureSettingsFolder = migrations[0].task;
+
+            ensureSettingsFolder();
+            expect(cwdStub.calledOnce).to.be.true;
+            expect(fs.existsSync(path.join(env.dir, 'content/settings'))).to.be.true;
+
+            cwdStub.restore();
+            env.cleanup();
+        });
+    });
+});

--- a/test/unit/tasks/ensure-structure-spec.js
+++ b/test/unit/tasks/ensure-structure-spec.js
@@ -20,7 +20,8 @@ describe('Unit: Tasks > ensure-structure', function () {
         'content/themes',
         'content/data',
         'content/images',
-        'content/logs'
+        'content/logs',
+        'content/settings'
     ];
 
     expectedFiles.forEach((file) => {


### PR DESCRIPTION
refs TryGhost/Ghost#9528

- adds `content/settings` folder to install process (for new installations)
- adds a core migration that makes sure, `content/settings` exists (for older installations)

----

## Todos:
- [ ] ~~create default `routes.yaml` file on install and migration. Question: where to get the default values from?~~
- [ ] make sure it works fine with the Ghost changes
- [x] define the version for the migration