### PR TITLE
feat(ls command): don't render table when no instances found

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -17,9 +17,13 @@ class LsCommand extends Command {
                 });
             });
         }).then((rows) => {
-            this.ui.table(['Name', 'Location', 'Version', 'Status', 'URL', 'Port', 'Process Manager'], rows, {
-                style: {head: ['cyan']}
-            });
+            if (rows.length) {
+                this.ui.table(['Name', 'Location', 'Version', 'Status', 'URL', 'Port', 'Process Manager'], rows, {
+                    style: {head: ['cyan']}
+                });
+            } else {
+                this.ui.log('No installed ghost instances found', 'cyan');
+            }
         });
     }
 }

--- a/test/unit/commands/ls-spec.js
+++ b/test/unit/commands/ls-spec.js
@@ -65,4 +65,17 @@ describe('Unit: Commands > ls', function () {
             });
         });
     });
+
+    it('Doesn\'t create a table when no instances exist', function () {
+        const getAllInstancesStub = sinon.stub().resolves([]);
+        const tableStub = sinon.stub();
+        const logStub = sinon.stub();
+
+        const instance = new LsCommand({log: logStub, table: tableStub}, {getAllInstances: getAllInstancesStub});
+        instance.run().then(() => {
+            expect(tableStub.called).to.be.false;
+            expect(logStub.calledOnce).to.be.true;
+            expect(logStub.args[0][0]).to.equal('No installed ghost instances found');
+        })
+    })
 });


### PR DESCRIPTION
no issue

Currently, when a user runs `ghost ls` and has no installed ghost instances, they just get a table header. This  can be confusing, so instead, we're outputting a more informative message of "No installed ghost instances found"