### PR TITLE
chore(doctor): use more informative task title for checking ghost user

### DIFF
--- a/lib/commands/doctor/checks/logged-in-ghost-user.js
+++ b/lib/commands/doctor/checks/logged-in-ghost-user.js
@@ -5,7 +5,7 @@ const chalk = require('chalk');
 const fs = require('fs');
 const ghostUser = require('../../../utils/use-ghost-user');
 
-const taskTitle = 'Checking if user is logged in with ghost user';
+const taskTitle = 'Ensuring user is not logged in as ghost user';
 
 function loggedInGhostUser() {
     const uid = process.getuid();


### PR DESCRIPTION
No issue

I was just updating an instance and looking over the command history. I was confused as to why the `Checking if user is logged in with ghost user` task passed, since I wasn't logged in as ghost. It took me a minute to realize the task was checking that the current user _isn't_ ghost. This PR updates the wording to convey the message