### PR TITLE
[WIP] fix(config): don't overwrite corrupt files

### DIFF
--- a/lib/commands/doctor/checks/validate-config.js
+++ b/lib/commands/doctor/checks/validate-config.js
@@ -20,9 +20,9 @@ function validateConfig(ctx, task) {
             return task.skip('Instance is currently running');
         }
 
-        const config = Config.exists(path.join(process.cwd(), `config.${ctx.system.environment}.json`));
+        const config = Config.load(path.join(process.cwd(), `config.${ctx.system.environment}.json`));
 
-        if (config === false) {
+        if (config === null) {
             return Promise.reject(new errors.ConfigError({
                 environment: ctx.system.environment,
                 message: 'Config file is not valid JSON',

--- a/lib/system.js
+++ b/lib/system.js
@@ -202,7 +202,13 @@ class System {
      */
     cachedInstance(dir) {
         if (!this._instanceCache[dir]) {
-            this._instanceCache[dir] = new Instance(this.ui, this, dir);
+            let instance = new Instance(this.ui, this, dir);
+            if (!instance.config.isValid()) {
+                this.ui.log(`The config file "${dir}/config.${this.environment}.json" is invalid!`, 'red');
+                instance = null;
+            }
+
+            this._instanceCache[dir] = instance;
         }
 
         return this._instanceCache[dir];

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -23,7 +23,12 @@ class Config {
         }
 
         this.file = filename;
-        this.values = Config.exists(this.file) || {};
+
+        if (Config.exists(this.file)) {
+            this.values = Config.load(this.file);
+        } else {
+            this.values = {};
+        }
     }
 
     /**
@@ -93,6 +98,16 @@ class Config {
     }
 
     /**
+     * Checks the validity of the current config
+     *
+     * @method validate
+     * @public
+     */
+    isValid() {
+        return (this.values && typeof this.values === 'object');
+    }
+
+    /**
      * Checks whether or not a config file exists
      * @param {string} filename Filename to check
      *
@@ -101,12 +116,19 @@ class Config {
      * @public
      */
     static exists(filename) {
-        try {
-            const result = fs.readJsonSync(filename);
-            return result;
-        } catch (e) {
-            return false;
-        }
+        return fs.existsSync(filename);
+    }
+
+    /**
+     * Reads a config file from disk
+     * @param {string} filename Filename to check
+     *
+     * @static
+     * @method valid
+     * @public
+     */
+    static load(filename) {
+        return fs.readJsonSync(filename, {throws: false});
     }
 }
 


### PR DESCRIPTION
refs #690 

This is a WIP. I want to get feedback before I go _too_ far!

For now, the config defaults to an undefined state, which causes upstream errors (specifically calling config-specific methods in commands). There are 3 potential methods to fix this
- Copy the config file to {unspecified} location and continue like currently done
- Exit when encountering a bad config file (this can cause unintended consequences for global commands [specifically `ghost ls`])
- Add checks in Command

I'm not really a fan of any of these, since they feel really hacky.

Tests will be added when we determine what should be done 😄 
