### PR TITLE
chore(utils): improve error message for incompatible ghost zip

### DIFF
--- a/lib/utils/version-from-zip.js
+++ b/lib/utils/version-from-zip.js
@@ -40,7 +40,11 @@ module.exports = function versionFromZip(zipPath, currentVersion) {
     }
 
     if (pkg.engines && pkg.engines.cli && !semver.satisfies(cliPackage.version, pkg.engines.cli)) {
-        return Promise.reject(new errors.SystemError('Zip file contains a Ghost version incompatible with this version of the CLI.'));
+        return Promise.reject(new errors.SystemError({
+            message: 'Zip file contains a Ghost version incompatible with this version of the CLI.',
+            help: `Required: v${pkg.engines.cli}, current: v${cliPackage.version}`,
+            suggestion: 'npm install -g ghost-cli@latest'
+        }));
     }
 
     if (currentVersion && semver.lt(pkg.version, currentVersion)) {

--- a/test/unit/utils/version-from-zip-spec.js
+++ b/test/unit/utils/version-from-zip-spec.js
@@ -106,6 +106,8 @@ describe('Unit: Utils > versionFromZip', function () {
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.SystemError);
             expect(error.message).to.equal('Zip file contains a Ghost version incompatible with this version of the CLI.');
+            expect(error.options.help).to.equal('Required: v^0.0.1, current: v1.7.0');
+            expect(error.options.suggestion).to.equal('npm install -g ghost-cli@latest');
         });
     });
 


### PR DESCRIPTION
refs #681
refs #587

Give the user more information why the installation of the zip file failed. Renders the required and the current installed CLI version and the command to run to solve the issue.

Looks like this:

![image](https://user-images.githubusercontent.com/8037602/38601908-b9f89fc2-3d9b-11e8-811c-fae485662530.png)

