### PR TITLE
fix(doctor): skip install dir checks for local installs

### DIFF
--- a/lib/commands/doctor/checks/install-folder-permissions.js
+++ b/lib/commands/doctor/checks/install-folder-permissions.js
@@ -16,7 +16,9 @@ function installFolderPermissions(ctx) {
             task: taskTitle
         }));
     }).then(() => {
-        if (ctx.local || !ctx.system.platform.linux || (ctx.argv && ctx.argv['setup-linux-user'] === false)) {
+        const isLocal = ctx.local || (ctx.instance && ctx.instance.process.name === 'local');
+
+        if (isLocal || !ctx.system.platform.linux || (ctx.argv && ctx.argv['setup-linux-user'] === false)) {
             return Promise.resolve();
         }
 

--- a/test/unit/commands/doctor/checks/install-folder-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/install-folder-permissions-spec.js
@@ -42,6 +42,19 @@ describe('Unit: Doctor Checks > installFolderPermissions', function () {
         });
     });
 
+    it('skips checking parent folder permissions if local process manager is used', function () {
+        const accessStub = sandbox.stub(fs, 'access').resolves();
+        const checkDirectoryStub = sandbox.stub().resolves();
+        const installFolderPermissions = proxyquire(modulePath, {
+            './check-directory': checkDirectoryStub
+        }).task;
+
+        return installFolderPermissions({instance: {process: {name: 'local'}}}).then(() => {
+            expect(accessStub.calledOnce).to.be.true;
+            expect(checkDirectoryStub.called).to.be.false;
+        });
+    });
+
     it('skips checking parent folder permissions if os is not linux', function () {
         const accessStub = sandbox.stub(fs, 'access').resolves();
         const checkDirectoryStub = sandbox.stub().resolves();


### PR DESCRIPTION
closes #711 

We successfully pass this check for the `ghost install local` command and the intention was to always pass/skip it for local installs. The `local` argument is only available when executing the installation command. But this check also runs for `ghost start` and `ghost update` when there's no `local` argument.

This change will skip the check now also when the local process manager is used, which usually means that it's a local installation.