### PR TITLE
feat(start): direct user to admin interface

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -22,6 +22,8 @@ class StartCommand extends Command {
 
     run(argv) {
         const ProcessManager = require('../process-manager');
+        const url  = require('url');
+        const chalk = require('chalk');
 
         const instance = this.system.getInstance();
         const runOptions = {quiet: argv.quiet};
@@ -59,7 +61,19 @@ class StartCommand extends Command {
                     });
                 }).then(() => {
                     if (!argv.quiet) {
-                        this.ui.log(`You can access your blog at ${instance.config.get('url')}`, 'cyan');
+                        const isInstall = process.argv[2] === 'install';
+                        let adminUrl = instance.config.get('admin.url') || instance.config.get('url');
+
+                        adminUrl = url.resolve(adminUrl, '/ghost/');
+
+                        this.ui.log(`You can access your publication at ${chalk.cyan(instance.config.get('url'))}`, 'white');
+
+                        if (isInstall) {
+                            // Show a different message after a fresh install
+                            this.ui.log(`Next, go to to your admin interface at ${chalk.cyan(adminUrl)} to complete the setup of your publication`, 'white');
+                        } else {
+                            this.ui.log(`Your admin interface is located at ${chalk.cyan(adminUrl)}`, 'white');
+                        }
 
                         if (instance.config.get('mail.transport') === 'Direct') {
                             this.ui.log('\nGhost uses direct mail by default', 'green');


### PR DESCRIPTION
closes #665

- added a new message that shows the URL to the admin interface
- uses custom admin URL, if set in config
- shows a slightly different message when rendered after the `install` process