### PR TITLE
fix(migrate): remove unnecessary config overwrite during db migrations

### DIFF
--- a/lib/tasks/migrate.js
+++ b/lib/tasks/migrate.js
@@ -12,9 +12,6 @@ module.exports = function runMigrations(context) {
         config.set('paths.contentPath', path.join(context.instance.dir, 'content')).save();
     }
 
-    const transports = config.get('logging.transports', null);
-    config.set('logging.transports', ['file']).save();
-
     const contentDir = path.join(context.instance.dir, 'content');
     const currentDir = path.join(context.instance.dir, 'current');
     let knexMigratorPromise;
@@ -33,9 +30,7 @@ module.exports = function runMigrations(context) {
         });
     }
 
-    return knexMigratorPromise.then(() => {
-        config.set('logging.transports', transports).save();
-    }).catch((error) => {
+    return knexMigratorPromise.catch((error) => {
         if (error.stderr && error.stderr.match(/CODE: ENOTFOUND/)) {
             // Database not found
             error = new errors.ConfigError({
@@ -72,7 +67,6 @@ module.exports = function runMigrations(context) {
             });
         }
 
-        config.set('logging.transports', transports).save();
         return Promise.reject(error);
     });
 }


### PR DESCRIPTION
refs #708
- this was from the days where we executed knex-migrator directly. We no longer do that, so suppressing the knex-migrator command output is no longer necessary

todo:
- [x] do a test w/sudo to make sure that works as well