### PR TITLE
Updated the folder check's help command to consider special permissions

### DIFF
--- a/lib/commands/doctor/checks/check-permissions.js
+++ b/lib/commands/doctor/checks/check-permissions.js
@@ -18,7 +18,7 @@ module.exports = function checkPermissions(type, task) {
         },
         folder: {
             command: 'find ./ -type d ! -perm 775 ! -perm 755',
-            help: `Run ${chalk.green('sudo find ./ -type d -exec chmod 775 {} \\;')} and try again.`
+            help: `Run ${chalk.green('sudo find ./ -type d -exec chmod 000775 {} \\;')} and try again.`
         },
         files: {
             command: 'find ./  -type f ! -path "./versions/*" ! -perm 664 ! -perm 644',


### PR DESCRIPTION
Updated the folder check's help command to remove any special permissions (setuid, setgid and sticky bits) in addition to setting the proper standard permissions.