### PR TITLE
fix(doctor): Folder permissions check considers setuid, setgid, and sticky bits

### DIFF
--- a/lib/commands/doctor/checks/check-permissions.js
+++ b/lib/commands/doctor/checks/check-permissions.js
@@ -18,6 +18,7 @@ module.exports = function checkPermissions(type, task) {
         },
         folder: {
             command: 'find ./ -type d ! -perm 775 ! -perm 755',
+            // chmod mode from http://man7.org/linux/man-pages/man1/chmod.1.html#SETUID_AND_SETGID_BITS
             help: `Run ${chalk.green('sudo find ./ -type d -exec chmod 00775 {} \\;')} and try again.`
         },
         files: {

--- a/lib/commands/doctor/checks/check-permissions.js
+++ b/lib/commands/doctor/checks/check-permissions.js
@@ -18,7 +18,7 @@ module.exports = function checkPermissions(type, task) {
         },
         folder: {
             command: 'find ./ -type d ! -perm 775 ! -perm 755',
-            help: `Run ${chalk.green('sudo find ./ -type d -exec chmod 775 {} \\;')} and try again.`
+            help: `Run ${chalk.green('sudo find ./ -type d -exec chmod 00775 {} \\;')} and try again.`
         },
         files: {
             command: 'find ./  -type f ! -path "./versions/*" ! -perm 664 ! -perm 644',

--- a/test/unit/commands/doctor/checks/folder-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/folder-permissions-spec.js
@@ -41,7 +41,7 @@ describe('Unit: Doctor Checks > Checking folder permissions', function () {
             expect(error).to.be.an.instanceof(errors.SystemError);
             expect(error.message).to.match(/Your installation folder contains some directories or files with incorrect permissions:/);
             expect(error.message).to.match(/- \.\/system\/apps/);
-            expect(error.message).to.match(/sudo find \.\/ -type d -exec chmod 775 \{\} \\;/);
+            expect(error.message).to.match(/sudo find \.\/ -type d -exec chmod 00775 \{\} \\;/);
             expect(execaStub.called).to.be.true;
         });
     });
@@ -55,7 +55,7 @@ describe('Unit: Doctor Checks > Checking folder permissions', function () {
             expect(error).to.be.an.instanceof(errors.SystemError);
             expect(error.message).to.match(/Your installation folder contains a directory or file with incorrect permissions:/);
             expect(error.message).to.match(/- .\/content\/images\/test.jpg/);
-            expect(error.message).to.match(/sudo find \.\/ -type d -exec chmod 775 \{\} \\;/);
+            expect(error.message).to.match(/sudo find \.\/ -type d -exec chmod 00775 \{\} \\;/);
             expect(execaStub.called).to.be.true;
         });
     });


### PR DESCRIPTION
fix(doctor): Folder permissions check considers setuid, setgid, and sticky bits

closes #724
- Prefixed the folder permissions check help command chmod parameter with "00" to clear the setuid, setgid, and sticky bits
- Updated the unit tests for folder permissions to coincide with aforementioned change