### PR TITLE
fix(linux): remove strict no such user error message checking

### DIFF
--- a/lib/tasks/linux.js
+++ b/lib/tasks/linux.js
@@ -10,9 +10,8 @@ module.exports = function linuxSetupTask(ctx) {
         execa.shellSync('id ghost');
         userExists = true;
     } catch (e) {
-        if (!e.message.match(/no such user/i)) {
-            return Promise.reject(e);
-        }
+        // an error here essentially means that the user doesn't exist
+        // so we don't need to do any additional checking really
     }
 
     return ctx.ui.listr([{

--- a/test/unit/tasks/linux-spec.js
+++ b/test/unit/tasks/linux-spec.js
@@ -18,23 +18,6 @@ function fakeListr(tasks, ctx) {
 }
 
 describe('Unit: Tasks > linux', function () {
-    it('rejects if execa error message is not an expected one', function () {
-        const shellStub = sinon.stub().throws(new Error('unexpected'));
-        const linux = proxyquire(modulePath, {
-            execa: {shellSync: shellStub}
-        });
-        const listrStub = sinon.stub();
-        return linux({ui: {listr: listrStub}}).then(() => {
-            expect(false, 'error should have been thrown').to.be.true;
-        }).catch((error) => {
-            expect(error).to.be.an.instanceof(Error);
-            expect(error.message).to.equal('unexpected');
-            expect(shellStub.calledOnce).to.be.true;
-            expect(shellStub.calledWithExactly('id ghost')).to.be.true;
-            expect(listrStub.called).to.be.false;
-        });
-    });
-
     it('skips creating user if user already exists', function () {
         const shellStub = sinon.stub();
         const linux = proxyquire(modulePath, {
@@ -53,7 +36,7 @@ describe('Unit: Tasks > linux', function () {
         });
     });
 
-    it('creates creating user if user already exists', function () {
+    it('creates user if user doesn\'t exist', function () {
         const shellStub = sinon.stub().throws(new Error('No such user'));
         const linux = proxyquire(modulePath, {
             execa: {shellSync: shellStub}


### PR DESCRIPTION
closes #676
- an error thrown in this place essentially means there's no user, so the strict error message checking is unnecessary and breaks systems in which the id message is different