### PR TITLE
feat(config): add config get & set subcommands

### DIFF
--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -5,6 +5,18 @@ const Command           = require('../../command');
 const advancedOptions   = require('./advanced');
 
 class ConfigCommand extends Command {
+    static configureSubcommands(commandName, commandArgs, extensions) {
+        return commandArgs.command({
+            command: 'get <key>',
+            describe: 'Get a specific value from the configuration file',
+            handler: (argv) => this._run(`${commandName} get`, argv, extensions)
+        }).command({
+            command: 'set <key> <value>',
+            describe: 'Set a specific value in the configuration file',
+            handler: (argv) => this._run(`${commandName} set`, argv, extensions)
+        });
+    }
+
     constructor(ui, system) {
         super(ui, system);
 
@@ -154,6 +166,7 @@ class ConfigCommand extends Command {
         } else if (key) {
             // setter
             this.instance.config.set(key, value).save();
+            this.ui.log(`Successfully set '${key}' to '${value}'`, 'green');
             return Promise.resolve();
         }
 


### PR DESCRIPTION
this is another approach to the feature added in #693 , using yargs subcommand support instead.