### PR TITLE
Ensure version folder is cleaned up in the event of a yarn install failure.

### DIFF
--- a/lib/tasks/yarn-install.js
+++ b/lib/tasks/yarn-install.js
@@ -54,6 +54,10 @@ const subTasks = {
                     file.path = file.path.replace('package/', '');
                     return file;
                 }
+            }).catch((error) => {
+                // Clean up the install folder since the decompress failed
+                fs.removeSync(ctx.installPath);
+                return Promise.reject(error);
             });
         });
     }
@@ -73,11 +77,17 @@ module.exports = function yarnInstall(ui, zipFile) {
 
     tasks.push({
         title: 'Installing dependencies',
-        task: (ctx) => yarn(['install', '--no-emoji', '--no-progress'], {
-            cwd: ctx.installPath,
-            env: {NODE_ENV: 'production'},
-            observe: true
-        })
+        task: (ctx) => {
+            return yarn(['install', '--no-emoji', '--no-progress'], {
+                cwd: ctx.installPath,
+                env: {NODE_ENV: 'production'},
+                observe: true
+            }).catch((error) => {
+                // Add error catcher so we can cleanup the install path if an error occurs
+                fs.removeSync(ctx.installPath);
+                return Promise.reject(error);
+            });
+        }
     });
 
     return ui.listr(tasks, false);

--- a/test/acceptance/install-local-spec.js
+++ b/test/acceptance/install-local-spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const {expect} = require('chai');
 const fs  = require('fs-extra');
 
 const AcceptanceTest = require('../utils/acceptance-test');

--- a/test/unit/bootstrap-spec.js
+++ b/test/unit/bootstrap-spec.js
@@ -1,7 +1,7 @@
 'use strict';
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const env = require('../utils/env');
+const {setupTestFolder, cleanupTestFolders} = require('../utils/test-folder');
 const path = require('path');
 const proxyquire = require('proxyquire');
 
@@ -14,12 +14,16 @@ describe('Unit: Bootstrap', function () {
         sinon.restore();
     });
 
+    after(() => {
+        cleanupTestFolders();
+    });
+
     describe('discoverCommands', function () {
         const bootstrap = require(modulePath);
 
         it('loads basic command names into commands object', function () {
             let commands = {};
-            const testEnv = env({
+            const testEnv = setupTestFolder({
                 dirs: ['commands/test3'],
                 files: [{
                     path: 'commands/test.js',
@@ -47,7 +51,7 @@ describe('Unit: Bootstrap', function () {
 
         it('returns unmodified commands object if no commands dir exists for an extension', function () {
             let commands = {};
-            const testEnv = env({});
+            const testEnv = setupTestFolder({});
 
             commands = bootstrap.discoverCommands(commands, testEnv.dir, 'testing');
 
@@ -56,7 +60,7 @@ describe('Unit: Bootstrap', function () {
         });
 
         it('ignores non-js files or folders without an index.js', function () {
-            const testEnv = env({
+            const testEnv = setupTestFolder({
                 dirs: ['commands/test2', 'commands/test3'],
                 files: [{
                     path: 'commands/test.js',
@@ -85,7 +89,7 @@ describe('Unit: Bootstrap', function () {
         });
 
         it('namespaces a command with the extension name if another command exists with the same basename', function () {
-            const testEnv = env({
+            const testEnv = setupTestFolder({
                 dirs: ['commands/test2'],
                 files: [{
                     path: 'commands/test.js',

--- a/test/unit/commands/doctor/checks/validate-config-spec.js
+++ b/test/unit/commands/doctor/checks/validate-config-spec.js
@@ -3,22 +3,19 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const errors = require('../../../../../lib/errors');
-const setupEnv = require('../../../../utils/env');
+const {setupTestFolder, cleanupTestFolders} = require('../../../../utils/test-folder');
 const advancedOpts = require('../../../../../lib/commands/config/advanced');
 
 const check = require('../../../../../lib/commands/doctor/checks/validate-config');
 const validateConfig = check.task;
 
 describe('Unit: Doctor Checks > validateConfig', function () {
-    let env;
-
     afterEach(function () {
         sinon.restore();
+    });
 
-        if (env) {
-            env.cleanup();
-            env = null;
-        }
+    after(() => {
+        cleanupTestFolders();
     });
 
     it('skips if instance not set', function () {
@@ -39,7 +36,7 @@ describe('Unit: Doctor Checks > validateConfig', function () {
     });
 
     it('rejects if environment is passed and no config exists for that environment', function () {
-        env = setupEnv();
+        const env = setupTestFolder();
         const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
         const runningStub = sinon.stub().resolves(false);
 
@@ -58,7 +55,7 @@ describe('Unit: Doctor Checks > validateConfig', function () {
     });
 
     it('rejects if environment is passed and the config file is not valid json', function () {
-        env = setupEnv({files: [{path: 'config.testing.json', contents: 'not json'}]});
+        const env = setupTestFolder({files: [{path: 'config.testing.json', contents: 'not json'}]});
         const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
         const runningStub = sinon.stub().resolves(false);
 
@@ -78,7 +75,7 @@ describe('Unit: Doctor Checks > validateConfig', function () {
 
     it('rejects with error if config values does not pass', function () {
         const config = {server: {port: 2368}};
-        env = setupEnv({files: [{path: 'config.testing.json', content: config, json: true}]});
+        const env = setupTestFolder({files: [{path: 'config.testing.json', content: config, json: true}]});
         const urlStub = sinon.stub(advancedOpts.url, 'validate').returns('Invalid URL');
         const portStub = sinon.stub(advancedOpts.port, 'validate').returns('Port is in use');
         sinon.stub(process, 'cwd').returns(env.dir);
@@ -101,7 +98,7 @@ describe('Unit: Doctor Checks > validateConfig', function () {
 
     it('passes if all validate functions return true', function () {
         const config = {server: {port: 2368}};
-        const env = setupEnv({files: [{path: 'config.testing.json', content: config, json: true}]});
+        const env = setupTestFolder({files: [{path: 'config.testing.json', content: config, json: true}]});
         const urlStub = sinon.stub(advancedOpts.url, 'validate').returns(true);
         const portStub = sinon.stub(advancedOpts.port, 'validate').returns(true);
         sinon.stub(process, 'cwd').returns(env.dir);

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -3,7 +3,7 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const configStub = require('../../utils/config-stub');
-const setupEnv = require('../../utils/env');
+const {setupTestFolder, cleanupTestFolders} = require('../../utils/test-folder');
 const Promise = require('bluebird');
 const path = require('path');
 const fs = require('fs-extra');
@@ -13,6 +13,10 @@ const errors = require('../../../lib/errors');
 const Instance = require('../../../lib/instance');
 
 describe('Unit: Commands > Update', function () {
+    after(() => {
+        cleanupTestFolders();
+    });
+
     it('configureOptions adds setup & doctor options', function () {
         const superStub = sinon.stub().returnsArg(1);
         const doctorStub = sinon.stub().returnsArg(1);
@@ -339,7 +343,7 @@ describe('Unit: Commands > Update', function () {
                 '../tasks/yarn-install': yarnInstallStub
             });
             const instance = new UpdateCommand({}, {});
-            const env = setupEnv();
+            const env = setupTestFolder();
             const ctx = {
                 installPath: path.join(env.dir, 'versions/1.0.0'),
                 version: '1.0.0'
@@ -349,7 +353,6 @@ describe('Unit: Commands > Update', function () {
             return instance.downloadAndUpdate(ctx, task).then(() => {
                 expect(yarnInstallStub.calledOnce).to.be.true;
                 expect(task.title).to.equal('Downloading and updating Ghost to v1.0.0');
-                env.cleanup();
             });
         });
 
@@ -363,7 +366,7 @@ describe('Unit: Commands > Update', function () {
                 dirs: ['versions/1.0.0', 'versions/1.0.1'],
                 links: [['versions/1.0.0', 'current']]
             };
-            const env = setupEnv(envCfg);
+            const env = setupTestFolder(envCfg);
             const ctx = {
                 installPath: path.join(env.dir, 'versions/1.0.1'),
                 force: false
@@ -376,8 +379,6 @@ describe('Unit: Commands > Update', function () {
                 expect(fs.existsSync(ctx.installPath)).to.be.true;
                 expect(yarnInstallStub.called).to.be.false;
                 expect(task.skip.calledOnce).to.be.true;
-
-                env.cleanup();
             });
         });
 
@@ -391,7 +392,7 @@ describe('Unit: Commands > Update', function () {
                 dirs: ['versions/1.0.0', 'versions/1.0.1'],
                 links: [['versions/1.0.0', 'current']]
             };
-            const env = setupEnv(envCfg);
+            const env = setupTestFolder(envCfg);
             const ctx = {
                 installPath: path.join(env.dir, 'versions/1.0.1'),
                 force: true
@@ -402,8 +403,6 @@ describe('Unit: Commands > Update', function () {
             return instance.downloadAndUpdate(ctx, {}).then(() => {
                 expect(fs.existsSync(ctx.installPath)).to.be.false;
                 expect(yarnInstallStub.calledOnce).to.be.true;
-
-                env.cleanup();
             });
         });
     });
@@ -480,7 +479,7 @@ describe('Unit: Commands > Update', function () {
                 'versions/1.5.1',
                 'versions/1.5.2'
             ];
-            const env = setupEnv({dirs: dirs});
+            const env = setupTestFolder({dirs: dirs});
             const UpdateCommand = require(modulePath);
             const instance = new UpdateCommand({}, {});
             const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
@@ -493,8 +492,6 @@ describe('Unit: Commands > Update', function () {
                 dirs.forEach((version) => {
                     expect(fs.existsSync(path.join(env.dir, version))).to.be.true;
                 });
-
-                env.cleanup();
             });
         });
 
@@ -512,7 +509,7 @@ describe('Unit: Commands > Update', function () {
                     'versions/1.5.0'
                 ]
             };
-            const env = setupEnv(envCfg);
+            const env = setupTestFolder(envCfg);
             const UpdateCommand = require(modulePath);
             const instance = new UpdateCommand({}, {});
             const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
@@ -540,8 +537,6 @@ describe('Unit: Commands > Update', function () {
                 removedVersions.forEach((version) => {
                     expect(fs.existsSync(path.join(env.dir, 'versions', version))).to.be.false;
                 });
-
-                env.cleanup();
             });
         });
     });
@@ -665,7 +660,7 @@ describe('Unit: Commands > Update', function () {
                 dirs: ['versions/1.0.0', 'versions/1.0.1'],
                 links: [['versions/1.0.0', 'current']]
             }
-            const env = setupEnv(envCfg);
+            const env = setupTestFolder(envCfg);
             const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
             const config = configStub();
             config.get.withArgs('active-version').returns('1.0.0');
@@ -686,7 +681,6 @@ describe('Unit: Commands > Update', function () {
             expect(config.save.calledOnce).to.be.true;
 
             cwdStub.restore();
-            env.cleanup();
         });
 
         it('does things correctly with rollback', function () {
@@ -695,7 +689,7 @@ describe('Unit: Commands > Update', function () {
                 dirs: ['versions/1.0.0', 'versions/1.0.1'],
                 links: [['versions/1.0.1', 'current']]
             }
-            const env = setupEnv(envCfg);
+            const env = setupTestFolder(envCfg);
             const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
             const config = configStub();
             config.get.withArgs('active-version').returns('1.0.1');
@@ -716,7 +710,6 @@ describe('Unit: Commands > Update', function () {
             expect(config.save.calledOnce).to.be.true;
 
             cwdStub.restore();
-            env.cleanup();
         });
     });
 });

--- a/test/unit/tasks/ensure-structure-spec.js
+++ b/test/unit/tasks/ensure-structure-spec.js
@@ -1,33 +1,38 @@
 'use strict';
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const setupEnv = require('../../utils/env');
+const {setupTestFolder, cleanupTestFolders} = require('../../utils/test-folder');
 const fs = require('fs');
 const path = require('path');
 
 const ensureStructure = require('../../../lib/tasks/ensure-structure');
 
 describe('Unit: Tasks > ensure-structure', function () {
-    const env = setupEnv();
-    const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
-
-    ensureStructure();
-    expect(cwdStub.calledOnce).to.be.true;
-
-    const expectedFiles = [
-        'versions',
-        'content/apps',
-        'content/themes',
-        'content/data',
-        'content/images',
-        'content/logs',
-        'content/settings'
-    ];
-
-    expectedFiles.forEach((file) => {
-        expect(fs.existsSync(path.join(env.dir, file))).to.be.true;
+    after(() => {
+        cleanupTestFolders()
     });
 
-    cwdStub.restore();
-    env.cleanup();
+    it('works', function () {
+        const env = setupTestFolder();
+        const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
+
+        ensureStructure();
+        expect(cwdStub.calledOnce).to.be.true;
+
+        const expectedFiles = [
+            'versions',
+            'content/apps',
+            'content/themes',
+            'content/data',
+            'content/images',
+            'content/logs',
+            'content/settings'
+        ];
+
+        expectedFiles.forEach((file) => {
+            expect(fs.existsSync(path.join(env.dir, file))).to.be.true;
+        });
+
+        cwdStub.restore();
+    });
 });

--- a/test/unit/tasks/yarn-install-spec.js
+++ b/test/unit/tasks/yarn-install-spec.js
@@ -3,7 +3,7 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const Promise = require('bluebird');
-const setupEnv = require('../../utils/env');
+const {setupTestFolder, cleanupTestFolders} = require('../../utils/test-folder');
 const path = require('path');
 const fs = require('fs');
 
@@ -11,6 +11,10 @@ const modulePath = '../../../lib/tasks/yarn-install';
 const errors = require('../../../lib/errors');
 
 describe('Unit: Tasks > yarn-install', function () {
+    after(() => {
+        cleanupTestFolders();
+    });
+
     it('base function calls subtasks and yarn util', function () {
         const yarnStub = sinon.stub().resolves();
         const yarnInstall = proxyquire(modulePath, {
@@ -216,7 +220,7 @@ describe('Unit: Tasks > yarn-install', function () {
         });
 
         it('creates dir, decompresses and maps files', function () {
-            const env = setupEnv();
+            const env = setupTestFolder();
             const downloadStub = sinon.stub().resolves({downloadedData: true});
             const shasumStub = sinon.stub().returns('asdf1234');
             const decompressStub = sinon.stub().resolves();

--- a/test/utils/acceptance-test.js
+++ b/test/utils/acceptance-test.js
@@ -27,7 +27,7 @@ const cp = require('child_process');
 const tmp = require('tmp');
 const find = require('lodash/find');
 const path = require('path');
-const env = require('./env');
+const {setupTestFolder} = require('./test-folder');
 
 global.Promise = require('bluebird');
 
@@ -41,7 +41,7 @@ module.exports = class AcceptanceTest {
     }
 
     setup(type) {
-        this.cleanupDir = env(type, this.dir).cleanup;
+        this.cleanupDir = setupTestFolder(type, this.dir).cleanup;
     }
 
     path(file) {

--- a/test/utils/test-folder.js
+++ b/test/utils/test-folder.js
@@ -4,6 +4,8 @@ const tmp = require('tmp');
 const path = require('path');
 const isObject = require('lodash/isObject');
 
+const currentTestFolders = {};
+
 const builtin = {
     full: {
         dirs: ['versions/1.0.0', 'content'],
@@ -35,7 +37,7 @@ const builtin = {
     }
 };
 
-module.exports = function setupEnv(typeOrDefinition, dir) {
+function setupTestFolder(typeOrDefinition, dir) {
     typeOrDefinition = typeOrDefinition || {}; // default to empty object
 
     const setup = isObject(typeOrDefinition) ? typeOrDefinition : builtin[typeOrDefinition];
@@ -64,10 +66,22 @@ module.exports = function setupEnv(typeOrDefinition, dir) {
         });
     }
 
-    return {
+    const testFolder = {
         dir: dir,
         cleanup: () => {
             fs.removeSync(dir);
+            delete currentTestFolders[dir];
         }
-    }
-};
+    };
+
+    currentTestFolders[dir] = testFolder;
+    return testFolder;
+}
+
+function cleanupTestFolders() {
+    Object.keys(currentTestFolders).forEach((key) => {
+        currentTestFolders[key].cleanup();
+    });
+}
+
+module.exports = {setupTestFolder, cleanupTestFolders};


### PR DESCRIPTION
refs #726 
- if an error occurs during yarn install (called as part of ghost install or ghost update) we remove the version folder for the particular install so that future runs of `ghost update` don't treat the folder as successfully installed.