### PR TITLE
fix(extensions): fix error when global modules folder doesn't exist

### DIFF
--- a/lib/utils/find-extensions.js
+++ b/lib/utils/find-extensions.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const path = require('path');
 const findPlugins = require('find-plugins');
 const createDebug = require('debug');
@@ -25,7 +26,7 @@ module.exports = function findExtensions() {
         keyword: 'ghost-cli-extension',
         configName: 'ghost-cli',
         include: localExtensions,
-        dir: npmRoot,
+        dir: fs.existsSync(npmRoot) ? npmRoot : process.cwd(),
         scanAllDirs: true,
         sort: true
     }).map((ext) => {

--- a/test/unit/utils/find-extensions-spec.js
+++ b/test/unit/utils/find-extensions-spec.js
@@ -13,7 +13,7 @@ const localExtensions = [
 ];
 
 describe('Unit: Utils > find-extensions', function () {
-    let findExtensions, findStub;
+    let findExtensions, findStub, existsStub;
 
     beforeEach(() => {
         findStub = sinon.stub().returns([
@@ -28,13 +28,17 @@ describe('Unit: Utils > find-extensions', function () {
             }
         ]);
 
+        existsStub = sinon.stub();
+
         findExtensions = proxyquire(modulePath, {
             'find-plugins': findStub,
-            'global-modules': '.'
+            'global-modules': '.',
+            fs: {existsSync: existsStub}
         });
     });
 
     it('calls find-plugins with proper args', function () {
+        existsStub.returns(true);
         findExtensions();
         expect(findStub.calledOnce).to.be.true;
         const args = findStub.args[0][0];
@@ -53,7 +57,28 @@ describe('Unit: Utils > find-extensions', function () {
         expect(args).to.deep.equal(expected);
     });
 
+    it('uses process.cwd() when global modules dir doesn\'t exist', function () {
+        existsStub.returns(false);
+        findExtensions();
+        expect(findStub.calledOnce).to.be.true;
+        const args = findStub.args[0][0];
+
+        const expected = {
+            keyword: 'ghost-cli-extension',
+            configName: 'ghost-cli',
+            scanAllDirs: true,
+            dir: process.cwd(),
+            sort: true
+        };
+
+        const extensions = args.include.map((ext) => ext.split('extensions/')[1]);
+        delete args.include;
+        expect(extensions).to.deep.equal(localExtensions);
+        expect(args).to.deep.equal(expected);
+    });
+
     it('generates proper extension names', function () {
+        existsStub.returns(true);
         const names = findExtensions().map((ext) => ext.name);
         const expectedNames = ['test', 'rest', undefined];
         expect(names).to.deep.equal(expectedNames);


### PR DESCRIPTION
closes #723
- default to process.cwd() when folder shown by global-modules doesn't exist