### PR TITLE
feat(flags): add global `dir` option

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -145,7 +145,10 @@ const bootstrap = {
         // TODO: evaluate if `wrap` is actually needed?
         yargs.wrap(Math.min(100, yargs.terminalWidth()))
             .epilogue('For more information, see our docs at https://docs.ghost.org/v1/docs/ghost-cli')
-            .option('D', {
+            .option('d', {
+                alias: 'dir',
+                describe: 'Folder to run command in'
+            }).option('D', {
                 alias: 'development',
                 describe: 'Run in development mode',
                 type: 'boolean'

--- a/lib/command.js
+++ b/lib/command.js
@@ -107,7 +107,42 @@ class Command {
      * @method run
      * @private
      */
-    static _run(commandName, argv, extensions) {
+    static _run(commandName, argv = {}, extensions) {
+        debug('running command prep');
+        // Set process title
+        process.title = `ghost ${commandName}`;
+
+        // Create CLI-wide UI & System instances
+        const ui = new UI({
+            verbose: argv.verbose,
+            allowPrompt: argv.prompt
+        });
+
+        // This needs to run before the installation check
+        if (argv.dir) {
+            debug('Directory specified, attempting to update');
+            const path = require('path');
+            const dir = path.resolve(argv.dir);
+            try {
+                if (this.ensureDir) {
+                    const {ensureDirSync} = require('fs-extra');
+                    ensureDirSync(dir);
+                }
+
+                process.chdir(dir);
+            } catch (error) {
+                /* istanbul ignore next */
+                const err = error.message || error.code || error;
+                ui.log(`Unable to use "${dir}" (error ${err}). Please fix the issue and try again.`, 'red', true);
+                process.exit(1);
+            }
+            /* istanbul ignore next */
+            // In order to keep the rest of the function from running, chdir / exit is stubbed to
+            // throw an error in the tests so this line is technically unreachable. Since it's only
+            // a debug statement, we're not going to worry about it
+            debug('Finished updating directory');
+        }
+
         if (!this.global) {
             const checkValidInstall = require('./utils/check-valid-install');
 
@@ -120,15 +155,6 @@ class Command {
             checkRootUser(commandName);
         }
 
-        // Set process title
-        process.title = `ghost ${commandName}`;
-        const verbose = argv.verbose;
-
-        // Create CLI-wide UI & System instances
-        const ui = new UI({
-            verbose: verbose,
-            allowPrompt: argv.prompt
-        });
         const system = new System(ui, extensions);
 
         // Set the initial environment based on args or NODE_ENV

--- a/lib/command.js
+++ b/lib/command.js
@@ -136,10 +136,7 @@ class Command {
                 ui.log(`Unable to use "${dir}" (error ${err}). Please fix the issue and try again.`, 'red', true);
                 process.exit(1);
             }
-            /* istanbul ignore next */
-            // In order to keep the rest of the function from running, chdir / exit is stubbed to
-            // throw an error in the tests so this line is technically unreachable. Since it's only
-            // a debug statement, we're not going to worry about it
+
             debug('Finished updating directory');
         }
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -19,14 +19,6 @@ class InstallCommand extends Command {
         const yarnInstall = require('../tasks/yarn-install');
         const ensureStructure = require('../tasks/ensure-structure');
 
-        // Dir was specified, so we make sure it exists and chdir into it.
-        if (argv.dir) {
-            const dir = path.resolve(argv.dir);
-
-            fs.ensureDirSync(dir);
-            process.chdir(dir);
-        }
-
         let version = argv.version;
         const filesInDir = fs.readdirSync(process.cwd());
 
@@ -144,5 +136,6 @@ InstallCommand.options = {
     }
 };
 InstallCommand.checkVersion = true;
+InstallCommand.ensureDir = true;
 
 module.exports = InstallCommand;

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -35,7 +35,7 @@ class UI {
      * @param {Object} options
      */
     constructor(options) {
-        this.options = Object.assign(defaultOptions, options);
+        this.options = Object.assign({}, defaultOptions, options);
 
         // Set up i/o streams
         this.stdin = this.options.stdin;

--- a/test/unit/command-spec.js
+++ b/test/unit/command-spec.js
@@ -218,7 +218,7 @@ describe('Unit: Command', function () {
             }
             const Command = proxyquire(modulePath, {
                 './utils/check-root-user': checkRootUserStub,
-                './ui': ShortCircuit
+                './system': ShortCircuit
             });
 
             const TestCommand = class extends Command {};
@@ -226,7 +226,7 @@ describe('Unit: Command', function () {
             TestCommand.allowRoot = true;
 
             try {
-                TestCommand._run('test', {});
+                TestCommand._run('test', {dir: '.'});
             } catch (e) {
                 expect(e).to.exist;
                 expect(e.message).to.equal('you shall not pass');

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -39,26 +39,6 @@ describe('Unit: Commands > Install', function () {
             sinon.restore();
         })
 
-        it('creates dir and changes into it if --dir option is passed', function () {
-            const chdirStub = sinon.stub(process, 'chdir').throws();
-            const ensureDirStub = sinon.stub();
-
-            const InstallCommand = proxyquire(modulePath, {
-                'fs-extra': {ensureDirSync: ensureDirStub}
-            });
-            const testInstance = new InstallCommand({}, {});
-
-            try {
-                testInstance.run({dir: '/some/dir'});
-            } catch (e) {
-                // ignore error, chdir is supposed to throw the error
-                expect(ensureDirStub.calledOnce).to.be.true;
-                expect(ensureDirStub.calledWithExactly('/some/dir')).to.be.true;
-                expect(chdirStub.calledOnce).to.be.true;
-                expect(chdirStub.calledWithExactly('/some/dir')).to.be.true;
-            }
-        });
-
         it('rejects if directory is not empty', function () {
             const readdirStub = sinon.stub().returns([
                 '.ghost-cli',


### PR DESCRIPTION
Add ability to specify which directory Ghost should run in

refs + closes #538

WIP
- Should permissions even be checked? We already have improvements to Ghost doctor which included much more in-depth + variable permissions checks
- Tests 🙃 