### PR TITLE
fix(buster): make buster a gloabl command

### DIFF
--- a/lib/commands/buster.js
+++ b/lib/commands/buster.js
@@ -11,5 +11,6 @@ class BusterCommand extends Command {
 
 BusterCommand.description = 'Who ya gonna call?';
 BusterCommand.longDescription = 'When there\'s something strange in your neighborhood....';
+BusterCommand.global = true;
 
 module.exports = BusterCommand;


### PR DESCRIPTION
Yarn's cache is relative to the user, and has no requirement on any ghost instance.