### PR TITLE
fix(migrate): move setting of content-path to setup

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -107,6 +107,11 @@ class SetupCommand extends Command {
                 ctx.instance = this.system.getInstance();
                 ctx.instance.name = (argv.pname || url.parse(ctx.instance.config.get('url')).hostname).replace(/\./g, '-');
                 this.system.addInstance(ctx.instance);
+
+                // Ensure we set the content path when we set up the instance
+                if (!ctx.instance.config.has('paths.contentPath')) {
+                    ctx.instance.config.set('paths.contentPath', path.join(ctx.instance.dir, 'content')).save();
+                }
             }
         }];
 

--- a/lib/tasks/migrate.js
+++ b/lib/tasks/migrate.js
@@ -6,14 +6,10 @@ const errors = require('../errors');
 const ghostUser = require('../utils/use-ghost-user');
 
 module.exports = function runMigrations(context) {
-    const config = context.instance.config;
+    const {config, dir} = context.instance;
 
-    if (!config.has('paths.contentPath')) {
-        config.set('paths.contentPath', path.join(context.instance.dir, 'content')).save();
-    }
-
-    const contentDir = path.join(context.instance.dir, 'content');
-    const currentDir = path.join(context.instance.dir, 'current');
+    const contentDir = path.join(dir, 'content');
+    const currentDir = path.join(dir, 'current');
     let knexMigratorPromise;
 
     const args = ['--init', '--mgpath', currentDir];
@@ -21,12 +17,12 @@ module.exports = function runMigrations(context) {
     // If we're using sqlite and the ghost user owns the content folder, then
     // we should run sudo, otherwise run normally
     if (ghostUser.shouldUseGhostUser(contentDir)) {
-        const knexMigratorPath = path.resolve(context.instance.dir, 'current/node_modules/.bin/knex-migrator-migrate');
+        const knexMigratorPath = path.resolve(dir, 'current/node_modules/.bin/knex-migrator-migrate');
         knexMigratorPromise = context.ui.sudo(`${knexMigratorPath} ${args.join(' ')}`, {sudoArgs: '-E -u ghost'});
     } else {
         knexMigratorPromise = execa('knex-migrator-migrate', args, {
             preferLocal: true,
-            localDir: path.join(context.instance.dir, 'current')
+            localDir: path.join(dir, 'current')
         });
     }
 

--- a/test/unit/tasks/migrate-spec.js
+++ b/test/unit/tasks/migrate-spec.js
@@ -2,26 +2,15 @@
 const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
+const configStub = require('../../utils/config-stub');
 
 const errors = require('../../../lib/errors');
 
 const migratePath = '../../../lib/tasks/migrate';
 
-function getConfigStub(noContentPath) {
-    const config = {
-        get: sinon.stub(),
-        set: sinon.stub().returnsThis(),
-        has: sinon.stub(),
-        save: sinon.stub().returnsThis()
-    };
-
-    config.has.withArgs('paths.contentPath').returns(!noContentPath);
-    return config;
-}
-
 describe('Unit: Tasks > Migrate', function () {
     it('runs direct command if useGhostUser returns false', function () {
-        const config = getConfigStub(true);
+        const config = configStub();
         const execaStub = sinon.stub().resolves();
         const useGhostUserStub = sinon.stub().returns(false);
 
@@ -37,15 +26,11 @@ describe('Unit: Tasks > Migrate', function () {
             expect(useGhostUserStub.args[0][0]).to.equal('/some-dir/content');
             expect(execaStub.calledOnce).to.be.true;
             expect(sudoStub.called).to.be.false;
-            expect(config.has.calledOnce).to.be.true;
-            expect(config.set.calledOnce).to.be.true;
-            expect(config.set.args[0]).to.deep.equal(['paths.contentPath', '/some-dir/content']);
-            expect(config.save.called).to.be.true;
         });
     });
 
     it('runs sudo command if useGhostUser returns true', function () {
-        const config = getConfigStub();
+        const config = configStub();
         const execaStub = sinon.stub().resolves();
         const useGhostUserStub = sinon.stub().returns(true);
 
@@ -65,7 +50,7 @@ describe('Unit: Tasks > Migrate', function () {
     });
 
     it('throws config error with db host if database not found', function () {
-        const config = getConfigStub();
+        const config = configStub();
         const execaStub = sinon.stub().returns(Promise.reject({stderr: 'CODE: ENOTFOUND'}));
         const useGhostUserStub = sinon.stub().returns(false);
 
@@ -83,7 +68,7 @@ describe('Unit: Tasks > Migrate', function () {
     });
 
     it('throws config error with db user if access denied error', function () {
-        const config = getConfigStub();
+        const config = configStub();
         const execaStub = sinon.stub().returns(Promise.reject({stderr: 'CODE: ER_ACCESS_DENIED_ERROR'}));
         const useGhostUserStub = sinon.stub().returns(false);
 
@@ -101,7 +86,7 @@ describe('Unit: Tasks > Migrate', function () {
     });
 
     it('throws system error if sqlite3 error is thrown by knex', function () {
-        const config = getConfigStub();
+        const config = configStub();
         const execaStub = sinon.stub().returns(Promise.reject({stdout: 'Knex: run\n$ npm install sqlite3 --save\nError:'}));
         const useGhostUserStub = sinon.stub().returns(false);
 
@@ -123,7 +108,7 @@ describe('Unit: Tasks > Migrate', function () {
 
         process.argv = ['node', 'ghost', 'update'];
 
-        const config = getConfigStub();
+        const config = configStub();
         const execaStub = sinon.stub().rejects({stderr: 'YA_GOOFED'});
         const useGhostUserStub = sinon.stub().returns(false);
 
@@ -149,7 +134,7 @@ describe('Unit: Tasks > Migrate', function () {
 
         process.argv = ['node', 'ghost', 'setup', 'migrate'];
 
-        const config = getConfigStub();
+        const config = configStub();
         const execaStub = sinon.stub().rejects({stderr: 'YA_GOOFED'});
         const useGhostUserStub = sinon.stub().returns(false);
 


### PR DESCRIPTION
closes #708
- remove any need to save the config out of the migrations step
- instead, we set the content path during ghost setup

todo:
- [x] some manual testing