### PR TITLE
fix(run): local process manager forwards Ghost error message correctly

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -68,7 +68,7 @@ class RunCommand extends Command {
             }
 
             // NOTE: Backwards compatibility of https://github.com/TryGhost/Ghost/pull/9440
-            setTimeout(() => {instance.process.error(message.error);}, 1000);
+            setTimeout(() => {instance.process.error({message: message.error})}, 1000);
         });
     }
 

--- a/lib/utils/local-process.js
+++ b/lib/utils/local-process.js
@@ -60,7 +60,7 @@ Please ensure the content folder has correct permissions and try again.`));
             cp.on('message', (msg) => {
                 if (msg.error) {
                     fs.removeSync(path.join(cwd, PID_FILE));
-                    return reject(new errors.GhostError(msg.error));
+                    return reject(new errors.GhostError(msg.message));
                 }
 
                 /* istanbul ignore else */

--- a/test/unit/commands/run-spec.js
+++ b/test/unit/commands/run-spec.js
@@ -191,7 +191,7 @@ describe('Unit: Commands > Run', function () {
             try {
                 expect(successStub.called).to.be.false;
                 expect(errorStub.calledOnce).to.be.true;
-                expect(errorStub.calledWithExactly('oops I did it again')).to.be.true;
+                expect(errorStub.calledWithExactly({message: 'oops I did it again'})).to.be.true;
                 done();
             } catch (e) {
                 done(e);

--- a/test/unit/utils/local-process-spec.js
+++ b/test/unit/utils/local-process-spec.js
@@ -196,7 +196,7 @@ describe('Unit: Utils > local-process', function () {
                 done();
             });
 
-            cp.emit('message', {error: 'Test Error Message'});
+            cp.emit('message', {error: true, message: 'Test Error Message'});
         });
 
         it('writes pid to file, resolves on start message', function (done) {


### PR DESCRIPTION
closes #742

- the target process manager has not received the correct error format

I have tested production - it's different. On production we do the port polling and if Ghost does not start (because it's not a child process where we can easily receive an IPC message), we print the journalctl command to get the information why Ghost has not started.