### PR TITLE
fix(url): ensure trailing slash gets appended to url

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -22,7 +22,6 @@ class StartCommand extends Command {
 
     run(argv) {
         const ProcessManager = require('../process-manager');
-        const url  = require('url');
         const chalk = require('chalk');
 
         const instance = this.system.getInstance();
@@ -64,7 +63,8 @@ class StartCommand extends Command {
                         const isInstall = process.argv[2] === 'install';
                         let adminUrl = instance.config.get('admin.url') || instance.config.get('url');
 
-                        adminUrl = url.resolve(adminUrl, '/ghost/');
+                        // Strip the trailing slash and add the admin path
+                        adminUrl = `${adminUrl.replace(/\/$/,'')}/ghost/`;
 
                         this.ui.log(`You can access your publication at ${chalk.cyan(instance.config.get('url'))}`, 'white');
 

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -208,6 +208,26 @@ describe('Unit: Commands > Start', function () {
             });
         });
 
+        it('is normally loud', function () {
+            myInstance.config.get.withArgs('url').returns('https://my-amazing.site/blog');
+            myInstance.process = {};
+            const ui = {
+                run: () => Promise.resolve(),
+                listr: () => Promise.resolve(),
+                log: sinon.stub()
+            };
+            const start = new StartCommand(ui, mySystem);
+            const runCommandStub = sinon.stub(start, 'runCommand').resolves();
+            return start.run({enable: false}).then(() => {
+                expect(runCommandStub.calledOnce).to.be.true;
+                expect(ui.log.calledTwice).to.be.true;
+                expect(ui.log.args[0][0]).to.match(/You can access your publication at/);
+                expect(ui.log.args[0][0]).to.include('https://my-amazing.site/blog');
+                expect(ui.log.args[1][0]).to.match(/Your admin interface is located at/);
+                expect(ui.log.args[1][0]).to.include('https://my-amazing.site/blog/ghost/');
+            });
+        });
+
         it('shows custom admin url', function () {
             const oldArgv = process.argv;
             process.argv = ['', '', 'start']


### PR DESCRIPTION
closes #748 

The root of the problem stems from the fact we don't ensure trailing slashes when we set the URL. It's well-known that Ghost redirects URLs w/o a trailing slash to the trailing slash equivalent, so we might as well add the trailing slash here

Something that I would like to do but I'm not sure how to go about doing is add the trailing slash for existing installations. I know I can add a migration, but we also need to expect the URL will not be correct since it can be modified by running `ghost config set url https://my.site/blog`

