### PR TITLE
feat(startup): improve startup time by lazily requiring ui deps

### DIFF
--- a/bin/ghost
+++ b/bin/ghost
@@ -11,6 +11,14 @@ if (argv.length === 0) {
     process.exit(1);
 }
 
+const debug = require('debug')('ghost-cli:bin');
+
+debug('Starting Ghost-CLI');
+
 const yargs = require('yargs');
+debug('args parser loaded');
+
 const bootstrap = require('../lib/bootstrap');
+debug('bootstrap loaded');
+
 bootstrap.run(argv, yargs);

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -1,20 +1,19 @@
 'use strict';
-const ora       = require('ora');
-const omit      = require('lodash/omit');
-const chalk     = require('chalk');
-const execa     = require('execa');
-const Listr     = require('listr');
-const Table     = require('cli-table3');
-const Promise   = require('bluebird');
-const inquirer  = require('inquirer');
-const isObject  = require('lodash/isObject');
-const stripAnsi = require('strip-ansi');
-const ListrError = require('listr/lib/listr-error');
-const logSymbols = require('log-symbols');
-const isFunction = require('lodash/isFunction');
 
-const errors = require('../errors');
+const ora         = require('ora');
+const Promise     = require('bluebird');
+const isObject    = require('lodash/isObject');
+const logSymbols  = require('log-symbols');
+const isFunction  = require('lodash/isFunction');
+const lazyRequire = require('import-lazy')(require);
 const CLIRenderer = require('./renderer');
+
+const omit = lazyRequire('lodash/omit');
+const chalk = lazyRequire('chalk');
+const execa = lazyRequire('execa');
+const Listr = lazyRequire('listr');
+const Table = lazyRequire('cli-table3');
+const errors = lazyRequire('../errors');
 
 const defaultOptions = {
     stdin: process.stdin,
@@ -44,14 +43,21 @@ class UI {
         this.verbose = this.options.verbose;
         this.allowPrompt = this.options.allowPrompt && Boolean(this.stdout.isTTY);
 
-        // Add custom prompt module that uses the
-        // specified streams
-        this.inquirer = inquirer.createPromptModule({
-            input: this.stdin,
-            output: this.stdout
-        });
-
         CLIRenderer.ui = this;
+    }
+
+    get inquirer() {
+        if (!this._inquirer) {
+            // Add custom prompt module that uses the
+            // specified streams
+            const inquirer = require('inquirer');
+            this._inquirer = inquirer.createPromptModule({
+                input: this.stdin,
+                output: this.stdout
+            });
+        }
+
+        return this._inquirer;
     }
 
     /**
@@ -316,6 +322,9 @@ class UI {
      * @public
      */
     error(error, system) {
+        const stripAnsi   = require('strip-ansi');
+        const ListrError  = require('listr/lib/listr-error');
+
         const debugInfo = this._formatDebug(system);
 
         if (error instanceof errors.CliError) {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "generate-password": "1.4.0",
     "global-modules": "1.0.0",
     "got": "8.3.1",
+    "import-lazy": "3.1.0",
     "inquirer": "5.2.0",
     "is-running": "2.1.0",
     "latest-version": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,6 +1915,10 @@ ignore@^3.3.3:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
+import-lazy@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
no issue
- dep: import-lazy@3.1.0
- add debug instrumentation to bin file
- lazily-import ui dependencies

Before these changes (key line is the "bootstrap loaded" line):
<img width="1144" alt="screen shot 2018-07-13 at 6 15 57 pm" src="https://user-images.githubusercontent.com/5167581/42716373-30cf93be-86c9-11e8-9c4d-8b330738d832.png">

After these changes:
<img width="1127" alt="screen shot 2018-07-13 at 6 16 55 pm" src="https://user-images.githubusercontent.com/5167581/42716379-350842dc-86c9-11e8-906c-bac151c220f3.png">

The biggest 2 offenders (found by instrumenting each require in the UI library, were Listr (which took about 1s) and inquirer (which also took about 1s). Lazily requiring each of these reduced the startup time fairly significantly.
