### PR TITLE
fix(config): disallow URLs ending with `/ghost`

### DIFF
--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -3,6 +3,7 @@
 const portfinder = require('portfinder');
 const toString = require('lodash/toString');
 const validator = require('validator');
+const validateInstanceURL = require('../../utils/validate-instance-url');
 const url = require('url');
 
 const BASE_PORT = 2368;
@@ -21,15 +22,7 @@ const knownMailServices = [
 module.exports = {
     url: {
         description: 'Blog URL with protocol E.g. http://loveghost.com',
-        validate: (value) => {
-            const urlValidation = validator.isURL(value, {require_protocol: true});
-            const endsWithGhost = new RegExp('(?:/ghost/?)$', 'i');
-            if (urlValidation) {
-                return (!endsWithGhost.test(value)) || 'Ghost doesn\'t support running in a path that ends with `ghost`';
-            }
-
-            return 'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com';
-        },
+        validate: validateInstanceURL,
         transform: value => value.toLowerCase(),
         type: 'string',
         group: 'Ghost Options:'

--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -21,8 +21,15 @@ const knownMailServices = [
 module.exports = {
     url: {
         description: 'Blog URL with protocol E.g. http://loveghost.com',
-        validate: value => validator.isURL(value, {require_protocol: true}) ||
-            'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com',
+        validate: (value) => {
+            const urlValidation = validator.isURL(value, {require_protocol: true});
+            const endsWithGhost = new RegExp('(?:/ghost/?)$', 'i');
+            if (urlValidation) {
+                return (!endsWithGhost.test(value)) || 'Ghost doesn\'t support running in a path that ends with `ghost`';
+            }
+
+            return 'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com';
+        },
         transform: value => value.toLowerCase(),
         type: 'string',
         group: 'Ghost Options:'

--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -91,7 +91,7 @@ class ConfigCommand extends Command {
     }
 
     getConfigPrompts(argv) {
-        const validator = require('validator');
+        const validateInstanceURL = require('../../utils/validate-instance-url');
         const path = require('path');
 
         const prompts = [];
@@ -103,15 +103,7 @@ class ConfigCommand extends Command {
                 name: 'url',
                 message: 'Enter your blog URL:',
                 default: this.instance.config.get('url', 'http://localhost:2368'),
-                validate: (value) => {
-                    const urlValidation = validator.isURL(value, {require_protocol: true});
-                    const endsWithGhost = new RegExp('(?:/ghost/?)$', 'i');
-                    if (urlValidation) {
-                        return (!endsWithGhost.test(value)) || 'Ghost doesn\'t support running in a path that ends with `ghost`';
-                    }
-
-                    return 'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com';
-                }
+                validate: validateInstanceURL
             });
         }
 

--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -103,8 +103,15 @@ class ConfigCommand extends Command {
                 name: 'url',
                 message: 'Enter your blog URL:',
                 default: this.instance.config.get('url', 'http://localhost:2368'),
-                validate: (value) => validator.isURL(value, {require_protocol: true}) ||
-                    'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com'
+                validate: (value) => {
+                    const urlValidation = validator.isURL(value, {require_protocol: true});
+                    const endsWithGhost = new RegExp('(?:/ghost/?)$', 'i');
+                    if (urlValidation) {
+                        return (!endsWithGhost.test(value)) || 'Ghost doesn\'t support running in a path that ends with `ghost`';
+                    }
+
+                    return 'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com';
+                }
             });
         }
 

--- a/lib/utils/validate-instance-url.js
+++ b/lib/utils/validate-instance-url.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const {isURL} = require('validator');
+const endsWithGhost = /\/ghost\/?$/i;
+
+module.exports = function validateURL(url) {
+    const isValidURL = isURL(url, {require_protocol: true});
+    if (!isValidURL) {
+        return 'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com';
+    }
+
+    return (!endsWithGhost.test(url)) || 'Ghost doesn\'t support running in a path that ends with `ghost`';
+};

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -183,14 +183,13 @@ describe('Unit: Command > Config', function () {
         });
 
         it('returns url prompt with validator if url is not provided and db is sqlite3', function () {
+            const expectedValidator = require('../../../lib/utils/validate-instance-url')
             const argv = {db: 'sqlite3'};
             const result = config.getConfigPrompts(argv);
 
             expect(result).to.have.length(1);
             expect(result[0].name).to.equal('url');
-            expect(result[0].validate('http://localhost:2368')).to.be.true;
-            expect(result[0].validate('notaurl')).to.match(/Invalid URL/);
-            expect(result[0].validate('https://localhost:2368/ghost')).to.match(/path that ends with `ghost`/);
+            expect(result[0].validate).to.equal(expectedValidator);
         });
 
         it('returns db prompts if db arg not provided', function () {
@@ -466,13 +465,11 @@ describe('Unit: Command > Config', function () {
     describe('advanced options', function () {
         it('url', function () {
             const advancedOptions = require(advancedModulePath);
+            const expectedValidator = require('../../../lib/utils/validate-instance-url');
             expect(advancedOptions.url).to.exist;
 
             // Check validate function
-            expect(advancedOptions.url.validate('http://localhost:2368')).to.be.true;
-            expect(advancedOptions.url.validate('localhost:2368')).to.match(/Invalid URL/);
-            expect(advancedOptions.url.validate('not even remotely a URL')).to.match(/Invalid URL/);
-            expect(advancedOptions.url.validate('http://localhost:2368/ghost')).to.match(/path that ends with `ghost`/);
+            expect(advancedOptions.url.validate).to.equal(expectedValidator);
 
             // Check transform function
             expect(advancedOptions.url.transform('http://MyUpperCaseUrl.com')).to.equal('http://myuppercaseurl.com');

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -190,6 +190,7 @@ describe('Unit: Command > Config', function () {
             expect(result[0].name).to.equal('url');
             expect(result[0].validate('http://localhost:2368')).to.be.true;
             expect(result[0].validate('notaurl')).to.match(/Invalid URL/);
+            expect(result[0].validate('https://localhost:2368/ghost')).to.match(/path that ends with `ghost`/);
         });
 
         it('returns db prompts if db arg not provided', function () {
@@ -471,6 +472,7 @@ describe('Unit: Command > Config', function () {
             expect(advancedOptions.url.validate('http://localhost:2368')).to.be.true;
             expect(advancedOptions.url.validate('localhost:2368')).to.match(/Invalid URL/);
             expect(advancedOptions.url.validate('not even remotely a URL')).to.match(/Invalid URL/);
+            expect(advancedOptions.url.validate('http://localhost:2368/ghost')).to.match(/path that ends with `ghost`/);
 
             // Check transform function
             expect(advancedOptions.url.transform('http://MyUpperCaseUrl.com')).to.equal('http://myuppercaseurl.com');

--- a/test/unit/utils/validate-instance-url.js
+++ b/test/unit/utils/validate-instance-url.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const {expect} = require('chai');
+
+const validateURL = require('../../../lib/utils/validate-instance-url');
+
+describe('Unit: Utils > validateInstanceURL', function () {
+    it('non-URLs fail', function () {
+        expect(validateURL('totally a url')).to.match(/Invalid URL/);
+        expect(validateURL('notaurl')).to.match(/Invalid URL/);
+    });
+
+    it('protocol-free URLs fail', function () {
+        expect(validateURL('myghost.blog')).to.match(/include a protocol/);
+    });
+
+    it('trailing `ghost` subdir fails', function () {
+        expect(validateURL('https://myghost.blog/myghost/')).to.be.true;
+        expect(validateURL('https://myghost.blog/ghosted/')).to.be.true;
+        expect(validateURL('https://myghost.blog/ghost')).to.match(/path that ends with `ghost`/);
+        expect(validateURL('https://myghost.blog/ghost/')).to.match(/path that ends with `ghost`/);
+    });
+
+    it('everything else works', function () {
+        expect(validateURL('http://localhost:2368/')).to.be.true;
+        expect(validateURL('http://localhost:2368/testing')).to.be.true;
+        expect(validateURL('https://myghost.blog/')).to.be.true;
+        expect(validateURL('https://ghost.org/blog')).to.be.true;
+        expect(validateURL('https://blog.ghost.org/')).to.be.true;
+    });
+});


### PR DESCRIPTION
closes #754 

I'm not sure if there should be an additional check w/ `ghost start` (it's possible to manually configure the URL so the config check wouldn't be run) - adding it would require additional checks because the admin URL could differ from the hosted URL