### PR TITLE
Update check ui improvements

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -72,31 +72,33 @@ class UI {
      * @method run
      * @public
      */
-    run(promiseOrFunction, name, options) {
-        options = options || {};
-        options.text = options.text || name;
-        options.spinner = options.spinner || 'hamburger';
-        options.stream = this.stdout;
+    run(promiseOrFunction, name, options = {}) {
+        const {
+            text = name,
+            spinner = 'hamburger',
+            stream = this.stdout,
+            clear = false,
+            quiet = false
+        } = options;
+
+        const fn = () => Promise.resolve(isFunction(promiseOrFunction) ? promiseOrFunction() : promiseOrFunction);
 
         // The --quiet flag will skip outputting anything to the UI.
-        if (options.quiet) {
-            return Promise.resolve(isFunction(promiseOrFunction) ? promiseOrFunction() : promiseOrFunction);
+        if (quiet) {
+            return fn();
         }
 
-        this.spinner = ora(options).start();
+        this.spinner = ora({text, spinner, stream}).start();
 
-        return Promise.resolve(isFunction(promiseOrFunction) ? promiseOrFunction() : promiseOrFunction)
-            .then((result) => {
-                this.spinner.succeed();
-
-                return Promise.resolve(result);
-            }).catch((error) => {
-                this.spinner.fail();
-
-                return Promise.reject(error);
-            }).finally(() => {
-                this.spinner = null;
-            });
+        return fn().then((result) => {
+            this.spinner[clear ? 'stop' : 'succeed']();
+            return Promise.resolve(result);
+        }).catch((error) => {
+            this.spinner.fail();
+            return Promise.reject(error);
+        }).finally(() => {
+            this.spinner = null;
+        });
     }
 
     /**

--- a/lib/utils/update-check.js
+++ b/lib/utils/update-check.js
@@ -8,7 +8,11 @@ const pkg = require('../../package.json');
  * @param {UI} ui ui instance
  */
 module.exports = function updateCheck(ui) {
-    return latestVersion(pkg.name).then((latest) => {
+    return ui.run(
+        () => latestVersion(pkg.name),
+        'Checking for Ghost-CLI updates',
+        {clear: true}
+    ).then((latest) => {
         if (semver.lt(pkg.version, latest)) {
             const chalk = require('chalk');
 

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -65,7 +65,8 @@ describe('Unit: UI', function () {
     describe('run', function () {
         const spinner = {
             succeed: sinon.stub(),
-            fail: sinon.stub()
+            fail: sinon.stub(),
+            stop: sinon.stub()
         };
 
         const startStub = sinon.stub().returns(spinner);
@@ -77,6 +78,7 @@ describe('Unit: UI', function () {
         afterEach(() => {
             spinner.succeed.reset();
             spinner.fail.reset();
+            spinner.stop.reset();
             startStub.resetHistory();
             oraStub.resetHistory();
         });
@@ -147,6 +149,26 @@ describe('Unit: UI', function () {
                 })).to.be.true;
                 expect(startStub.calledOnce).to.be.true;
                 expect(spinner.succeed.calledOnce).to.be.true;
+                expect(ui.spinner, 'spinner is set to null').to.be.null;
+            });
+        });
+
+        it('starts spinner with options, handles clear option', function () {
+            const ui = new UI({stdout: {stdout: true}});
+            const testFunc = sinon.stub().resolves('foo');
+
+            return ui.run(testFunc, null, {text: 'do a thing', spinner: 'dots', clear: true}).then((result) => {
+                expect(result).to.equal('foo');
+                expect(testFunc.calledOnce).to.be.true;
+                expect(oraStub.calledOnce).to.be.true;
+                expect(oraStub.calledWithExactly({
+                    text: 'do a thing',
+                    spinner: 'dots',
+                    stream: {stdout: true}
+                })).to.be.true;
+                expect(startStub.calledOnce).to.be.true;
+                expect(spinner.stop.calledOnce).to.be.true;
+                expect(spinner.succeed.called).to.be.false;
                 expect(ui.spinner, 'spinner is set to null').to.be.null;
             });
         });


### PR DESCRIPTION
- add a `clear` option to `UI.run` that will clear the output on promise resolution
- wrap update check in `ui.run` so that on slow connections something is visibly happening.