### PR TITLE
fix(nginx): skip uninstall if url is not set

### DIFF
--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -223,8 +223,14 @@ class NginxExtension extends cli.Extension {
         }], false);
     }
 
-    uninstall(instance) {
-        const parsedUrl = url.parse(instance.config.get('url'));
+    uninstall({config}) {
+        const instanceUrl = config.get('url');
+
+        if (!instanceUrl) {
+            return Promise.resolve();
+        }
+
+        const parsedUrl = url.parse(instanceUrl);
         const confFile = `${parsedUrl.hostname}.conf`;
         const sslConfFile = `${parsedUrl.hostname}-ssl.conf`;
 

--- a/extensions/nginx/test/extension-spec.js
+++ b/extensions/nginx/test/extension-spec.js
@@ -653,6 +653,18 @@ describe('Unit: Extensions > Nginx', function () {
     describe('uninstall hook', function () {
         const instance = {config: {get: () => 'http://ghost.dev'}};
         const testEs = (val) => (new RegExp(/-ssl/)).test(val);
+
+        it('returns if no url exists in config', function () {
+            const config = {get: () => undefined};
+            const existsSync = sinon.stub().returns(false);
+            const ext = proxyNginx({'fs-extra': {existsSync}});
+
+            return ext.uninstall({config}).then(() => {
+                expect(existsSync.called).to.be.false;
+                expect(ext.restartNginx.called).to.be.false;
+            });
+        });
+
         it('Leaves nginx alone when no config file exists', function () {
             const esStub = sinon.stub().returns(false);
             const ext = proxyNginx({'fs-extra': {existsSync: esStub}});


### PR DESCRIPTION
no issue
- if you run `ghost install --no-setup` and then try to run `ghost uninstall`, the nginx extension would throw an error. This removes that error