### PR TITLE
Added handling for knex-migrator being executed in Ghost 2.0

### DIFF
--- a/extensions/systemd/test/systemd-spec.js
+++ b/extensions/systemd/test/systemd-spec.js
@@ -5,6 +5,7 @@ const proxyquire = require('proxyquire').noCallThru();
 
 const modulePath = '../systemd';
 const errors = require('../../../lib/errors');
+const configStub = require('../../../test/utils/config-stub');
 const Systemd = require(modulePath);
 
 const instance = {
@@ -30,6 +31,7 @@ describe('Unit: Systemd > Process Manager', function () {
         let ext, ui;
 
         beforeEach(function () {
+            instance.config = configStub();
             ui = {sudo: sinon.stub().resolves()},
             ext = new Systemd(ui, null, instance);
             ext.ensureStarted = sinon.stub().resolves();

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -41,6 +41,7 @@ class SetupCommand extends Command {
         const os = require('os');
         const url  = require('url');
         const path = require('path');
+        const semver = require('semver');
 
         const linux = require('../tasks/linux');
         const migrate = require('../tasks/migrate');
@@ -171,10 +172,20 @@ class SetupCommand extends Command {
             }));
 
             if (argv.migrate !== false) {
+                const instance = this.system.getInstance();
+
                 // Tack on db migration task to the end
                 tasks.push({
                     title: 'Running database migrations',
-                    task: migrate
+                    task: migrate,
+                    // CASE: We are about to install Ghost 2.0. We moved the execution of knex-migrator into Ghost.
+                    enabled: () => {
+                        if (semver.satisfies(instance.cliConfig.get('active-version'), '^2.0.0')) {
+                            return false;
+                        }
+
+                        return true;
+                    }
                 });
             }
 

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -73,7 +73,17 @@ class UpdateCommand extends Command {
             }, {
                 title: 'Running database migrations',
                 skip: (ctx) => ctx.rollback,
-                task: migrate
+                task: migrate,
+                // CASE: We have moved the execution of knex-migrator into Ghost 2.0.0.
+                //       If you are already on ^2 or you update from ^1 to ^2, then skip the task.
+                enabled: () => {
+                    if (semver.satisfies(instance.cliConfig.get('active-version'), '^2.0.0') ||
+                        semver.satisfies(context.version, '^2.0.0')) {
+                        return false;
+                    }
+
+                    return true;
+                }
             }, {
                 title: 'Restarting Ghost',
                 skip: () => !argv.restart,

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -70,11 +70,13 @@ class ProcessManager {
      */
     ensureStarted(options) {
         const portPolling = require('./utils/port-polling');
+        const semver = require('semver');
 
         options = Object.assign({
             stopOnError: true,
             port: this.instance.config.get('server.port'),
-            host: this.instance.config.get('server.host', 'localhost')
+            host: this.instance.config.get('server.host', 'localhost'),
+            useNetServer: semver.satisfies(this.instance.cliConfig.get('active-version'), '^2.0.0')
         }, options || {});
 
         return portPolling(options).catch((err) => {

--- a/lib/utils/port-polling.js
+++ b/lib/utils/port-polling.js
@@ -1,16 +1,71 @@
 'use strict';
 
-const net = require('net');
 const errors = require('../errors');
 
-module.exports = function portPolling(options) {
-    options = Object.assign({
-        timeoutInMS: 2000,
-        maxTries: 20,
-        delayOnConnectInMS: 3 * 2000,
-        logSuggestion: 'ghost log',
-        socketTimeoutInMS: 1000 * 60
-    }, options || {});
+/**
+ * @TODO: in theory it could happen that other clients connect, but tbh even with the port polling it was possible: you
+ *        could just start a server on the Ghost port
+ */
+const useNetServer = (options)=> {
+    return new Promise((resolve, reject)=> {
+        const net = require('net');
+        let waitTimeout = null;
+        let ghostSocket = null;
+
+        const server = net.createServer((socket)=> {
+            ghostSocket = socket;
+
+            socket.on('data', (data) => {
+                let message;
+
+                try {
+                    message = JSON.parse(data);
+                } catch (err) {
+                    message = {started: false, error: err};
+                }
+
+                if (waitTimeout) {
+                    clearTimeout(waitTimeout);
+                }
+
+                socket.destroy();
+                ghostSocket = null;
+
+                server.close(() => {
+                    if (message.started) {
+                        resolve();
+                    } else {
+                        reject(new errors.GhostError({
+                            message: message.error.message,
+                            help: message.error.help,
+                            suggestion: options.logSuggestion
+                        }));
+                    }
+                });
+            });
+        });
+
+        waitTimeout = setTimeout(() => {
+            if (ghostSocket) {
+                ghostSocket.destroy();
+            }
+
+            ghostSocket = null;
+
+            server.close(() => {
+                reject(new errors.GhostError({
+                    message: 'Could not communicate with Ghost',
+                    suggestion: options.logSuggestion
+                }));
+            });
+        }, options.netServerTimeoutInMS);
+
+        server.listen({host: options.socketAddress.host, port: options.socketAddress.port});
+    });
+};
+
+const usePortPolling = (options)=> {
+    const net = require('net');
 
     if (!options.port) {
         return Promise.reject(new errors.CliError({
@@ -18,7 +73,7 @@ module.exports = function portPolling(options) {
         }));
     }
 
-    const connectToGhostSocket = (() => {
+    const connectToGhostSocket = () => {
         return new Promise((resolve, reject) => {
             // if host is specified and is *not* 0.0.0.0 (listen on all ips), use the custom host
             const host = options.host && options.host !== '0.0.0.0' ? options.host : 'localhost';
@@ -35,7 +90,7 @@ module.exports = function portPolling(options) {
                 ghostSocket.destroy();
 
                 // force retry
-                const err = new Error();
+                const err = new Error('Socket timed out.');
                 err.retry = true;
                 reject(err);
             }));
@@ -73,7 +128,7 @@ module.exports = function portPolling(options) {
                 reject(err);
             }));
         });
-    });
+    };
 
     const startPolling = (() => {
         return new Promise((resolve, reject) => {
@@ -87,8 +142,12 @@ module.exports = function portPolling(options) {
                     .catch((err) => {
                         if (err.retry && tries < options.maxTries) {
                             tries = tries + 1;
-                            setTimeout(retry, options.timeoutInMS);
+                            setTimeout(retry, options.retryTimeoutInMS);
                             return;
+                        }
+
+                        if (err instanceof errors.CliError) {
+                            return reject(err);
                         }
 
                         reject(new errors.GhostError({
@@ -102,4 +161,26 @@ module.exports = function portPolling(options) {
     });
 
     return startPolling();
+};
+
+module.exports = function portPolling(options) {
+    options = Object.assign({
+        retryTimeoutInMS: 2000,
+        maxTries: 20,
+        delayOnConnectInMS: 3 * 2000,
+        logSuggestion: 'ghost log',
+        socketTimeoutInMS: 1000 * 60,
+        useNetServer: false,
+        netServerTimeoutInMS: 5 * 60 * 1000,
+        socketAddress: {
+            port: 1212,
+            host: 'localhost'
+        }
+    }, options || {});
+
+    if (options.useNetServer) {
+        return useNetServer(options);
+    }
+
+    return usePortPolling(options);
 };

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -67,12 +67,15 @@ describe('Unit: Process Manager', function () {
         });
 
         it('calls portPolling with options', function () {
+            const cliConfig = getConfigStub();
             const config = getConfigStub();
+
+            cliConfig.get.withArgs('active-version').returns('1.25.0');
             config.get.withArgs('server.port').returns(2368);
             config.get.withArgs('server.host').returns('10.0.1.0');
             portPollingStub.resolves();
 
-            const instance = new ProcessManager({}, {}, {config: config});
+            const instance = new ProcessManager({}, {}, {config, cliConfig});
             const stopStub = sinon.stub(instance, 'stop').resolves();
 
             return instance.ensureStarted({logSuggestion: 'test'}).then(() => {
@@ -82,19 +85,23 @@ describe('Unit: Process Manager', function () {
                     logSuggestion: 'test',
                     stopOnError: true,
                     port: 2368,
-                    host: '10.0.1.0'
+                    host: '10.0.1.0',
+                    useNetServer: false
                 })).to.be.true;
                 expect(stopStub.called).to.be.false;
             });
         });
 
         it('throws error without stopping if stopOnError is false', function () {
+            const cliConfig = getConfigStub();
             const config = getConfigStub();
+
+            cliConfig.get.withArgs('active-version').returns('1.25.0');
             config.get.withArgs('server.port').returns(2368);
             config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
-            const instance = new ProcessManager({}, {}, {config: config});
+            const instance = new ProcessManager({}, {}, {config, cliConfig});
             const stopStub = sinon.stub(instance, 'stop').resolves();
 
             return instance.ensureStarted({stopOnError: false}).then(() => {
@@ -105,19 +112,23 @@ describe('Unit: Process Manager', function () {
                 expect(portPollingStub.calledWithExactly({
                     stopOnError: false,
                     port: 2368,
-                    host: 'localhost'
+                    host: 'localhost',
+                    useNetServer: false
                 })).to.be.true;
                 expect(stopStub.called).to.be.false;
             });
         });
 
         it('throws error and calls stop if stopOnError is true', function () {
+            const cliConfig = getConfigStub();
             const config = getConfigStub();
+
+            cliConfig.get.withArgs('active-version').returns('1.25.0');
             config.get.withArgs('server.port').returns(2368);
             config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
-            const instance = new ProcessManager({}, {}, {config: config});
+            const instance = new ProcessManager({}, {}, {config, cliConfig});
             const stopStub = sinon.stub(instance, 'stop').resolves();
 
             return instance.ensureStarted({}).then(() => {
@@ -129,19 +140,23 @@ describe('Unit: Process Manager', function () {
                 expect(portPollingStub.calledWithExactly({
                     stopOnError: true,
                     port: 2368,
-                    host: 'localhost'
+                    host: 'localhost',
+                    useNetServer: false
                 })).to.be.true;
                 expect(stopStub.calledOnce).to.be.true;
             });
         });
 
         it('throws error and calls stop (swallows stop error) if stopOnError is true', function () {
+            const cliConfig = getConfigStub();
             const config = getConfigStub();
+
+            cliConfig.get.withArgs('active-version').returns('1.25.0');
             config.get.withArgs('server.port').returns(2368);
             config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
-            const instance = new ProcessManager({}, {}, {config: config});
+            const instance = new ProcessManager({}, {}, {config, cliConfig});
             const stopStub = sinon.stub(instance, 'stop').rejects(new Error('test error 2'));
 
             return instance.ensureStarted().then(() => {
@@ -153,7 +168,8 @@ describe('Unit: Process Manager', function () {
                 expect(portPollingStub.calledWithExactly({
                     stopOnError: true,
                     port: 2368,
-                    host: 'localhost'
+                    host: 'localhost',
+                    useNetServer: false
                 })).to.be.true;
                 expect(stopStub.calledOnce).to.be.true;
             });

--- a/test/unit/utils/port-polling-spec.js
+++ b/test/unit/utils/port-polling-spec.js
@@ -20,178 +20,338 @@ describe('Unit: Utils > portPolling', function () {
             });
     });
 
-    it('Ghost does never start', function () {
-        const netStub = sinon.stub();
+    describe('useNetServer is enabled', function () {
+        it('Ghost does start', function () {
+            const netStub = sinon.stub();
+            const socketStub = sinon.stub();
 
-        netStub.setTimeout = sinon.stub();
-        netStub.destroy = sinon.stub();
-        netStub.on = function (event, cb) {
-            if (event === 'error') {
-                cb(new Error('whoops'));
-            }
-        };
-
-        const connectStub = sinon.stub(net, 'connect').returns(netStub);
-
-        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100})
-            .then(() => {
-                throw new Error('Expected error');
-            })
-            .catch((err) => {
-                expect(err.options.suggestion).to.exist;
-                expect(err.message).to.eql('Ghost did not start.');
-                expect(err.err.message).to.eql('whoops');
-                expect(connectStub.callCount).to.equal(4);
-                expect(connectStub.calledWithExactly(1111, 'localhost'), 'uses localhost by default').to.be.true;
-                expect(netStub.destroy.callCount).to.eql(4);
+            socketStub.on = sinon.stub().callsFake((event, cb) => {
+                if (event === 'data') {
+                    cb(JSON.stringify({started: true}));
+                }
             });
-    });
 
-    it('Ghost does start, but falls over', function () {
-        const netStub = sinon.stub();
+            socketStub.destroy = sinon.stub();
 
-        netStub.setTimeout = sinon.stub();
-        netStub.destroy = sinon.stub();
-
-        let i = 0;
-        netStub.on = function (event, cb) {
-            i = i + 1;
-
-            if (event === 'close') {
+            netStub.listen = sinon.stub();
+            netStub.close = sinon.stub().callsFake((cb)=> {
                 cb();
-            } else if (event === 'error' && i === 3) {
-                cb(new Error());
-            } else if (event === 'connect' && i === 5) {
-                cb();
-            }
-        };
-
-        const connectStub = sinon.stub(net, 'connect').returns(netStub);
-
-        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100, delayOnConnectInMS: 150, host: '0.0.0.0'})
-            .then(() => {
-                throw new Error('Expected error');
-            })
-            .catch((err) => {
-                expect(err.options.suggestion).to.exist;
-                expect(err.message).to.eql('Ghost did not start.');
-                expect(connectStub.calledTwice).to.be.true;
-                expect(connectStub.calledWithExactly(1111, 'localhost'), 'uses localhost if host is 0.0.0.0').to.be.true;
-                expect(netStub.destroy.callCount).to.eql(2);
             });
-    });
 
-    it('Ghost does start', function () {
-        const netStub = sinon.stub();
-
-        netStub.setTimeout = sinon.stub();
-        netStub.destroy = sinon.stub();
-
-        let i = 0;
-        netStub.on = function (event, cb) {
-            i = i + 1;
-
-            if (i === 6) {
-                expect(event).to.eql('close');
-            } else if (i === 5 && event === 'connect') {
-                cb();
-            } else if (i === 3 && event === 'error') {
-                cb(new Error());
-            }
-        };
-
-        const connectStub = sinon.stub(net, 'connect').returns(netStub);
-
-        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100, delayOnConnectInMS: 150, host: '10.0.1.0'})
-            .then(() => {
-                expect(connectStub.calledTwice).to.be.true;
-                expect(connectStub.calledWithExactly(1111, '10.0.1.0'), 'uses custom host').to.be.true;
-                expect(netStub.destroy.callCount).to.eql(2);
-            })
-            .catch((err) => {
-                throw err;
-            });
-    });
-
-    it('Ghost does start, skip delay on connect', function () {
-        const netStub = sinon.stub();
-
-        netStub.setTimeout = sinon.stub();
-        netStub.destroy = sinon.stub();
-
-        netStub.on = function (event, cb) {
-            expect(event).to.not.eql('close');
-
-            if (event === 'connect') {
-                cb();
-            }
-        };
-
-        sinon.stub(net, 'connect').returns(netStub);
-
-        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100, delayOnConnectInMS: false})
-            .then(() => {
-                expect(netStub.destroy.callCount).to.eql(1);
-            })
-            .catch((err) => {
-                throw err;
-            });
-    });
-
-    it('socket times out', function () {
-        const netStub = sinon.stub();
-
-        netStub.setTimeout = sinon.stub();
-        netStub.destroy = sinon.stub();
-
-        netStub.on = function (event, cb) {
-            if (event === 'timeout') {
-                cb();
-            }
-        };
-
-        sinon.stub(net, 'connect').returns(netStub);
-
-        return portPolling({port: 1111, maxTries: 3, timeoutInMS: 100, socketTimeoutInMS: 300})
-            .then(() => {
-                throw new Error('Expected error');
-            })
-            .catch((err) => {
-                expect(err.options.suggestion).to.exist;
-                expect(err.message).to.eql('Ghost did not start.');
-                expect(netStub.destroy.callCount).to.eql(4);
-            });
-    });
-
-    it('Ghost connects, but socket times out kicks in', function () {
-        const netStub = sinon.stub();
-
-        netStub.setTimeout = sinon.stub();
-        netStub.destroy = sinon.stub();
-
-        const events = {};
-        netStub.on = function (event, cb) {
-            if (event === 'connect') {
-                cb();
-
+            sinon.stub(net, 'createServer').callsFake((fn) => {
                 setTimeout(() => {
-                    events.timeout();
+                    fn(socketStub);
                 }, 100);
-            }
 
-            events[event] = cb;
-        };
-
-        sinon.stub(net, 'connect').returns(netStub);
-
-        return portPolling({port: 1111, maxTries: 2, timeoutInMS: 100, socketTimeoutInMS: 300})
-            .then(() => {
-                throw new Error('Expected error');
-            })
-            .catch((err) => {
-                expect(err.options.suggestion).to.exist;
-                expect(err.message).to.eql('Ghost did not start.');
-                expect(netStub.destroy.callCount).to.eql(3);
+                return netStub;
             });
+
+            return portPolling({
+                netServerTimeoutInMS: 1000,
+                useNetServer: true
+            }).then(() => {
+                expect(net.createServer.calledOnce).to.be.true;
+                expect(netStub.listen.callCount).to.eql(1);
+                expect(netStub.listen.calledWithExactly({host: 'localhost', port: 1212})).to.be.true;
+                expect(netStub.close.callCount).to.eql(1);
+
+                expect(socketStub.destroy.callCount).to.eql(1);
+                expect(socketStub.on.callCount).to.eql(1);
+            }).catch((err) => {
+                throw err;
+            });
+        });
+
+        it('Ghost didn\'t start', function () {
+            const netStub = sinon.stub();
+            const socketStub = sinon.stub();
+
+            socketStub.on = sinon.stub().callsFake((event, cb) => {
+                if (event === 'data') {
+                    cb(JSON.stringify({false: true, error: {message: 'Syntax Error'}}));
+                }
+            });
+
+            socketStub.destroy = sinon.stub();
+
+            netStub.listen = sinon.stub();
+            netStub.close = sinon.stub().callsFake((cb)=> {
+                cb();
+            });
+
+            sinon.stub(net, 'createServer').callsFake((fn) => {
+                setTimeout(() => {
+                    fn(socketStub);
+                }, 100);
+
+                return netStub;
+            });
+
+            return portPolling({
+                netServerTimeoutInMS: 1000,
+                useNetServer: true
+            }).then(() => {
+                expect('1').to.equal(1, 'Ghost should not start.');
+            }).catch((err) => {
+                expect(err.message).to.eql('Syntax Error');
+                expect(net.createServer.calledOnce).to.be.true;
+                expect(netStub.listen.calledOnce).to.be.true;
+                expect(netStub.listen.calledWithExactly({host: 'localhost', port: 1212})).to.be.true;
+                expect(netStub.close.callCount).to.eql(1);
+
+                expect(socketStub.destroy.callCount).to.eql(1);
+                expect(socketStub.on.callCount).to.eql(1);
+            });
+        });
+
+        it('Ghost does not communicate, expect timeout', function () {
+            const netStub = sinon.stub();
+            const socketStub = sinon.stub();
+
+            socketStub.on = sinon.stub();
+            socketStub.destroy = sinon.stub();
+
+            netStub.listen = sinon.stub();
+            netStub.close = sinon.stub().callsFake((cb)=> {
+                cb();
+            });
+
+            sinon.stub(net, 'createServer').callsFake(() => {
+                return netStub;
+            });
+
+            return portPolling({
+                netServerTimeoutInMS: 500,
+                useNetServer: true
+            }).then(() => {
+                expect('1').to.equal(1, 'Ghost should not start.');
+            }).catch((err) => {
+                expect(err.message).to.eql('Could not communicate with Ghost');
+                expect(net.createServer.calledOnce).to.be.true;
+                expect(netStub.listen.calledOnce).to.be.true;
+                expect(netStub.listen.calledWithExactly({host: 'localhost', port: 1212})).to.be.true;
+                expect(netStub.close.callCount).to.eql(1);
+
+                expect(socketStub.destroy.callCount).to.eql(0);
+                expect(socketStub.on.callCount).to.eql(0);
+            });
+        });
+
+        it('Ghost does not answer, expect timeout', function () {
+            const netStub = sinon.stub();
+            const socketStub = sinon.stub();
+
+            socketStub.on = sinon.stub();
+            socketStub.destroy = sinon.stub();
+
+            netStub.listen = sinon.stub();
+            netStub.close = sinon.stub().callsFake((cb)=> {
+                cb();
+            });
+
+            sinon.stub(net, 'createServer').callsFake((fn) => {
+                setTimeout(() => {
+                    fn(socketStub);
+                }, 100);
+
+                return netStub;
+            });
+
+            return portPolling({
+                netServerTimeoutInMS: 500,
+                useNetServer: true
+            }).then(() => {
+                expect('1').to.equal(1, 'Ghost should not start.');
+            }).catch((err) => {
+                expect(err.message).to.eql('Could not communicate with Ghost');
+                expect(net.createServer.calledOnce).to.be.true;
+                expect(netStub.listen.calledOnce).to.be.true;
+                expect(netStub.listen.calledWithExactly({host: 'localhost', port: 1212})).to.be.true;
+                expect(netStub.close.callCount).to.eql(1);
+
+                expect(socketStub.destroy.callCount).to.eql(1);
+                expect(socketStub.on.callCount).to.eql(1);
+            });
+        });
+    });
+
+    describe('useNetServer is disabled', function () {
+        it('Ghost does never start', function () {
+            const netStub = sinon.stub();
+
+            netStub.setTimeout = sinon.stub();
+            netStub.destroy = sinon.stub();
+            netStub.on = function (event, cb) {
+                if (event === 'error') {
+                    cb(new Error('whoops'));
+                }
+            };
+
+            const connectStub = sinon.stub(net, 'connect').returns(netStub);
+
+            return portPolling({port: 1111, maxTries: 3, retryTimeoutInMS: 100})
+                .then(() => {
+                    throw new Error('Expected error');
+                })
+                .catch((err) => {
+                    expect(err.options.suggestion).to.exist;
+                    expect(err.message).to.eql('Ghost did not start.');
+                    expect(err.err.message).to.eql('whoops');
+                    expect(connectStub.callCount).to.equal(4);
+                    expect(connectStub.calledWithExactly(1111, 'localhost'), 'uses localhost by default').to.be.true;
+                    expect(netStub.destroy.callCount).to.eql(4);
+                });
+        });
+
+        it('Ghost does start, but falls over', function () {
+            const netStub = sinon.stub();
+
+            netStub.setTimeout = sinon.stub();
+            netStub.destroy = sinon.stub();
+
+            let i = 0;
+            netStub.on = function (event, cb) {
+                i = i + 1;
+
+                if (event === 'close') {
+                    cb();
+                } else if (event === 'error' && i === 3) {
+                    cb(new Error());
+                } else if (event === 'connect' && i === 5) {
+                    cb();
+                }
+            };
+
+            const connectStub = sinon.stub(net, 'connect').returns(netStub);
+
+            return portPolling({port: 1111, maxTries: 3, retryTimeoutInMS: 100, delayOnConnectInMS: 150, host: '0.0.0.0'})
+                .then(() => {
+                    throw new Error('Expected error');
+                })
+                .catch((err) => {
+                    expect(err.options.suggestion).to.exist;
+                    expect(err.message).to.eql('Ghost did not start.');
+                    expect(err.err.message).to.eql('Ghost died.');
+                    expect(connectStub.calledTwice).to.be.true;
+                    expect(connectStub.calledWithExactly(1111, 'localhost'), 'uses localhost if host is 0.0.0.0').to.be.true;
+                    expect(netStub.destroy.callCount).to.eql(2);
+                });
+        });
+
+        it('Ghost does start', function () {
+            const netStub = sinon.stub();
+
+            netStub.setTimeout = sinon.stub();
+            netStub.destroy = sinon.stub();
+
+            let i = 0;
+            netStub.on = function (event, cb) {
+                i = i + 1;
+
+                if (i === 6) {
+                    expect(event).to.eql('close');
+                } else if (i === 5 && event === 'connect') {
+                    cb();
+                } else if (i === 3 && event === 'error') {
+                    cb(new Error());
+                }
+            };
+
+            const connectStub = sinon.stub(net, 'connect').returns(netStub);
+
+            return portPolling({port: 1111, maxTries: 3, retryTimeoutInMS: 100, delayOnConnectInMS: 150, host: '10.0.1.0'})
+                .then(() => {
+                    expect(connectStub.calledTwice).to.be.true;
+                    expect(connectStub.calledWithExactly(1111, '10.0.1.0'), 'uses custom host').to.be.true;
+                    expect(netStub.destroy.callCount).to.eql(2);
+                })
+                .catch((err) => {
+                    throw err;
+                });
+        });
+
+        it('Ghost does start, skip delay on connect', function () {
+            const netStub = sinon.stub();
+
+            netStub.setTimeout = sinon.stub();
+            netStub.destroy = sinon.stub();
+
+            netStub.on = function (event, cb) {
+                expect(event).to.not.eql('close');
+
+                if (event === 'connect') {
+                    cb();
+                }
+            };
+
+            sinon.stub(net, 'connect').returns(netStub);
+
+            return portPolling({port: 1111, maxTries: 3, retryTimeoutInMS: 100, delayOnConnectInMS: false})
+                .then(() => {
+                    expect(netStub.destroy.callCount).to.eql(1);
+                })
+                .catch((err) => {
+                    throw err;
+                });
+        });
+
+        it('socket times out', function () {
+            const netStub = sinon.stub();
+
+            netStub.setTimeout = sinon.stub();
+            netStub.destroy = sinon.stub();
+
+            netStub.on = function (event, cb) {
+                if (event === 'timeout') {
+                    cb();
+                }
+            };
+
+            sinon.stub(net, 'connect').returns(netStub);
+
+            return portPolling({port: 1111, maxTries: 3, retryTimeoutInMS: 100, socketTimeoutInMS: 300})
+                .then(() => {
+                    throw new Error('Expected error');
+                })
+                .catch((err) => {
+                    expect(err.options.suggestion).to.exist;
+                    expect(err.message).to.eql('Ghost did not start.');
+                    expect(err.err.message).to.eql('Socket timed out.');
+                    expect(netStub.destroy.callCount).to.eql(4);
+                });
+        });
+
+        it('Ghost connects, but socket times out kicks in', function () {
+            const netStub = sinon.stub();
+
+            netStub.setTimeout = sinon.stub();
+            netStub.destroy = sinon.stub();
+
+            const events = {};
+            netStub.on = function (event, cb) {
+                if (event === 'connect') {
+                    cb();
+
+                    setTimeout(() => {
+                        events.timeout();
+                    }, 100);
+                }
+
+                events[event] = cb;
+            };
+
+            sinon.stub(net, 'connect').returns(netStub);
+
+            return portPolling({port: 1111, maxTries: 2, retryTimeoutInMS: 100, socketTimeoutInMS: 300})
+                .then(() => {
+                    throw new Error('Expected error');
+                })
+                .catch((err) => {
+                    expect(err.options.suggestion).to.exist;
+                    expect(err.message).to.eql('Ghost did not start.');
+                    expect(err.err.message).to.eql('Socket timed out.');
+                    expect(netStub.destroy.callCount).to.eql(3);
+                });
+        });
     });
 });


### PR DESCRIPTION
refs #759

This PR is **not finished**, please no code review. Feel free to add questions or concerns  👍 

The current port polling logic to detect if a blog is up or down on start/restart is too simple and the error handling was not good, because we weren't able to receive the reason why a blog didn't start up. Using the http port to communicate with simple messages between the CLI and Ghost is impossible, because it's the http port (!). Browsers use the same transport layer.

Ghost 2.0.0 has more requirements. It executes knex-migrator internally and brings the blog into maintenance mode. That means the server starts already, but the blog is not ready or fully started.

We just change how we communicate. We don't connect to Ghost, Ghost has to connect to the CLI.

- [x] use net server for communication
- [x] do final manual testing on ubuntu
- [x] ensure we haven't break the local process manager
- [x] fix tests
- [x] optimise error message for the websockets

This change is backwards compatible, because the CLI will support v1 and v2 (latest and previous major).