### PR TITLE
feat: added support for named start

### DIFF
--- a/lib/commands/doctor/index.js
+++ b/lib/commands/doctor/index.js
@@ -34,6 +34,8 @@ class DoctorCommand extends Command {
                 findValidInstall('doctor');
                 instance = this.system.getInstance();
                 instance.checkEnvironment();
+            } else {
+                instance = this.system.getInstance();
             }
 
             const context = {

--- a/lib/commands/doctor/index.js
+++ b/lib/commands/doctor/index.js
@@ -27,10 +27,7 @@ class DoctorCommand extends Command {
 
             if (
                 !argv.skipInstanceCheck &&
-                !(argv.categories &&
-                    argv.categories.length === 1 &&
-                    ['install', 'start'].includes(argv.categories[0])
-                )
+                !(argv.categories && argv.categories.length === 1 && argv.categories[0] === 'install')
             ) {
                 const findValidInstall = require('../../utils/find-valid-install');
 

--- a/lib/commands/doctor/index.js
+++ b/lib/commands/doctor/index.js
@@ -27,7 +27,10 @@ class DoctorCommand extends Command {
 
             if (
                 !argv.skipInstanceCheck &&
-                !(argv.categories && argv.categories.length === 1 && argv.categories[0] === 'install')
+                !(argv.categories &&
+                    argv.categories.length === 1 &&
+                    ['install', 'start'].includes(argv.categories[0])
+                )
             ) {
                 const findValidInstall = require('../../utils/find-valid-install');
 

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -26,7 +26,12 @@ class StartCommand extends Command {
         const getInstance = require('../utils/get-instance');
 
         const runOptions = {quiet: argv.quiet};
-        const instance = getInstance(argv.name, this.system, 'start');
+        const instance = getInstance({
+            name: argv.name,
+            system: this.system,
+            command: 'start',
+            recurse: !argv.dir
+        });
 
         const isRunning = await instance.isRunning();
         if (isRunning) {

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -23,8 +23,10 @@ class StartCommand extends Command {
     }
 
     async run(argv) {
-        const instance = this.system.getInstance();
+        const getInstance = require('../utils/get-instance');
+
         const runOptions = {quiet: argv.quiet};
+        const instance = getInstance(argv.name, this.system, 'start');
 
         const isRunning = await instance.isRunning();
         if (isRunning) {
@@ -45,17 +47,34 @@ class StartCommand extends Command {
         await this.ui.run(() => instance.start(argv.enable), `Starting Ghost: ${instance.name}`, runOptions);
 
         if (!argv.quiet) {
-            let adminUrl = instance.config.get('admin.url', instance.config.get('url', ''));
+            const chalk = require('chalk');
+            const isInstall = process.argv[2] === 'install';
+            let adminUrl = instance.config.get('admin.url') || instance.config.get('url');
+
             // Strip the trailing slash and add the admin path
             adminUrl = `${adminUrl.replace(/\/$/,'')}/ghost/`;
 
-            this.ui.log('\n------------------------------------------------------------------------------', 'white');
-            this.ui.log('Your admin interface is located at', adminUrl, 'green', 'link', true);
+            this.ui.log(`You can access your publication at ${chalk.cyan(instance.config.get('url'))}`, 'white');
+
+            if (isInstall) {
+                // Show a different message after a fresh install
+                this.ui.log(`Next, go to to your admin interface at ${chalk.cyan(adminUrl)} to complete the setup of your publication`, 'white');
+            } else {
+                this.ui.log(`Your admin interface is located at ${chalk.cyan(adminUrl)}`, 'white');
+            }
+
+            if (instance.config.get('mail.transport') === 'Direct') {
+                this.ui.log('\nGhost uses direct mail by default', 'green');
+                this.ui.log('To set up an alternative email method read our docs at https://docs.ghost.org/docs/mail-config', 'green');
+            }
         }
     }
 }
 
+StartCommand.global = true;
 StartCommand.description = 'Start an instance of Ghost';
+StartCommand.longDescription = '$0 start [name]\n Starts a known instance of Ghost'
+StartCommand.params = '[name]'
 StartCommand.options = {
     enable: {
         description: '[--no-enable] Enable/don\'t enable instance restart on server reboot (if the process manager supports it)',

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -73,8 +73,8 @@ class StartCommand extends Command {
 
 StartCommand.global = true;
 StartCommand.description = 'Start an instance of Ghost';
-StartCommand.longDescription = '$0 start [name]\n Starts a known instance of Ghost'
-StartCommand.params = '[name]'
+StartCommand.longDescription = '$0 start [name]\n Starts a known instance of Ghost';
+StartCommand.params = '[name]';
 StartCommand.options = {
     enable: {
         description: '[--no-enable] Enable/don\'t enable instance restart on server reboot (if the process manager supports it)',

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -47,26 +47,12 @@ class StartCommand extends Command {
         await this.ui.run(() => instance.start(argv.enable), `Starting Ghost: ${instance.name}`, runOptions);
 
         if (!argv.quiet) {
-            const chalk = require('chalk');
-            const isInstall = process.argv[2] === 'install';
-            let adminUrl = instance.config.get('admin.url') || instance.config.get('url');
-
+            let adminUrl = instance.config.get('admin.url', instance.config.get('url', ''));
             // Strip the trailing slash and add the admin path
             adminUrl = `${adminUrl.replace(/\/$/,'')}/ghost/`;
 
-            this.ui.log(`You can access your publication at ${chalk.cyan(instance.config.get('url'))}`, 'white');
-
-            if (isInstall) {
-                // Show a different message after a fresh install
-                this.ui.log(`Next, go to to your admin interface at ${chalk.cyan(adminUrl)} to complete the setup of your publication`, 'white');
-            } else {
-                this.ui.log(`Your admin interface is located at ${chalk.cyan(adminUrl)}`, 'white');
-            }
-
-            if (instance.config.get('mail.transport') === 'Direct') {
-                this.ui.log('\nGhost uses direct mail by default', 'green');
-                this.ui.log('To set up an alternative email method read our docs at https://docs.ghost.org/docs/mail-config', 'green');
-            }
+            this.ui.log('\n------------------------------------------------------------------------------', 'white');
+            this.ui.log('Your admin interface is located at', adminUrl, 'green', 'link', true);
         }
     }
 }

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -57,9 +57,7 @@ class StartCommand extends Command {
     }
 }
 
-StartCommand.global = true;
 StartCommand.description = 'Start an instance of Ghost';
-StartCommand.longDescription = '$0 start [name]\n Starts a known instance of Ghost';
 StartCommand.params = '[name]';
 StartCommand.options = {
     enable: {
@@ -68,5 +66,6 @@ StartCommand.options = {
         default: true
     }
 };
+StartCommand.global = true;
 
 module.exports = StartCommand;

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -43,7 +43,7 @@ class StartCommand extends Command {
             ].join('\n'), 'yellow');
         }
 
-        await this.runCommand(DoctorCommand, {categories: ['start'], ...argv, quiet: true});
+        await this.runCommand(DoctorCommand, {categories: ['start'], ...argv, quiet: true, skipInstanceCheck: true});
         await this.ui.run(() => instance.start(argv.enable), `Starting Ghost: ${instance.name}`, runOptions);
 
         if (!argv.quiet) {

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -27,7 +27,12 @@ class StopCommand extends Command {
             return this.stopAll();
         }
 
-        const instance = getInstance(argv.name, this.system, 'stop');
+        const instance = getInstance({
+            name: argv.name,
+            system: this.system,
+            command: 'stop',
+            recurse: !argv.dir
+        });
         const isRunning = await instance.isRunning();
 
         if (!isRunning) {

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -39,12 +39,10 @@ class StopCommand extends Command {
     }
 
     async stopAll() {
-        const Promise = require('bluebird');
-
         const instances = this.system.getAllInstances(true);
-        await Promise.each(instances, async ({name}) => {
+        for (const {name} of instances) {
             await this.ui.run(() => this.run({quiet: true, name}), `Stopping Ghost: ${name}`);
-        });
+        }
     }
 }
 

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -20,26 +20,16 @@ class StopCommand extends Command {
     }
 
     async run(argv) {
-        const {SystemError} = require('../errors');
-        const findValidInstall = require('../utils/find-valid-install');
-
+        const getInstance = require('../utils/get-instance');
         const runOptions = {quiet: argv.quiet};
 
         if (argv.all) {
             return this.stopAll();
         }
 
-        if (!argv.name) {
-            findValidInstall('stop', true);
-        }
-
-        const instance = this.system.getInstance(argv.name);
-
-        if (argv.name && !instance) {
-            throw new SystemError(`Ghost instance '${argv.name}' does not exist`);
-        }
-
+        const instance = getInstance(argv.name, this.system, 'stop');
         const isRunning = await instance.isRunning();
+
         if (!isRunning) {
             this.ui.log('Ghost is already stopped! For more information, run', 'ghost ls', 'green', 'cmd', true);
             return;

--- a/lib/utils/get-instance.js
+++ b/lib/utils/get-instance.js
@@ -1,20 +1,31 @@
-const checkValidInstall = require('./check-valid-install');
 const {SystemError} = require('../errors');
+const findValidInstallation = require('./find-valid-install');
 
-function getInstance(instanceName, system, commandName) {
-    const instance = system.getInstance(instanceName);
-
+/**
+ * @param {object} options
+ * @param {string} options.name
+ * @param {import('../system.js')} options.system
+ * @param {string} options.command
+ * @param {boolean} options.recurse
+ */
+function getInstance({
+    name: instanceName,
+    system,
+    command: commandName,
+    recurse
+}) {
     if (instanceName) {
+        const instance = system.getInstance(instanceName);
         if (!instance) {
             throw new SystemError(`Ghost instance '${instanceName}' does not exist`);
         }
 
         process.chdir(instance.dir);
+        return instance;
     }
 
-    checkValidInstall(commandName);
-
-    return instance;
+    findValidInstallation(commandName, recurse);
+    return system.getInstance();
 }
 
 module.exports = getInstance;

--- a/lib/utils/get-instance.js
+++ b/lib/utils/get-instance.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const checkValidInstall = require('./check-valid-install');
+const {SystemError} = require('../errors');
+
+function findInstance(instanceName, system, commandName) {
+    const instance = system.getInstance(instanceName);
+
+    if (instanceName) {
+        if (!instance) {
+            throw new SystemError(`Ghost instance "${instanceName}" does not exist`);
+        }
+
+        process.chdir(instance.dir);
+    }
+
+    checkValidInstall(commandName);
+
+    return instance;
+}
+
+module.exports = findInstance;

--- a/lib/utils/get-instance.js
+++ b/lib/utils/get-instance.js
@@ -3,7 +3,7 @@
 const checkValidInstall = require('./check-valid-install');
 const {SystemError} = require('../errors');
 
-function findInstance(instanceName, system, commandName) {
+function getInstance(instanceName, system, commandName) {
     const instance = system.getInstance(instanceName);
 
     if (instanceName) {
@@ -19,4 +19,4 @@ function findInstance(instanceName, system, commandName) {
     return instance;
 }
 
-module.exports = findInstance;
+module.exports = getInstance;

--- a/lib/utils/get-instance.js
+++ b/lib/utils/get-instance.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const checkValidInstall = require('./check-valid-install');
 const {SystemError} = require('../errors');
 
@@ -8,7 +6,7 @@ function getInstance(instanceName, system, commandName) {
 
     if (instanceName) {
         if (!instance) {
-            throw new SystemError(`Ghost instance "${instanceName}" does not exist`);
+            throw new SystemError(`Ghost instance '${instanceName}' does not exist`);
         }
 
         process.chdir(instance.dir);

--- a/test/unit/commands/doctor/command-spec.js
+++ b/test/unit/commands/doctor/command-spec.js
@@ -1,5 +1,5 @@
 'use strict';
-const expect = require('chai').expect;
+const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 
@@ -143,7 +143,7 @@ describe('Unit: Commands > Doctor', function () {
         });
     });
 
-    it('skips instance check if only category is install, uses correct context', function () {
+    it('skips instance check if category is install, uses correct context', function () {
         const ui = {listr: sinon.stub().resolves()};
         const instanceStub = {checkEnvironment: sinon.stub()};
         const system = {
@@ -181,6 +181,54 @@ describe('Unit: Commands > Doctor', function () {
                 local: true,
                 argv: true,
                 categories: ['install'],
+                _: ['doctor']
+            });
+            expect(context.system).to.equal(system);
+            expect(context.instance).to.not.exist;
+            expect(context.ui).to.equal(ui);
+            expect(context.local).to.be.true;
+            expect(context.isDoctorCommand).to.be.true;
+        });
+    });
+
+    it('skips instance check if category is start, uses correct context', function () {
+        const ui = {listr: sinon.stub().resolves()};
+        const instanceStub = {checkEnvironment: sinon.stub()};
+        const system = {
+            getInstance: sinon.stub().returns(instanceStub),
+            hook: sinon.stub().resolves([{
+                title: 'Extension Task 1',
+                task: 'someTask'
+            }])
+        };
+        const checkValidStub = sinon.stub();
+
+        const DoctorCommand = proxyquire(modulePath, {
+            '../../utils/check-valid-install': checkValidStub,
+            './checks': [{category: ['start']}]
+        });
+        const instance = new DoctorCommand(ui, system);
+
+        return instance.run({
+            skipInstanceCheck: false,
+            local: true,
+            argv: true,
+            categories: ['start'],
+            _: ['doctor']
+        }).then(() => {
+            expect(checkValidStub.called).to.be.false;
+            expect(system.getInstance.called).to.be.false;
+            expect(system.hook.calledOnce).to.be.true;
+            expect(system.hook.calledWithExactly('doctor')).to.be.true;
+            expect(instanceStub.checkEnvironment.called).to.be.false;
+            expect(ui.listr.calledOnce).to.be.true;
+            expect(ui.listr.args[0][0]).to.deep.equal([{category: ['start']}]);
+            const context = ui.listr.args[0][1];
+            expect(context.argv).to.deep.equal({
+                skipInstanceCheck: false,
+                local: true,
+                argv: true,
+                categories: ['start'],
                 _: ['doctor']
             });
             expect(context.system).to.equal(system);

--- a/test/unit/commands/doctor/command-spec.js
+++ b/test/unit/commands/doctor/command-spec.js
@@ -191,7 +191,7 @@ describe('Unit: Commands > Doctor', function () {
         });
     });
 
-    it('skips instance check if category is start, uses correct context', function () {
+    it('skips instance check if category is start, uses correct context', async function () {
         const ui = {listr: sinon.stub().resolves()};
         const instanceStub = {checkEnvironment: sinon.stub()};
         const system = {
@@ -209,34 +209,34 @@ describe('Unit: Commands > Doctor', function () {
         });
         const instance = new DoctorCommand(ui, system);
 
-        return instance.run({
+        await instance.run({
             skipInstanceCheck: false,
             local: true,
             argv: true,
             categories: ['start'],
             _: ['doctor']
-        }).then(() => {
-            expect(checkValidStub.called).to.be.false;
-            expect(system.getInstance.called).to.be.false;
-            expect(system.hook.calledOnce).to.be.true;
-            expect(system.hook.calledWithExactly('doctor')).to.be.true;
-            expect(instanceStub.checkEnvironment.called).to.be.false;
-            expect(ui.listr.calledOnce).to.be.true;
-            expect(ui.listr.args[0][0]).to.deep.equal([{category: ['start']}]);
-            const context = ui.listr.args[0][1];
-            expect(context.argv).to.deep.equal({
-                skipInstanceCheck: false,
-                local: true,
-                argv: true,
-                categories: ['start'],
-                _: ['doctor']
-            });
-            expect(context.system).to.equal(system);
-            expect(context.instance).to.not.exist;
-            expect(context.ui).to.equal(ui);
-            expect(context.local).to.be.true;
-            expect(context.isDoctorCommand).to.be.true;
         });
+
+        expect(checkValidStub.called).to.be.false;
+        expect(system.getInstance.called).to.be.false;
+        expect(system.hook.calledOnce).to.be.true;
+        expect(system.hook.calledWithExactly('doctor')).to.be.true;
+        expect(instanceStub.checkEnvironment.called).to.be.false;
+        expect(ui.listr.calledOnce).to.be.true;
+        expect(ui.listr.args[0][0]).to.deep.equal([{category: ['start']}]);
+        const context = ui.listr.args[0][1];
+        expect(context.argv).to.deep.equal({
+            skipInstanceCheck: false,
+            local: true,
+            argv: true,
+            categories: ['start'],
+            _: ['doctor']
+        });
+        expect(context.system).to.equal(system);
+        expect(context.instance).to.not.exist;
+        expect(context.ui).to.equal(ui);
+        expect(context.local).to.be.true;
+        expect(context.isDoctorCommand).to.be.true;
     });
 
     describe('filters checks correctly', function () {

--- a/test/unit/commands/doctor/command-spec.js
+++ b/test/unit/commands/doctor/command-spec.js
@@ -143,7 +143,7 @@ describe('Unit: Commands > Doctor', function () {
         });
     });
 
-    it('skips instance check if category is install, uses correct context', function () {
+    it('skips instance check if only category is install, uses correct context', function () {
         const ui = {listr: sinon.stub().resolves()};
         const instanceStub = {checkEnvironment: sinon.stub()};
         const system = {
@@ -189,54 +189,6 @@ describe('Unit: Commands > Doctor', function () {
             expect(context.local).to.be.true;
             expect(context.isDoctorCommand).to.be.true;
         });
-    });
-
-    it('skips instance check if category is start, uses correct context', async function () {
-        const ui = {listr: sinon.stub().resolves()};
-        const instanceStub = {checkEnvironment: sinon.stub()};
-        const system = {
-            getInstance: sinon.stub().returns(instanceStub),
-            hook: sinon.stub().resolves([{
-                title: 'Extension Task 1',
-                task: 'someTask'
-            }])
-        };
-        const checkValidStub = sinon.stub();
-
-        const DoctorCommand = proxyquire(modulePath, {
-            '../../utils/check-valid-install': checkValidStub,
-            './checks': [{category: ['start']}]
-        });
-        const instance = new DoctorCommand(ui, system);
-
-        await instance.run({
-            skipInstanceCheck: false,
-            local: true,
-            argv: true,
-            categories: ['start'],
-            _: ['doctor']
-        });
-
-        expect(checkValidStub.called).to.be.false;
-        expect(system.getInstance.called).to.be.false;
-        expect(system.hook.calledOnce).to.be.true;
-        expect(system.hook.calledWithExactly('doctor')).to.be.true;
-        expect(instanceStub.checkEnvironment.called).to.be.false;
-        expect(ui.listr.calledOnce).to.be.true;
-        expect(ui.listr.args[0][0]).to.deep.equal([{category: ['start']}]);
-        const context = ui.listr.args[0][1];
-        expect(context.argv).to.deep.equal({
-            skipInstanceCheck: false,
-            local: true,
-            argv: true,
-            categories: ['start'],
-            _: ['doctor']
-        });
-        expect(context.system).to.equal(system);
-        expect(context.instance).to.not.exist;
-        expect(context.ui).to.equal(ui);
-        expect(context.local).to.be.true;
-        expect(context.isDoctorCommand).to.be.true;
     });
 
     describe('filters checks correctly', function () {

--- a/test/unit/commands/doctor/command-spec.js
+++ b/test/unit/commands/doctor/command-spec.js
@@ -121,7 +121,6 @@ describe('Unit: Commands > Doctor', function () {
 
         return instance.run({skipInstanceCheck: true, local: true, argv: true}).then(() => {
             expect(findValidStub.called).to.be.false;
-            expect(system.getInstance.called).to.be.false;
             expect(system.hook.calledOnce).to.be.true;
             expect(system.hook.calledWithExactly('doctor')).to.be.true;
             expect(instanceStub.checkEnvironment.called).to.be.false;
@@ -136,7 +135,6 @@ describe('Unit: Commands > Doctor', function () {
             const context = ui.listr.args[0][1];
             expect(context.argv).to.deep.equal({skipInstanceCheck: true, local: true, argv: true});
             expect(context.system).to.equal(system);
-            expect(context.instance).to.not.exist;
             expect(context.ui).to.equal(ui);
             expect(context.local).to.be.true;
             expect(context.isDoctorCommand).to.be.false;
@@ -169,7 +167,6 @@ describe('Unit: Commands > Doctor', function () {
             _: ['doctor']
         }).then(() => {
             expect(findValidStub.called).to.be.false;
-            expect(system.getInstance.called).to.be.false;
             expect(system.hook.calledOnce).to.be.true;
             expect(system.hook.calledWithExactly('doctor')).to.be.true;
             expect(instanceStub.checkEnvironment.called).to.be.false;
@@ -184,7 +181,6 @@ describe('Unit: Commands > Doctor', function () {
                 _: ['doctor']
             });
             expect(context.system).to.equal(system);
-            expect(context.instance).to.not.exist;
             expect(context.ui).to.equal(ui);
             expect(context.local).to.be.true;
             expect(context.isDoctorCommand).to.be.true;
@@ -210,7 +206,7 @@ describe('Unit: Commands > Doctor', function () {
             const DoctorCommand = proxyquire(modulePath, {
                 './checks': testChecks
             });
-            instance = new DoctorCommand({listr: listrStub}, {hook: hookStub});
+            instance = new DoctorCommand({listr: listrStub}, {hook: hookStub, getInstance: sinon.stub()});
         });
 
         afterEach(() => {

--- a/test/unit/commands/setup-spec.js
+++ b/test/unit/commands/setup-spec.js
@@ -488,7 +488,7 @@ describe('Unit: Commands > Setup', function () {
             config: {options: {setup: {test: true}}}
         }, {}];
 
-        const yargs = {option: sinon.stub(), epilogue: () => true};
+        const yargs = {option: sinon.stub(), epilogue: () => true, usage: () => true};
         yargs.option.returns(yargs);
         SetupCommand.configureOptions.call({options: {}}, 'Test', yargs, extensions, true);
         expect(yargs.option.called).to.be.true;

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const createConfigStub = require('../../utils/config-stub');
@@ -9,7 +9,6 @@ const UI = require('../../../lib/ui');
 const DoctorCommand = require('../../../lib/commands/doctor');
 
 const modulePath = '../../../lib/commands/start';
-const StartCommand = require(modulePath);
 
 function getStubs(dir, environment = undefined) {
     const ui = new UI({});
@@ -170,7 +169,7 @@ describe('Unit: Commands > Start', function () {
             config: {options: {start: {test: true}}}
         }, {}];
 
-        const yargs = {option: sinon.stub(), epilogue: () => true};
+        const yargs = {option: sinon.stub(), epilogue: () => true, usage: () => true};
         yargs.option.returns(yargs);
         StartCommand.configureOptions.call({options: {}}, 'Test', yargs, extensions, true);
         expect(yargs.option.called).to.be.true;

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -125,7 +125,8 @@ describe('Unit: Commands > Start', function () {
             expect(runCommand.calledWithExactly(DoctorCommand, {
                 categories: ['start'],
                 quiet: true,
-                checkMem: false
+                checkMem: false,
+                skipInstanceCheck: true
             })).to.be.true;
             expect(run.calledOnce).to.be.true;
             expect(start.calledOnce).to.be.true;
@@ -152,7 +153,8 @@ describe('Unit: Commands > Start', function () {
             expect(runCommand.calledWithExactly(DoctorCommand, {
                 categories: ['start'],
                 quiet: true,
-                checkMem: false
+                checkMem: false,
+                skipInstanceCheck: true
             })).to.be.true;
             expect(run.calledOnce).to.be.true;
             expect(start.calledOnce).to.be.true;

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -9,7 +9,6 @@ const UI = require('../../../lib/ui');
 const DoctorCommand = require('../../../lib/commands/doctor');
 
 const modulePath = '../../../lib/commands/start';
-const StartCommand = require(modulePath);
 
 function getStubs(dir, environment = undefined) {
     const ui = new UI({});
@@ -22,23 +21,30 @@ function getStubs(dir, environment = undefined) {
     instance._config.environment = environment;
     system.environment = environment;
 
-    const getInstance = sinon.stub(system, 'getInstance').returns(instance);
-
     return {
-        ui, system, instance, getInstance
+        ui, system, instance
     };
 }
 
 describe('Unit: Commands > Start', function () {
     describe('run', function () {
         const oldArgv = process.argv;
+        let StartCommand;
+        let returnedInstance;
+
+        beforeEach(function () {
+            StartCommand = proxyquire(modulePath, {
+                '../utils/get-instance': sinon.stub().callsFake(() => returnedInstance),
+            });
+        })
 
         afterEach(() => {
             process.argv = oldArgv;
         });
 
         it('notifies and exits for already running instance', async function () {
-            const {ui, system, instance, getInstance} = getStubs('/var/www/ghost');
+            const {ui, system, instance} = getStubs('/var/www/ghost');
+            returnedInstance = instance;
             const isRunning = sinon.stub(instance, 'isRunning').resolves(true);
             const checkEnvironment = sinon.stub(instance, 'checkEnvironment');
             const log = sinon.stub(ui, 'log');
@@ -49,7 +55,6 @@ describe('Unit: Commands > Start', function () {
             const runCommand = sinon.stub(cmd, 'runCommand').resolves();
 
             await cmd.run({});
-            expect(getInstance.calledOnce).to.be.true;
             expect(isRunning.calledOnce).to.be.true;
             expect(log.calledOnce).to.be.true;
 
@@ -61,6 +66,7 @@ describe('Unit: Commands > Start', function () {
 
         it('warns of http use in production', async function () {
             const {ui, system, instance} = getStubs('/var/www/ghost', 'production');
+            returnedInstance = instance;
             const logStub = sinon.stub(ui, 'log');
             const isRunning = sinon.stub(instance, 'isRunning').resolves(false);
             const checkEnvironment = sinon.stub(instance, 'checkEnvironment');
@@ -85,6 +91,7 @@ describe('Unit: Commands > Start', function () {
 
         it('no warning with ssl in production', async function () {
             const {ui, system, instance} = getStubs('/var/www/ghost', 'production');
+            returnedInstance = instance;
             const logStub = sinon.stub(ui, 'log');
             const isRunning = sinon.stub(instance, 'isRunning').resolves(false);
             const checkEnvironment = sinon.stub(instance, 'checkEnvironment');
@@ -105,7 +112,8 @@ describe('Unit: Commands > Start', function () {
         });
 
         it('runs startup checks and starts correctly', async function () {
-            const {ui, system, instance, getInstance} = getStubs('/var/www/ghost');
+            const {ui, system, instance} = getStubs('/var/www/ghost');
+            returnedInstance = instance;
             const isRunning = sinon.stub(instance, 'isRunning').resolves(false);
             const checkEnvironment = sinon.stub(instance, 'checkEnvironment');
             const log = sinon.stub(ui, 'log');
@@ -118,16 +126,15 @@ describe('Unit: Commands > Start', function () {
             instance.config.get.returns('http://localhost:2368');
 
             await cmd.run({checkMem: false});
-            expect(getInstance.calledOnce).to.be.true;
             expect(isRunning.calledOnce).to.be.true;
             expect(checkEnvironment.calledOnce).to.be.true;
             expect(runCommand.calledOnce).to.be.true;
-            expect(runCommand.calledWithExactly(DoctorCommand, {
+            expect(runCommand.args[0][1]).to.deep.equal({
                 categories: ['start'],
                 quiet: true,
                 checkMem: false,
                 skipInstanceCheck: true
-            })).to.be.true;
+            });
             expect(run.calledOnce).to.be.true;
             expect(start.calledOnce).to.be.true;
             expect(log.calledTwice).to.be.true;
@@ -135,7 +142,8 @@ describe('Unit: Commands > Start', function () {
         });
 
         it('doesn\'t log if quiet is set to true', async function () {
-            const {ui, system, instance, getInstance} = getStubs('/var/www/ghost');
+            const {ui, system, instance} = getStubs('/var/www/ghost');
+            returnedInstance = instance;
             const isRunning = sinon.stub(instance, 'isRunning').resolves(false);
             const checkEnvironment = sinon.stub(instance, 'checkEnvironment');
             const log = sinon.stub(ui, 'log');
@@ -146,16 +154,15 @@ describe('Unit: Commands > Start', function () {
             const runCommand = sinon.stub(cmd, 'runCommand').resolves();
 
             await cmd.run({checkMem: false, quiet: true});
-            expect(getInstance.calledOnce).to.be.true;
             expect(isRunning.calledOnce).to.be.true;
             expect(checkEnvironment.calledOnce).to.be.true;
             expect(runCommand.calledOnce).to.be.true;
-            expect(runCommand.calledWithExactly(DoctorCommand, {
+            expect(runCommand.args[0][1]).to.deep.equal({
                 categories: ['start'],
                 quiet: true,
                 checkMem: false,
                 skipInstanceCheck: true
-            })).to.be.true;
+            });
             expect(run.calledOnce).to.be.true;
             expect(start.calledOnce).to.be.true;
             expect(log.called).to.be.false;

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -9,6 +9,7 @@ const UI = require('../../../lib/ui');
 const DoctorCommand = require('../../../lib/commands/doctor');
 
 const modulePath = '../../../lib/commands/start';
+const StartCommand = require(modulePath);
 
 function getStubs(dir, environment = undefined) {
     const ui = new UI({});

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -6,7 +6,6 @@ const createConfigStub = require('../../utils/config-stub');
 const Instance = require('../../../lib/instance');
 const System = require('../../../lib/system');
 const UI = require('../../../lib/ui');
-const DoctorCommand = require('../../../lib/commands/doctor');
 
 const modulePath = '../../../lib/commands/start';
 
@@ -34,9 +33,9 @@ describe('Unit: Commands > Start', function () {
 
         beforeEach(function () {
             StartCommand = proxyquire(modulePath, {
-                '../utils/get-instance': sinon.stub().callsFake(() => returnedInstance),
+                '../utils/get-instance': sinon.stub().callsFake(() => returnedInstance)
             });
-        })
+        });
 
         afterEach(() => {
             process.argv = oldArgv;

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -112,7 +112,7 @@ describe('Unit: Commands > Stop', function () {
             config: {options: {stop: {test: true}}}
         }, {}];
 
-        const yargs = {option: sinon.stub(), epilogue: noop};
+        const yargs = {option: sinon.stub(), epilogue: () => true};
         yargs.option.returns(yargs);
         StopCommand.configureOptions.call({options: {}}, 'Test', yargs, extensions, true);
         expect(yargs.option.called).to.be.true;

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -112,7 +112,7 @@ describe('Unit: Commands > Stop', function () {
             config: {options: {stop: {test: true}}}
         }, {}];
 
-        const yargs = {option: sinon.stub(), epilogue: () => true};
+        const yargs = {option: sinon.stub(), epilogue: noop};
         yargs.option.returns(yargs);
         StopCommand.configureOptions.call({options: {}}, 'Test', yargs, extensions, true);
         expect(yargs.option.called).to.be.true;

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -1,4 +1,3 @@
-'use strict';
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
@@ -19,17 +18,17 @@ describe('Unit: Commands > Stop', function () {
         });
 
         it('checks for valid install if name not specified', async function () {
-            const findStub = sinon.stub().throws(new Error('findValidInstall'));
+            const getInstance = sinon.stub().throws(new Error('getInstance'));
             const Command = proxyquire(modulePath, {
-                '../utils/find-valid-install': findStub
+                '../utils/get-instance': getInstance
             });
             const stop = new Command();
 
             try {
                 await stop.run({});
             } catch (error) {
-                expect(error.message).to.equal('findValidInstall');
-                expect(findStub.calledOnce).to.be.true;
+                expect(error.message).to.equal('getInstance');
+                expect(getInstance.calledOnce).to.be.true;
                 return;
             }
 
@@ -54,12 +53,13 @@ describe('Unit: Commands > Stop', function () {
             const log = sinon.stub();
             const isRunning = sinon.stub().resolves(false);
             const getInstance = sinon.stub().returns({isRunning});
-            const stop = new StopCommand({log}, {getInstance});
+            const Command = proxyquire(modulePath, {'../utils/get-instance': getInstance});
+            const stop = new Command({log});
 
             await stop.run({name: 'testing'});
 
             expect(getInstance.calledOnce).to.be.true;
-            expect(getInstance.calledWithExactly('testing')).to.be.true;
+            expect(getInstance.args[0][0]).to.equal('testing');
             expect(isRunning.calledOnce).to.be.true;
             expect(log.calledOnce).to.be.true;
         });
@@ -72,12 +72,13 @@ describe('Unit: Commands > Stop', function () {
             const stop = sinon.stub().resolves();
 
             const getInstance = sinon.stub().returns({isRunning, stop});
+            const Command = proxyquire(modulePath, {'../utils/get-instance': getInstance});
 
-            const cmd = new StopCommand({log, run}, {getInstance});
+            const cmd = new Command({log, run});
             await cmd.run({name: 'testing'});
 
             expect(getInstance.calledOnce).to.be.true;
-            expect(getInstance.calledWithExactly('testing')).to.be.true;
+            expect(getInstance.args[0][0]).to.equal('testing');
             expect(isRunning.calledOnce).to.be.true;
             expect(run.calledOnce).to.be.true;
             expect(stop.calledOnce).to.be.true;

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -59,7 +59,7 @@ describe('Unit: Commands > Stop', function () {
             await stop.run({name: 'testing'});
 
             expect(getInstance.calledOnce).to.be.true;
-            expect(getInstance.args[0][0]).to.equal('testing');
+            expect(getInstance.args[0][0]?.name).to.equal('testing');
             expect(isRunning.calledOnce).to.be.true;
             expect(log.calledOnce).to.be.true;
         });
@@ -78,7 +78,7 @@ describe('Unit: Commands > Stop', function () {
             await cmd.run({name: 'testing'});
 
             expect(getInstance.calledOnce).to.be.true;
-            expect(getInstance.args[0][0]).to.equal('testing');
+            expect(getInstance.args[0][0]?.name).to.equal('testing');
             expect(isRunning.calledOnce).to.be.true;
             expect(run.calledOnce).to.be.true;
             expect(stop.calledOnce).to.be.true;

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -59,7 +59,7 @@ describe('Unit: Commands > Stop', function () {
             await stop.run({name: 'testing'});
 
             expect(getInstance.calledOnce).to.be.true;
-            expect(getInstance.args[0][0]?.name).to.equal('testing');
+            expect(getInstance.args[0][0].name).to.equal('testing');
             expect(isRunning.calledOnce).to.be.true;
             expect(log.calledOnce).to.be.true;
         });
@@ -78,7 +78,7 @@ describe('Unit: Commands > Stop', function () {
             await cmd.run({name: 'testing'});
 
             expect(getInstance.calledOnce).to.be.true;
-            expect(getInstance.args[0][0]?.name).to.equal('testing');
+            expect(getInstance.args[0][0].name).to.equal('testing');
             expect(isRunning.calledOnce).to.be.true;
             expect(run.calledOnce).to.be.true;
             expect(stop.calledOnce).to.be.true;

--- a/test/unit/utils/get-instance-spec.js
+++ b/test/unit/utils/get-instance-spec.js
@@ -1,0 +1,59 @@
+'use strict';
+const {expect} = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+const {SystemError} = require('../../../lib/errors');
+const modulePath = '../../../lib/utils/get-instance';
+
+describe('Unit: Utils > getInstance', function () {
+    let getInstance, stubs, system;
+    beforeEach(function () {
+        stubs = {
+            checkValidInstall: sinon.stub().callsFake(a => a),
+            chdir: sinon.stub(process, 'chdir'),
+            getInstance: sinon.stub().returns('It\'s-a Me, Mario!')
+        };
+
+        system = {getInstance: stubs.getInstance};
+        getInstance = proxyquire(modulePath, {
+            './check-valid-install': stubs.checkValidInstall
+        });
+    });
+
+    this.afterEach(function () {
+        sinon.restore();
+    });
+
+    it('Doesn\'t change directory by default', function () {
+        const result = getInstance(undefined, system, 'test');
+
+        expect(result).to.equal('It\'s-a Me, Mario!');
+        expect(stubs.getInstance.calledOnce).to.be.true;
+        expect(stubs.chdir.called).to.be.false;
+        expect(stubs.checkValidInstall.calledOnce).to.be.true;
+        expect(stubs.checkValidInstall.calledWithExactly('test')).to.be.true;
+    });
+
+    it('Fails if the instance cannot be found', function () {
+        stubs.getInstance.returns(null);
+
+        try {
+            getInstance('ghosted', system, 'test');
+            expect(false, 'Promise should have rejected').to.be.true;
+        } catch (error) {
+            expect(error).to.be.instanceof(SystemError);
+            expect(error.message).to.equal('Ghost instance "ghosted" does not exist');
+        }
+    });
+
+    it('Chdirs into instance directory when it exists', function () {
+        const dir = '/path/to/ghost';
+        stubs.getInstance.returns({dir});
+
+        const result = getInstance('i', system, 'test');
+
+        expect(result.dir).to.equal(dir);
+        expect(stubs.chdir.calledOnce).to.to.true;
+        expect(stubs.chdir.calledWithExactly(dir)).to.be.true;
+    });
+})

--- a/test/unit/utils/get-instance-spec.js
+++ b/test/unit/utils/get-instance-spec.js
@@ -8,14 +8,14 @@ describe('Unit: Utils > getInstance', function () {
     let getInstance, stubs, system;
     beforeEach(function () {
         stubs = {
-            checkValidInstall: sinon.stub().callsFake(a => a),
+            findValidInstallation: sinon.stub().callsFake(a => a),
             chdir: sinon.stub(process, 'chdir'),
             getInstance: sinon.stub().returns('It\'s-a Me, Mario!')
         };
 
         system = {getInstance: stubs.getInstance};
         getInstance = proxyquire(modulePath, {
-            './check-valid-install': stubs.checkValidInstall
+            './find-valid-install': stubs.findValidInstallation
         });
     });
 
@@ -24,20 +24,20 @@ describe('Unit: Utils > getInstance', function () {
     });
 
     it('Doesn\'t change directory by default', function () {
-        const result = getInstance(undefined, system, 'test');
+        const result = getInstance({name: undefined, system, command: 'test', recurse: false});
 
         expect(result).to.equal('It\'s-a Me, Mario!');
         expect(stubs.getInstance.calledOnce).to.be.true;
         expect(stubs.chdir.called).to.be.false;
-        expect(stubs.checkValidInstall.calledOnce).to.be.true;
-        expect(stubs.checkValidInstall.calledWithExactly('test')).to.be.true;
+        expect(stubs.findValidInstallation.calledOnce).to.be.true;
+        expect(stubs.findValidInstallation.calledWithExactly('test', false)).to.be.true;
     });
 
     it('Fails if the instance cannot be found', function () {
         stubs.getInstance.returns(null);
 
         try {
-            getInstance('ghosted', system, 'test');
+            getInstance({name: 'ghosted', system, command: 'test', recurse: false});
             expect(false, 'Promise should have rejected').to.be.true;
         } catch (error) {
             expect(error).to.be.instanceof(SystemError);
@@ -49,7 +49,7 @@ describe('Unit: Utils > getInstance', function () {
         const dir = '/path/to/ghost';
         stubs.getInstance.returns({dir});
 
-        const result = getInstance('i', system, 'test');
+        const result = getInstance({name: 'i', system, command: 'test', recurse: false});
 
         expect(result.dir).to.equal(dir);
         expect(stubs.chdir.calledOnce).to.to.true;

--- a/test/unit/utils/get-instance-spec.js
+++ b/test/unit/utils/get-instance-spec.js
@@ -56,4 +56,4 @@ describe('Unit: Utils > getInstance', function () {
         expect(stubs.chdir.calledOnce).to.to.true;
         expect(stubs.chdir.calledWithExactly(dir)).to.be.true;
     });
-})
+});

--- a/test/unit/utils/get-instance-spec.js
+++ b/test/unit/utils/get-instance-spec.js
@@ -1,4 +1,3 @@
-'use strict';
 const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
@@ -42,7 +41,7 @@ describe('Unit: Utils > getInstance', function () {
             expect(false, 'Promise should have rejected').to.be.true;
         } catch (error) {
             expect(error).to.be.instanceof(SystemError);
-            expect(error.message).to.equal('Ghost instance "ghosted" does not exist');
+            expect(error.message).to.equal('Ghost instance \'ghosted\' does not exist');
         }
     });
 


### PR DESCRIPTION
Adds functionality similar to the stop command - `ghost start {name}` now works as `ghost stop {name}` always has

I realized this wasn't a thing as I was testing #765, and given the Stop command already has this functionality, I figured it would be a 5 minute fix, but it turns out both the Start and Stop Command Unit tests aren't super dry, so I ended up going down the rabbit hole of drying up the tests. It might be easier to review commit by commit 😬 

I know this coincides w/ the release of 1.9.0; I don't think it will make much of a difference if this gets released before or afterwards.