### PR TITLE
Fix issue with systemd failed state

### DIFF
--- a/extensions/systemd/systemd.js
+++ b/extensions/systemd/systemd.js
@@ -2,11 +2,13 @@
 
 const fs = require('fs');
 const execa = require('execa');
-const cli = require('../../lib');
 const getUid = require('./get-uid');
 const chalk = require('chalk');
+const {ProcessManager, errors} = require('../../lib');
 
-class SystemdProcessManager extends cli.ProcessManager {
+const {CliError, ProcessError, SystemError} = errors;
+
+class SystemdProcessManager extends ProcessManager {
     get systemdName() {
         return `ghost_${this.instance.name}`;
     }
@@ -17,19 +19,16 @@ class SystemdProcessManager extends cli.ProcessManager {
 
     start() {
         this._precheck();
+        const {logSuggestion} = this;
 
         return this.ui.sudo(`systemctl start ${this.systemdName}`)
-            .then(() => {
-                return this.ensureStarted({
-                    logSuggestion: this.logSuggestion
-                });
-            })
+            .then(() => this.ensureStarted({logSuggestion}))
             .catch((error) => {
-                if (error instanceof cli.errors.CliError) {
+                if (error instanceof CliError) {
                     throw error;
                 }
 
-                throw new cli.errors.ProcessError(error);
+                throw new ProcessError(error);
             });
     }
 
@@ -37,61 +36,59 @@ class SystemdProcessManager extends cli.ProcessManager {
         this._precheck();
 
         return this.ui.sudo(`systemctl stop ${this.systemdName}`)
-            .catch((error) => Promise.reject(new cli.errors.ProcessError(error)));
+            .catch((error) => { throw new ProcessError(error); });
     }
 
     restart() {
         this._precheck();
+        const {logSuggestion} = this;
 
         return this.ui.sudo(`systemctl restart ${this.systemdName}`)
-            .then(() => {
-                return this.ensureStarted({
-                    logSuggestion: this.logSuggestion
-                });
-            })
+            .then(() => this.ensureStarted({logSuggestion}))
             .catch((error) => {
-                if (error instanceof cli.errors.CliError) {
+                if (error instanceof CliError) {
                     throw error;
                 }
 
-                throw new cli.errors.ProcessError(error);
+                throw new ProcessError(error);
             });
     }
 
     isEnabled() {
         return this.ui.sudo(`systemctl is-enabled ${this.systemdName}`)
-            .then(() => Promise.resolve(true))
+            .then(() => true)
             .catch((error) => {
                 // Systemd prints out "disabled" if service isn't enabled
                 // or "failed to get unit file state" if something else goes wrong
                 if (!error.message.match(/disabled|Failed to get unit file state/)) {
-                    return Promise.reject(error);
+                    throw error;
                 }
 
-                return Promise.resolve(false);
+                return false;
             });
     }
 
     enable() {
         return this.ui.sudo(`systemctl enable ${this.systemdName} --quiet`)
-            .catch((error) => Promise.reject(new cli.errors.ProcessError(error)));
+            .catch((error) => { throw new ProcessError(error); });
     }
 
     disable() {
         return this.ui.sudo(`systemctl disable ${this.systemdName} --quiet`)
-            .catch((error) => Promise.reject(new cli.errors.ProcessError(error)));
+            .catch((error) => { throw new ProcessError(error); });
     }
 
     isRunning() {
         return this.ui.sudo(`systemctl is-active ${this.systemdName}`)
-            .then(() => Promise.resolve(true))
-            .catch ((error) => {
+            .then(() => true)
+            .catch((error) => {
                 // Systemd prints out "inactive" if service isn't running
                 // or "activating" if service hasn't completely started yet
                 if (!error.message.match(/inactive|activating/)) {
-                    return Promise.reject(new cli.errors.ProcessError(error));
+                    throw new ProcessError(error);
                 }
-                return Promise.resolve(false);
+
+                return false;
             });
     }
 
@@ -100,7 +97,7 @@ class SystemdProcessManager extends cli.ProcessManager {
 
         // getUid returns either the uid or null
         if (!uid) {
-            throw new cli.errors.SystemError({
+            throw new SystemError({
                 message: 'Systemd process manager has not been set up or is corrupted.',
                 help: `Run ${chalk.green('ghost setup linux-user systemd')} and try again.`
             });
@@ -110,7 +107,7 @@ class SystemdProcessManager extends cli.ProcessManager {
             return;
         }
 
-        throw new cli.errors.SystemError({
+        throw new SystemError({
             message: 'Systemd process manager has not been set up or is corrupted.',
             help: `Run ${chalk.green('ghost setup systemd')} and try again.`
         });


### PR DESCRIPTION
closes #761 
- cleanup es6 usage in systemd extension
- auto-call reset-failed when systemd is in failed state to prevent errors