### PR TITLE
Avoid direct upgrade to v2

### DIFF
--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -178,10 +178,9 @@ class UpdateCommand extends Command {
             return Promise.resolve(true);
         }
 
-        const updateVersion = force ? null : activeVersion;
         const resolveVersion = zip ?
-            () => require('../utils/version-from-zip')(zip, updateVersion) :
-            () => require('../utils/resolve-version')(version, updateVersion, v1);
+            () => require('../utils/version-from-zip')(zip, activeVersion, force) :
+            () => require('../utils/resolve-version')(version, activeVersion, v1, force);
 
         return resolveVersion().then((version) => {
             context.version = version;

--- a/lib/utils/resolve-version.js
+++ b/lib/utils/resolve-version.js
@@ -11,11 +11,11 @@ const MIN_RELEASE = '>= 1.0.0';
  * and/or a passed version & any locally installed versions
  *
  * @param {String} version Any version supplied manually by the user
- * @param {String} update Current version if we are updating
+ * @param {String} activeVersion Current version if we are updating
  * @param {Boolean} v1 Whether or not to limit versions to 1.x release versions
  * @return Promise<string> Promise that resolves with the version to install
  */
-module.exports = function resolveVersion(version, update, v1 = false) {
+module.exports = function resolveVersion(version, activeVersion, v1 = false, force = false) {
     // If version contains a leading v, remove it
     if (version && version.match(/^v[0-9]/)) {
         version = version.slice(1);
@@ -29,7 +29,7 @@ module.exports = function resolveVersion(version, update, v1 = false) {
     }
 
     return yarn(['info', 'ghost', 'versions', '--json']).then((result) => {
-        let comparator = update ? `>${update}` : MIN_RELEASE;
+        let comparator = !force && activeVersion ? `>${activeVersion}` : MIN_RELEASE;
 
         if (v1) {
             comparator += ' <2.0.0';
@@ -53,7 +53,33 @@ module.exports = function resolveVersion(version, update, v1 = false) {
                 }));
             }
 
-            return version || versions.pop();
+            let versionToReturn = version || versions.pop();
+
+            if (v1 && activeVersion && semver.satisfies(activeVersion, '^2.0.0')) {
+                return Promise.reject(new errors.CliError({
+                    message: 'You can\'t downgrade from v2 to v1 using these options.',
+                    help: 'Please run "ghost update --rollback".'
+                }));
+            }
+
+            // CASE: you haven't passed `--v1` and you are not about to install a fresh blog
+            if (!v1 && activeVersion) {
+                const majorVersionJump = semver.major(activeVersion) !== semver.major(versionToReturn);
+
+                // CASE: use latest v1 release
+                if (majorVersionJump && force) {
+                    while (!semver.satisfies(versionToReturn, '^1.0.0')) {
+                        versionToReturn = versions.pop();
+                    }
+                } else if (majorVersionJump && versions.length) {
+                    return Promise.reject(new errors.CliError({
+                        message: 'You are about to migrate to Ghost 2.0. Your blog is not on the latest Ghost 1.0 version.',
+                        help: 'Please run "ghost update --v1".'
+                    }));
+                }
+            }
+
+            return versionToReturn;
         } catch (e) {
             return Promise.reject(new errors.CliError({
                 message: 'Ghost-CLI was unable to load versions from Yarn.',

--- a/lib/utils/version-from-zip.js
+++ b/lib/utils/version-from-zip.js
@@ -6,7 +6,7 @@ const semver = require('semver');
 const AdmZip = require('adm-zip');
 const cliPackage = require('../../package.json');
 
-module.exports = function versionFromZip(zipPath, currentVersion) {
+module.exports = function versionFromZip(zipPath, currentVersion, force = false) {
     if (!path.isAbsolute(zipPath)) {
         zipPath = path.join(process.cwd(), zipPath);
     }
@@ -47,7 +47,7 @@ module.exports = function versionFromZip(zipPath, currentVersion) {
         }));
     }
 
-    if (currentVersion && semver.lt(pkg.version, currentVersion)) {
+    if (force && semver.lt(pkg.version, currentVersion)) {
         return Promise.reject(
             new errors.SystemError('Zip file contains an older release version than what is currently installed.')
         );

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -712,7 +712,7 @@ describe('Unit: Commands > Update', function () {
             return instance.version(context).then((result) => {
                 expect(result).to.be.true;
                 expect(resolveVersion.calledOnce).to.be.true;
-                expect(resolveVersion.calledWithExactly(null, '1.0.0', true)).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, '1.0.0', true, false)).to.be.true;
                 expect(context.version).to.equal('1.0.1');
                 expect(context.installPath).to.equal('/var/www/ghost/versions/1.0.1');
             });
@@ -740,7 +740,7 @@ describe('Unit: Commands > Update', function () {
                 expect(result).to.be.true;
                 expect(resolveVersion.called).to.be.false;
                 expect(zipVersion.calledOnce).to.be.true;
-                expect(zipVersion.calledWithExactly('/some/zip/file.zip', '1.0.0')).to.be.true;
+                expect(zipVersion.calledWithExactly('/some/zip/file.zip', '1.0.0', false)).to.be.true;
                 expect(context.version).to.equal('1.1.0');
                 expect(context.installPath).to.equal('/var/www/ghost/versions/1.1.0');
             });
@@ -763,7 +763,7 @@ describe('Unit: Commands > Update', function () {
             return instance.version(context).then((result) => {
                 expect(result).to.be.false;
                 expect(resolveVersion.calledOnce).to.be.true;
-                expect(resolveVersion.calledWithExactly(null, null, false)).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, '1.0.0', false, true)).to.be.true;
             });
         });
 
@@ -791,7 +791,7 @@ describe('Unit: Commands > Update', function () {
                 expect(error).to.be.an.instanceof(Error);
                 expect(error.message).to.equal('something bad');
                 expect(resolveVersion.calledOnce).to.be.true;
-                expect(resolveVersion.calledWithExactly(null, null, false)).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, '1.0.0', false, true)).to.be.true;
             });
         });
     });

--- a/test/unit/utils/version-from-zip-spec.js
+++ b/test/unit/utils/version-from-zip-spec.js
@@ -114,7 +114,7 @@ describe('Unit: Utils > versionFromZip', function () {
     it('rejects if update version passed and zip version < update version', function () {
         const versionFromZip = require(modulePath);
 
-        return versionFromZip(path.join(__dirname, '../../fixtures/ghostold.zip'), '1.5.0').then(() => {
+        return versionFromZip(path.join(__dirname, '../../fixtures/ghostold.zip'), '1.5.0', true).then(() => {
             expect(false, 'error should have been thrown').to.be.true;
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.SystemError);


### PR DESCRIPTION
refs #759

- extend version resolver
- detect major version jumps
- optimised code structure (use proper force option - this was hard to maintain/understand)

- [x] add unit tests
- [x] do manual test