### PR TITLE
feat(flag): add --v1 flag to install and update

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -41,7 +41,7 @@ class InstallCommand extends Command {
             categories: ['install'],
             skipInstanceCheck: true,
             quiet: true
-        }, argv, {local: local})).then(() => {
+        }, argv, {local})).then(() => {
             return this.ui.listr([{
                 title: 'Checking for latest Ghost version',
                 task: this.version
@@ -64,8 +64,9 @@ class InstallCommand extends Command {
                     task: this.casper
                 }], false)
             }], {
+                version,
                 zip: argv.zip,
-                version: version,
+                v1: argv.v1,
                 cliVersion: this.system.cliVersion
             })
         }).then(() => {
@@ -80,11 +81,13 @@ class InstallCommand extends Command {
     }
 
     version(ctx) {
-        const versionResolver = ctx.zip ?
-            require('../utils/version-from-zip') :
-            require('../utils/resolve-version');
+        const {version, zip, v1} = ctx;
 
-        return versionResolver(ctx.zip || ctx.version).then((version) => {
+        const resolveVersion = zip ?
+            () => require('../utils/version-from-zip')(zip) :
+            () => require('../utils/resolve-version')(version, null, v1);
+
+        return resolveVersion().then((version) => {
             ctx.version = version;
             ctx.installPath = path.join(process.cwd(), 'versions', version);
         });
@@ -133,6 +136,11 @@ InstallCommand.options = {
         description: '[--no-setup] Enable/Disable auto-running the setup command',
         type: 'boolean',
         default: true
+    },
+    v1: {
+        describe: 'Limit install to Ghost 1.x releases',
+        type: 'boolean',
+        default: false
     }
 };
 InstallCommand.checkVersion = true;

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -33,12 +33,15 @@ class UpdateCommand extends Command {
             );
         }
 
+        const {force, version, zip, v1} = argv;
+
         const context = {
-            instance: instance,
-            force: argv.force,
+            instance,
+            force,
             activeVersion: instance.cliConfig.get('active-version'),
-            version: argv.version,
-            zip: argv.zip
+            version,
+            zip,
+            v1
         };
 
         if (argv.rollback) {
@@ -169,18 +172,18 @@ class UpdateCommand extends Command {
     }
 
     version(context) {
-        if (context.rollback) {
+        const {rollback, zip, v1, version, force, activeVersion} = context;
+
+        if (rollback) {
             return Promise.resolve(true);
         }
 
-        const versionResolver = context.zip ?
-            require('../utils/version-from-zip') :
-            require('../utils/resolve-version');
+        const updateVersion = force ? null : activeVersion;
+        const resolveVersion = zip ?
+            () => require('../utils/version-from-zip')(zip, updateVersion) :
+            () => require('../utils/resolve-version')(version, updateVersion, v1);
 
-        return versionResolver(
-            context.zip || context.version,
-            context.force ? null : context.activeVersion
-        ).then((version) => {
+        return resolveVersion().then((version) => {
             context.version = version;
             context.installPath = path.join(process.cwd(), 'versions', version);
             return true;
@@ -225,6 +228,11 @@ UpdateCommand.options = {
         description: '[--no-restart] Enable/Disable restarting Ghost after updating',
         type: 'boolean',
         default: true
+    },
+    v1: {
+        describe: 'Limit update to Ghost 1.x releases',
+        type: 'boolean',
+        default: false
     }
 };
 UpdateCommand.checkVersion = true;

--- a/lib/utils/resolve-version.js
+++ b/lib/utils/resolve-version.js
@@ -10,11 +10,12 @@ const MIN_RELEASE = '>= 1.0.0';
  * Resolves the ghost version to installed based on available NPM versions
  * and/or a passed version & any locally installed versions
  *
- * @param {string} version Any version supplied manually by the user
- * @param {string} update Current version if we are updating
+ * @param {String} version Any version supplied manually by the user
+ * @param {String} update Current version if we are updating
+ * @param {Boolean} v1 Whether or not to limit versions to 1.x release versions
  * @return Promise<string> Promise that resolves with the version to install
  */
-module.exports = function resolveVersion(version, update) {
+module.exports = function resolveVersion(version, update, v1 = false) {
     // If version contains a leading v, remove it
     if (version && version.match(/^v[0-9]/)) {
         version = version.slice(1);
@@ -28,7 +29,11 @@ module.exports = function resolveVersion(version, update) {
     }
 
     return yarn(['info', 'ghost', 'versions', '--json']).then((result) => {
-        const comparator = update ? `>${update}` : MIN_RELEASE;
+        let comparator = update ? `>${update}` : MIN_RELEASE;
+
+        if (v1) {
+            comparator += ' <2.0.0';
+        }
 
         try {
             let versions = JSON.parse(result.stdout).data || [];

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -96,7 +96,7 @@ describe('Unit: Commands > Install', function () {
             const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
 
-            return testInstance.run({version: 'local', zip: ''}).then(() => {
+            return testInstance.run({version: 'local', zip: '', v1: true}).then(() => {
                 expect(false, 'run should have rejected').to.be.true;
             }).catch(() => {
                 expect(readdirStub.calledOnce).to.be.true;
@@ -105,7 +105,8 @@ describe('Unit: Commands > Install', function () {
                 expect(listrStub.args[0][1]).to.deep.equal({
                     version: null,
                     cliVersion: '1.0.0',
-                    zip: ''
+                    zip: '',
+                    v1: true
                 });
                 expect(setEnvironmentStub.calledOnce).to.be.true;
                 expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
@@ -125,7 +126,7 @@ describe('Unit: Commands > Install', function () {
             const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
 
-            return testInstance.run({version: '1.5.0', local: true, zip: ''}).then(() => {
+            return testInstance.run({version: '1.5.0', local: true, zip: '', v1: false}).then(() => {
                 expect(false, 'run should have rejected').to.be.true;
             }).catch(() => {
                 expect(readdirStub.calledOnce).to.be.true;
@@ -134,7 +135,8 @@ describe('Unit: Commands > Install', function () {
                 expect(listrStub.args[0][1]).to.deep.equal({
                     version: '1.5.0',
                     cliVersion: '1.0.0',
-                    zip: ''
+                    zip: '',
+                    v1: false
                 });
                 expect(setEnvironmentStub.calledOnce).to.be.true;
                 expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -17,6 +17,10 @@ describe('Unit: Commands > Update', function () {
         cleanupTestFolders();
     });
 
+    afterEach(() => {
+        sinon.restore();
+    });
+
     it('configureOptions adds setup & doctor options', function () {
         const superStub = sinon.stub().returnsArg(1);
         const doctorStub = sinon.stub().returnsArg(1);
@@ -77,7 +81,7 @@ describe('Unit: Commands > Update', function () {
             const linkStub = sinon.stub(cmdInstance, 'link').resolves();
             const stopStub = sinon.stub(cmdInstance, 'stop').resolves();
 
-            return cmdInstance.run({version: '2.0.1', force: false, zip: ''}).then(() => {
+            return cmdInstance.run({version: '2.0.1', force: false, zip: '', v1: false}).then(() => {
                 expect(runCommandStub.calledTwice).to.be.true;
                 expect(ui.run.calledOnce).to.be.true;
                 expect(versionStub.calledOnce).to.be.true;
@@ -86,7 +90,8 @@ describe('Unit: Commands > Update', function () {
                     force: false,
                     instance: fakeInstance,
                     activeVersion: '2.0.0',
-                    zip: ''
+                    zip: '',
+                    v1: false
                 });
                 expect(ui.log.calledOnce).to.be.false;
                 expect(ui.listr.calledOnce).to.be.true;
@@ -143,7 +148,7 @@ describe('Unit: Commands > Update', function () {
             const linkStub = sinon.stub(cmdInstance, 'link').resolves();
             const stopStub = sinon.stub(cmdInstance, 'stop').resolves();
 
-            return cmdInstance.run({version: '2.0.0', force: false, zip: ''}).then(() => {
+            return cmdInstance.run({version: '2.0.0', force: false, zip: '', v1: false}).then(() => {
                 expect(runCommandStub.calledTwice).to.be.true;
                 expect(ui.run.calledOnce).to.be.true;
                 expect(versionStub.calledOnce).to.be.true;
@@ -152,7 +157,8 @@ describe('Unit: Commands > Update', function () {
                     force: false,
                     instance: fakeInstance,
                     activeVersion: '1.25.0',
-                    zip: ''
+                    zip: '',
+                    v1: false
                 });
                 expect(ui.log.calledOnce).to.be.false;
                 expect(ui.listr.calledOnce).to.be.true;
@@ -188,7 +194,7 @@ describe('Unit: Commands > Update', function () {
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(false);
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
 
-            return cmdInstance.run({version: '1.0.0', force: false, zip: ''}).then(() => {
+            return cmdInstance.run({version: '1.0.0', force: false, zip: '', v1: false}).then(() => {
                 expect(runCommandStub.calledTwice).to.be.true;
                 expect(ui.run.calledOnce).to.be.true;
                 expect(versionStub.calledOnce).to.be.true;
@@ -197,7 +203,8 @@ describe('Unit: Commands > Update', function () {
                     force: false,
                     instance: fakeInstance,
                     activeVersion: '1.0.0',
-                    zip: ''
+                    zip: '',
+                    v1: false
                 });
                 expect(ui.log.calledTwice).to.be.true;
                 expect(ui.log.args[0][0]).to.match(/install is using out-of-date configuration/);
@@ -261,12 +268,10 @@ describe('Unit: Commands > Update', function () {
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(false);
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
-            const cwdStub = sinon.stub(process, 'cwd').returns(fakeInstance.dir);
+            sinon.stub(process, 'cwd').returns(fakeInstance.dir);
 
-            return cmdInstance.run({rollback: true, force: false, zip: ''}).then(() => {
+            return cmdInstance.run({rollback: true, force: false, zip: '', v1: false}).then(() => {
                 expect(runCommandStub.calledTwice).to.be.true;
-                cwdStub.restore();
-
                 expect(ui.run.calledOnce).to.be.true;
                 expect(versionStub.calledOnce).to.be.true;
                 expect(versionStub.args[0][0]).to.deep.equal({
@@ -276,7 +281,8 @@ describe('Unit: Commands > Update', function () {
                     activeVersion: '1.1.0',
                     installPath: '/var/www/ghost/versions/1.0.0',
                     rollback: true,
-                    zip: ''
+                    zip: '',
+                    v1: false
                 });
                 expect(ui.log.calledOnce).to.be.true;
                 expect(ui.log.args[0][0]).to.match(/up to date/);
@@ -322,14 +328,12 @@ describe('Unit: Commands > Update', function () {
             const stopStub = sinon.stub(cmdInstance, 'stop').resolves();
             const restartStub = sinon.stub(cmdInstance, 'restart').resolves();
             const linkStub = sinon.stub(cmdInstance, 'link').resolves();
-            const cwdStub = sinon.stub(process, 'cwd').returns(fakeInstance.dir);
+            sinon.stub(process, 'cwd').returns(fakeInstance.dir);
             const downloadStub = sinon.stub(cmdInstance, 'downloadAndUpdate');
             const removeOldVersionsStub = sinon.stub(cmdInstance, 'removeOldVersions');
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
 
             return cmdInstance.run({version: '1.1.0', rollback: false, force: false, restart: true}).then(() => {
-                cwdStub.restore();
-
                 expect(runCommandStub.calledTwice).to.be.true;
                 expect(ui.run.calledOnce).to.be.true;
                 expect(versionStub.calledOnce).to.be.true;
@@ -382,14 +386,12 @@ describe('Unit: Commands > Update', function () {
             sinon.stub(cmdInstance, 'stop').resolves();
             sinon.stub(cmdInstance, 'restart').resolves();
             sinon.stub(cmdInstance, 'link').resolves();
-            const cwdStub = sinon.stub(process, 'cwd').returns(fakeInstance.dir);
+            sinon.stub(process, 'cwd').returns(fakeInstance.dir);
             const downloadStub = sinon.stub(cmdInstance, 'downloadAndUpdate');
             const removeOldVersionsStub = sinon.stub(cmdInstance, 'removeOldVersions');
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
 
-            return cmdInstance.run({rollback: true, force: false, zip: '', restart: true}).then(() => {
-                cwdStub.restore();
-
+            return cmdInstance.run({rollback: true, force: false, zip: '', restart: true, v1: true}).then(() => {
                 const expectedCtx = {
                     version: '1.0.0',
                     force: false,
@@ -397,7 +399,8 @@ describe('Unit: Commands > Update', function () {
                     activeVersion: '1.1.0',
                     installPath: '/var/www/ghost/versions/1.0.0',
                     rollback: true,
-                    zip: ''
+                    zip: '',
+                    v1: true
                 };
 
                 expect(runCommandStub.calledTwice).to.be.true;
@@ -450,13 +453,12 @@ describe('Unit: Commands > Update', function () {
             const stopStub = sinon.stub(cmdInstance, 'stop').resolves();
             sinon.stub(cmdInstance, 'restart').resolves();
             sinon.stub(cmdInstance, 'link').resolves();
-            const cwdStub = sinon.stub(process, 'cwd').returns(fakeInstance.dir);
+            sinon.stub(process, 'cwd').returns(fakeInstance.dir);
             sinon.stub(cmdInstance, 'downloadAndUpdate');
             sinon.stub(cmdInstance, 'removeOldVersions');
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
 
-            return cmdInstance.run({rollback: true, force: false, zip: '', restart: true}).then(() => {
-                cwdStub.restore();
+            return cmdInstance.run({rollback: true, force: false, zip: '', restart: true, v1: false}).then(() => {
                 const expectedCtx = {
                     version: '1.0.0',
                     force: false,
@@ -464,7 +466,8 @@ describe('Unit: Commands > Update', function () {
                     activeVersion: '1.1.0',
                     installPath: '/var/www/ghost/versions/1.0.0',
                     rollback: true,
-                    zip: ''
+                    zip: '',
+                    v1: false
                 };
 
                 expect(runCommandStub.calledTwice).to.be.true;
@@ -625,11 +628,10 @@ describe('Unit: Commands > Update', function () {
             const env = setupTestFolder({dirs: dirs});
             const UpdateCommand = require(modulePath);
             const instance = new UpdateCommand({}, {});
-            const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
+            sinon.stub(process, 'cwd').returns(env.dir);
             const skipStub = sinon.stub();
 
             return instance.removeOldVersions({}, {skip: skipStub}).then(() => {
-                cwdStub.restore();
                 expect(skipStub.calledOnce).to.be.true;
 
                 dirs.forEach((version) => {
@@ -655,7 +657,7 @@ describe('Unit: Commands > Update', function () {
             const env = setupTestFolder(envCfg);
             const UpdateCommand = require(modulePath);
             const instance = new UpdateCommand({}, {});
-            const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
+            sinon.stub(process, 'cwd').returns(env.dir);
             const keptVersions = [
                 '1.1.0',
                 '1.2.0',
@@ -671,8 +673,6 @@ describe('Unit: Commands > Update', function () {
             ];
 
             return instance.removeOldVersions().then(() => {
-                cwdStub.restore();
-
                 keptVersions.forEach((version) => {
                     expect(fs.existsSync(path.join(env.dir, 'versions', version))).to.be.true;
                 });
@@ -704,17 +704,17 @@ describe('Unit: Commands > Update', function () {
                 rollback: false,
                 force: false,
                 version: null,
-                activeVersion: '1.0.0'
+                activeVersion: '1.0.0',
+                v1: true
             };
-            const cwdStub = sinon.stub(process, 'cwd').returns('/var/www/ghost');
+            sinon.stub(process, 'cwd').returns('/var/www/ghost');
 
             return instance.version(context).then((result) => {
                 expect(result).to.be.true;
                 expect(resolveVersion.calledOnce).to.be.true;
-                expect(resolveVersion.calledWithExactly(null, '1.0.0')).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, '1.0.0', true)).to.be.true;
                 expect(context.version).to.equal('1.0.1');
                 expect(context.installPath).to.equal('/var/www/ghost/versions/1.0.1');
-                cwdStub.restore();
             });
         });
 
@@ -731,9 +731,10 @@ describe('Unit: Commands > Update', function () {
                 force: false,
                 version: null,
                 activeVersion: '1.0.0',
-                zip: '/some/zip/file.zip'
+                zip: '/some/zip/file.zip',
+                v1: true
             };
-            const cwdStub = sinon.stub(process, 'cwd').returns('/var/www/ghost');
+            sinon.stub(process, 'cwd').returns('/var/www/ghost');
 
             return instance.version(context).then((result) => {
                 expect(result).to.be.true;
@@ -742,7 +743,6 @@ describe('Unit: Commands > Update', function () {
                 expect(zipVersion.calledWithExactly('/some/zip/file.zip', '1.0.0')).to.be.true;
                 expect(context.version).to.equal('1.1.0');
                 expect(context.installPath).to.equal('/var/www/ghost/versions/1.1.0');
-                cwdStub.restore();
             });
         });
 
@@ -756,13 +756,14 @@ describe('Unit: Commands > Update', function () {
                 rollback: false,
                 force: true,
                 version: null,
-                activeVersion: '1.0.0'
+                activeVersion: '1.0.0',
+                v1: false
             };
 
             return instance.version(context).then((result) => {
                 expect(result).to.be.false;
                 expect(resolveVersion.calledOnce).to.be.true;
-                expect(resolveVersion.calledWithExactly(null, null)).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, null, false)).to.be.true;
             });
         });
 
@@ -780,7 +781,8 @@ describe('Unit: Commands > Update', function () {
                 rollback: false,
                 force: true,
                 version: null,
-                activeVersion: '1.0.0'
+                activeVersion: '1.0.0',
+                v1: false
             };
 
             return instance.version(context).then(() => {
@@ -789,7 +791,7 @@ describe('Unit: Commands > Update', function () {
                 expect(error).to.be.an.instanceof(Error);
                 expect(error.message).to.equal('something bad');
                 expect(resolveVersion.calledOnce).to.be.true;
-                expect(resolveVersion.calledWithExactly(null, null)).to.be.true;
+                expect(resolveVersion.calledWithExactly(null, null, false)).to.be.true;
             });
         });
     });
@@ -804,7 +806,7 @@ describe('Unit: Commands > Update', function () {
                 links: [['versions/1.0.0', 'current']]
             }
             const env = setupTestFolder(envCfg);
-            const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
+            sinon.stub(process, 'cwd').returns(env.dir);
             const config = configStub();
             config.get.withArgs('active-version').returns('1.0.0');
             const context = {
@@ -822,8 +824,6 @@ describe('Unit: Commands > Update', function () {
             expect(config.set.calledWithExactly('previous-version', '1.0.0')).to.be.true;
             expect(config.set.calledWithExactly('active-version', '1.0.1')).to.be.true;
             expect(config.save.calledOnce).to.be.true;
-
-            cwdStub.restore();
         });
 
         it('does things correctly with rollback', function () {
@@ -833,7 +833,7 @@ describe('Unit: Commands > Update', function () {
                 links: [['versions/1.0.1', 'current']]
             }
             const env = setupTestFolder(envCfg);
-            const cwdStub = sinon.stub(process, 'cwd').returns(env.dir);
+            sinon.stub(process, 'cwd').returns(env.dir);
             const config = configStub();
             config.get.withArgs('active-version').returns('1.0.1');
             const context = {
@@ -851,8 +851,6 @@ describe('Unit: Commands > Update', function () {
             expect(config.set.calledWithExactly('previous-version', null)).to.be.true;
             expect(config.set.calledWithExactly('active-version', '1.0.0')).to.be.true;
             expect(config.save.calledOnce).to.be.true;
-
-            cwdStub.restore();
         });
     });
 });

--- a/test/unit/utils/resolve-version-spec.js
+++ b/test/unit/utils/resolve-version-spec.js
@@ -103,6 +103,14 @@ describe('Unit: resolveVersion', function () {
                 expect(version).to.equal('1.0.1');
             });
         });
+
+        it('filters out 2.0 version if v1 param is specified', function () {
+            stubYarn('{"data": ["1.0.0", "1.0.1", "1.52.37", "2.0.0"]}');
+
+            return resolveVersion(null, null, true).then(function (version) {
+                expect(version).to.equal('1.52.37');
+            });
+        });
     });
 
     describe('with existing version', function () {
@@ -110,6 +118,17 @@ describe('Unit: resolveVersion', function () {
             stubYarn('{"data": ["1.0.0", "1.0.1"]}');
 
             return resolveVersion(null, '1.0.1').then(function () {
+                throw new Error('Version finder should not have resolved');
+            }).catch(function (error) {
+                expect(error).to.be.an.instanceOf(Error);
+                expect(error.message).to.equal('No valid versions found.');
+            });
+        });
+
+        it('filters out 2.0 version if v1 param is specified', function () {
+            stubYarn('{"data": ["1.0.0", "1.0.1", "1.52.37", "2.0.0"]}');
+
+            return resolveVersion(null, '1.52.37', true).then(function () {
                 throw new Error('Version finder should not have resolved');
             }).catch(function (error) {
                 expect(error).to.be.an.instanceOf(Error);


### PR DESCRIPTION
refs #759
- adds --v1 flag to install and update commands
- add arg to resolveVersion util that limits versions to 1.x releases

TODO:
- [x] manual testing
- [x] fix unit tests