### PR TITLE
Fix(migrations): allow existing content/settings folder

### DIFF
--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -7,7 +7,7 @@ function ensureSettingsFolder(context) {
     const contentDir = context.instance.config.get('paths.contentPath');
 
     if (ghostUser.shouldUseGhostUser(contentDir)) {
-        return context.ui.sudo(`mkdir ${path.resolve(contentDir, 'settings')}`, {sudoArgs: '-E -u ghost'});
+        return context.ui.sudo(`mkdir -p ${path.resolve(contentDir, 'settings')}`, {sudoArgs: '-E -u ghost'});
     } else {
         const fs = require('fs-extra');
         fs.ensureDirSync(path.resolve(contentDir, 'settings'));

--- a/test/unit/migrations-spec.js
+++ b/test/unit/migrations-spec.js
@@ -31,7 +31,7 @@ describe('Unit: Migrations', function () {
                 expect(ghostUserStub.calledWithExactly('/var/www/ghost/content')).to.be.true;
                 expect(sudoStub.calledOnce).to.be.true;
                 expect(sudoStub.calledWithExactly(
-                    'mkdir /var/www/ghost/content/settings',
+                    'mkdir -p /var/www/ghost/content/settings',
                     {sudoArgs: '-E -u ghost'}
                 )).to.be.true;
             });


### PR DESCRIPTION
closes #776

In production sites, when the ghost user is used, the content/* folder needs to be owned by the Ghost user so the ghost application will not run into permission issues. In the migration, to make sure this happens, we run the `mkdir` command using sudo (i.e. `sudo -E -u ghost mkdir {path}`). When the Ghost user isn't needed, we use the `fs-extra` library to make sure the directory exists (specifically `ensureDirSync`). `fs.ensureDirSync` is equivilant to `mkdir -p` (not `mkdir`), so the behaviour differs. By adding the `p` flag to the `mkdir` command that's run when the Ghost user is used, the behaviour between the two cases are equalized, including support for a settings folder that already exists