### PR TITLE
chore(lint): use eslint-plugin-ghost for lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,68 +1,9 @@
 {
-  "env": {
-    "node": true,
-    "es6": true
-  },
-  "extends": "eslint:recommended",
-  "globals": {},
+  "plugins": ["ghost"],
+  "extends": [
+    "plugin:ghost/node"
+  ],
   "rules": {
-    "array-bracket-spacing": ["error", "never"],
-    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
-    "camelcase": ["error", {"properties": "never"}],
-    "comma-dangle": "error",
-    "comma-style": "error",
-    "curly": ["error", "all"],
-    "dot-notation": "error",
-    "eol-last": "error",
-    "eqeqeq": "error",
-    "func-names": "error",
-    "indent": ["error", 4, { "SwitchCase": 1 }],
-    "key-spacing": "error",
-    "keyword-spacing": "error",
-    "linebreak-style": "error",
-    "max-len": ["error", {
-      "code": 120,
-      "ignoreComments": true,
-      "ignoreStrings": true,
-      "ignoreTemplateLiterals": true,
-      "ignoreRegExpLiterals": true
-    }],
-    "new-cap": "error",
-    "new-parens": "error",
-    "no-caller": "error",
-    "no-console": "off",
-    "no-empty": "error",
-    "no-lonely-if": "error",
-    "no-multiple-empty-lines": "error",
-    "no-new": "error",
-    "no-plusplus": "error",
-    "no-trailing-spaces": "error",
-    "no-undef": "error",
-    "no-unused-vars": "error",
-    "no-use-before-define": "error",
-    "no-var": "error",
-    "no-with": "error",
-    "object-curly-newline": ["error", {"consistent": true}],
-    "object-curly-spacing": "error",
-    "padded-blocks": ["error", "never"],
-    "prefer-arrow-callback": "error",
-    "prefer-const": "error",
-    "quote-props": ["error", "as-needed"],
-    "quotes": ["error", "single"],
-    "space-before-blocks": "error",
-    "space-before-function-paren": ["error", {
-      "anonymous": "always",
-      "named": "never"
-    }],
-    "space-in-parens": ["error", "never"],
-    "space-infix-ops": "error",
-    "space-unary-ops": ["error", {
-      "words": false,
-      "nonwords": false
-    }],
-    "spaced-comment": "error",
-    "strict": ["error", "safe"],
-    "template-curly-spacing": "error",
-    "yoda": "error"
+    "no-console": ["off"]
   }
 }

--- a/extensions/nginx/migrations.js
+++ b/extensions/nginx/migrations.js
@@ -28,7 +28,7 @@ function migrateSSL(ctx, migrateTask) {
     }
 
     const confFileContents = fs.readFileSync(confFile, {encoding: 'utf8'});
-    const certCheck = new RegExp(`ssl_certificate ${originalCertFolder}/fullchain.cer;`)
+    const certCheck = new RegExp(`ssl_certificate ${originalCertFolder}/fullchain.cer;`);
 
     // Case to skip 3: SSL conf does not contain a cert config using the old LE cert
     if (!certCheck.test(confFileContents)) {

--- a/extensions/nginx/test/acme-spec.js
+++ b/extensions/nginx/test/acme-spec.js
@@ -37,7 +37,7 @@ describe('Unit: Extensions > Nginx > Acme', function () {
         });
 
         it('downloads acme.sh', function () {
-            const dwUrl = 'https://ghost.org/download'
+            const dwUrl = 'https://ghost.org/download';
             const fakeResponse = {
                 body: JSON.stringify({tarball_url: dwUrl}),
                 statusCode: 200
@@ -191,7 +191,7 @@ describe('Unit: Extensions > Nginx > Acme', function () {
 
             return acme.generate({sudo: sudoStub}).then((result) => {
                 expect(sudoStub.calledOnce).to.be.true;
-                expect(result).to.not.exist
+                expect(result).to.not.exist;
             });
         });
 
@@ -234,7 +234,7 @@ describe('Unit: Extensions > Nginx > Acme', function () {
                 expect(sudoStub.calledOnce).to.be.true;
                 expect(sudoStub.args[0][0]).to.equal(
                     '/etc/letsencrypt/acme.sh --remove --home /etc/letsencrypt --domain ghost.org'
-                )
+                );
             });
         });
 
@@ -250,7 +250,7 @@ describe('Unit: Extensions > Nginx > Acme', function () {
                 expect(sudoStub.calledOnce).to.be.true;
                 expect(sudoStub.args[0][0]).to.equal(
                     '/home/ghost/.acme.sh/acme.sh --remove --home /home/ghost/.acme.sh --domain ghost.org'
-                )
+                );
             });
         });
 

--- a/extensions/nginx/test/extension-spec.js
+++ b/extensions/nginx/test/extension-spec.js
@@ -241,7 +241,7 @@ describe('Unit: Extensions > Nginx', function () {
             ext.restartNginx = sinon.stub().rejects(new errors.CliError('Did not restart'));
 
             return ext.setupNginx(null, ctx, task).then(() => {
-                expect(false, 'Promise should have rejected').to.be.true
+                expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(error).to.exist;
                 expect(error).to.be.an.instanceof(errors.CliError);
@@ -272,7 +272,7 @@ describe('Unit: Extensions > Nginx', function () {
             ext.ui.sudo = sudo;
 
             return ext.setupNginx(null, ctx, task).then(() => {
-                expect(false, 'Promise should have rejected').to.be.true
+                expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(error).to.exist;
                 expect(error).to.be.an.instanceof(errors.ProcessError);
@@ -364,7 +364,7 @@ describe('Unit: Extensions > Nginx', function () {
 
         function getTasks(ext, args) {
             args = args || {};
-            args.prompt = true
+            args.prompt = true;
             ext.setupSSL(args, ctx, task);
 
             expect(task.skip.called, 'getTasks: task.skip').to.be.false;
@@ -399,11 +399,13 @@ describe('Unit: Extensions > Nginx', function () {
 
             beforeEach(function () {
                 DNS = new Error('DNS_ERROR');
-                proxy.dns = {lookup: () => {throw DNS}};
+                proxy.dns = {lookup: () => {
+                    throw DNS;
+                }};
             });
 
             it('Breaks if DNS fails (Not found & unknown)', function () {
-                DNS.code  = 'ENOTFOUND';
+                DNS.code = 'ENOTFOUND';
                 let ctx = {};
                 const ext = proxyNginx(proxy);
                 const tasks = getTasks(ext);
@@ -419,7 +421,7 @@ describe('Unit: Extensions > Nginx', function () {
                     log.reset();
                     ctx = {};
                     firstSet = true;
-                    return tasks[0].task(ctx)
+                    return tasks[0].task(ctx);
                 }).then(() => {
                     expect(false, 'Promise should have rejected').to.be.true;
                 }).catch((err) => {
@@ -433,7 +435,7 @@ describe('Unit: Extensions > Nginx', function () {
             });
 
             it('Everything skips when DNS fails', function () {
-                stubs.es.callsFake((val) => (val.indexOf('-ssl') < 0 || val.indexOf('acme') >= 0));
+                stubs.es.callsFake(val => (val.indexOf('-ssl') < 0 || val.indexOf('acme') >= 0));
 
                 const ctx = {dnsfail: true};
                 const ext = proxyNginx(proxy);
@@ -536,7 +538,7 @@ describe('Unit: Extensions > Nginx', function () {
 
             it('Rejects when command fails', function () {
                 const ext = proxyNginx(proxy);
-                ext.ui.sudo.rejects(new Error('Go ask George'))
+                ext.ui.sudo.rejects(new Error('Go ask George'));
                 const tasks = getTasks(ext);
 
                 return tasks[4].task().then(() => {
@@ -595,7 +597,7 @@ describe('Unit: Extensions > Nginx', function () {
                 stubs.templatify = sinon.stub().returns('nginx ssl config');
                 stubs.template = sinon.stub().returns(stubs.templatify);
                 proxy['fs-extra'].writeFile = sinon.stub().resolves();
-                proxy['lodash/template'] = stubs.template
+                proxy['lodash/template'] = stubs.template;
             });
 
             it('Provides necessary template data', function () {
@@ -612,7 +614,10 @@ describe('Unit: Extensions > Nginx', function () {
             });
 
             it('Templates subdirectories properly', function () {
-                ctx.instance.config.get = (key) => key === 'url' ? 'http://ghost.dev/blog' : 2368;
+                // eslint-disable-next-line arrow-body-style
+                ctx.instance.config.get = (key) => {
+                    return key === 'url' ? 'http://ghost.dev/blog' : 2368;
+                };
                 const ext = proxyNginx(proxy);
                 const tasks = getTasks(ext);
                 ext.template = sinon.stub().resolves();
@@ -640,7 +645,7 @@ describe('Unit: Extensions > Nginx', function () {
                     expect(ext.ui.sudo.calledOnce).to.be.true;
                     expect(err.options.stderr).to.equal('oh no!');
                 });
-            })
+            });
         });
         describe('Restart', function () {
             it('Restarts Nginx', function () {
@@ -656,7 +661,7 @@ describe('Unit: Extensions > Nginx', function () {
 
     describe('uninstall hook', function () {
         const instance = {config: {get: () => 'http://ghost.dev'}};
-        const testEs = (val) => (new RegExp(/-ssl/)).test(val);
+        const testEs = val => (new RegExp(/-ssl/)).test(val);
 
         it('returns if no url exists in config', function () {
             const config = {get: () => undefined};
@@ -680,8 +685,8 @@ describe('Unit: Extensions > Nginx', function () {
         });
 
         it('Removes http config', function () {
-            const sudoExp = new RegExp(/(available|enabled)\/ghost\.dev\.conf/)
-            const esStub = sinon.stub().callsFake((val) => !testEs(val));
+            const sudoExp = new RegExp(/(available|enabled)\/ghost\.dev\.conf/);
+            const esStub = sinon.stub().callsFake(val => !testEs(val));
             const ext = proxyNginx({'fs-extra': {existsSync: esStub}});
 
             return ext.uninstall(instance).then(() => {
@@ -693,7 +698,7 @@ describe('Unit: Extensions > Nginx', function () {
         });
 
         it('Removes https config', function () {
-            const sudoExp = new RegExp(/(available|enabled)\/ghost\.dev-ssl\.conf/)
+            const sudoExp = new RegExp(/(available|enabled)\/ghost\.dev-ssl\.conf/);
             const esStub = sinon.stub().callsFake(testEs);
             const ext = proxyNginx({'fs-extra': {existsSync: esStub}});
 
@@ -730,8 +735,8 @@ describe('Unit: Extensions > Nginx', function () {
 
         beforeEach(function () {
             ext = new NGINX();
-            ext.ui = {sudo: sinon.stub().resolves()}
-        })
+            ext.ui = {sudo: sinon.stub().resolves()};
+        });
 
         it('Soft reloads nginx', function () {
             const sudo = ext.ui.sudo;

--- a/extensions/nginx/test/migrations-spec.js
+++ b/extensions/nginx/test/migrations-spec.js
@@ -9,7 +9,7 @@ const modulePath = '../migrations';
 
 const cli = require('../../../lib');
 
-const context =  {
+const context = {
     instance: {
         dir: '/var/www/ghost',
         config: {

--- a/extensions/systemd/index.js
+++ b/extensions/systemd/index.js
@@ -45,16 +45,18 @@ class SystemdExtension extends Extension {
 
         return this.template(instance, contents, 'systemd service', serviceFilename, '/lib/systemd/system').then(
             () => this.ui.sudo('systemctl daemon-reload')
-        ).catch((error) => { throw new ProcessError(error); });
+        ).catch((error) => {
+            throw new ProcessError(error);
+        });
     }
 
     uninstall(instance) {
         const serviceFilename = `/lib/systemd/system/ghost_${instance.name}.service`;
 
         if (fs.existsSync(serviceFilename)) {
-            return this.ui.sudo(`rm ${serviceFilename}`).catch(
-                () => { throw new SystemError('Systemd service file link could not be removed, you will need to do this manually.'); }
-            );
+            return this.ui.sudo(`rm ${serviceFilename}`).catch(() => {
+                throw new SystemError('Systemd service file link could not be removed, you will need to do this manually.');
+            });
         }
 
         return Promise.resolve();

--- a/extensions/systemd/systemd.js
+++ b/extensions/systemd/systemd.js
@@ -33,15 +33,8 @@ class SystemdProcessManager extends ProcessManager {
                 this.instance.config.set('bootstrap-socket', socketAddress);
                 return this.instance.config.save();
             })
-            .then(() => {
-                return this.ui.sudo(`systemctl start ${this.systemdName}`)
-            })
-            .then(() => {
-                return this.ensureStarted({
-                    logSuggestion,
-                    socketAddress
-                });
-            })
+            .then(() => this.ui.sudo(`systemctl start ${this.systemdName}`))
+            .then(() => this.ensureStarted({logSuggestion, socketAddress}))
             .catch((error) => {
                 if (error instanceof CliError) {
                     throw error;
@@ -54,8 +47,9 @@ class SystemdProcessManager extends ProcessManager {
     stop() {
         this._precheck();
 
-        return this.ui.sudo(`systemctl stop ${this.systemdName}`)
-            .catch((error) => { throw new ProcessError(error); });
+        return this.ui.sudo(`systemctl stop ${this.systemdName}`).catch((error) => {
+            throw new ProcessError(error);
+        });
     }
 
     restart() {
@@ -74,15 +68,8 @@ class SystemdProcessManager extends ProcessManager {
                 this.instance.config.set('bootstrap-socket', socketAddress);
                 return this.instance.config.save();
             })
-            .then(() => {
-                return this.ui.sudo(`systemctl restart ${this.systemdName}`)
-            })
-            .then(() => {
-                return this.ensureStarted({
-                    logSuggestion,
-                    socketAddress
-                });
-            })
+            .then(() => this.ui.sudo(`systemctl restart ${this.systemdName}`))
+            .then(() => this.ensureStarted({logSuggestion, socketAddress}))
             .catch((error) => {
                 if (error instanceof CliError) {
                     throw error;
@@ -107,13 +94,15 @@ class SystemdProcessManager extends ProcessManager {
     }
 
     enable() {
-        return this.ui.sudo(`systemctl enable ${this.systemdName} --quiet`)
-            .catch((error) => { throw new ProcessError(error); });
+        return this.ui.sudo(`systemctl enable ${this.systemdName} --quiet`).catch((error) => {
+            throw new ProcessError(error);
+        });
     }
 
     disable() {
-        return this.ui.sudo(`systemctl disable ${this.systemdName} --quiet`)
-            .catch((error) => { throw new ProcessError(error); });
+        return this.ui.sudo(`systemctl disable ${this.systemdName} --quiet`).catch((error) => {
+            throw new ProcessError(error);
+        });
     }
 
     isRunning() {
@@ -132,7 +121,9 @@ class SystemdProcessManager extends ProcessManager {
                 if (error.stdout && error.stdout.match(/failed/)) {
                     return this.ui.sudo(`systemctl reset-failed ${this.systemdName}`)
                         .then(() => false)
-                        .catch((error) => { throw new ProcessError(error); });
+                        .catch((error) => {
+                            throw new ProcessError(error);
+                        });
                 }
 
                 throw new ProcessError(error);

--- a/extensions/systemd/test/extension-spec.js
+++ b/extensions/systemd/test/extension-spec.js
@@ -173,7 +173,7 @@ describe('Unit: Systemd > Extension', function () {
             const instance = {dir: '/some/dir', cliConfig: {get: getStub}, name: 'test'};
 
             return testInstance._setup({}, {instance: instance}, {skip: skipStub}).then(() => {
-                expect(false, 'Promise should have rejected').to.be.true
+                expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(error).to.exist;
                 expect(error).to.be.an.instanceof(errors.ProcessError);

--- a/extensions/systemd/test/systemd-spec.js
+++ b/extensions/systemd/test/systemd-spec.js
@@ -209,7 +209,7 @@ describe('Unit: Systemd > Process Manager', function () {
             ext.enable().then(() => {
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
-            })
+            });
         });
 
         it('Passes errors through', function () {
@@ -233,7 +233,7 @@ describe('Unit: Systemd > Process Manager', function () {
             ext.disable().then(() => {
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
-            })
+            });
         });
 
         it('Passes errors through', function () {

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -48,11 +48,11 @@ const bootstrap = {
         }
 
         // Read the directory and find the commands
-        fs.readdirSync(commandsDir).filter((command) => {
+        fs.readdirSync(commandsDir).filter(
             // Don't treat non-js files as commands, but also make sure any commands that are folders
             // with index.js files in them are loaded
-            return path.extname(command) === '.js' || fs.existsSync(path.join(commandsDir, command, 'index.js'));
-        }).forEach((command) => {
+            command => path.extname(command) === '.js' || fs.existsSync(path.join(commandsDir, command, 'index.js'))
+        ).forEach((command) => {
             const basename = path.basename(command, '.js');
             const commandName = commands[basename] ? `${extensionName}:${basename}` : basename;
             commands[commandName] = path.resolve(commandsDir, basename);
@@ -95,7 +95,7 @@ const bootstrap = {
         debug('Starting bootstrap process');
         // Look for any available extensions, including ones built-in to the CLI itself
         const extensions = findExtensions();
-        debug(`Found ${extensions.length} extensions: ${extensions.map((ext) => ext.pkg.name).join(', ')}`);
+        debug(`Found ${extensions.length} extensions: ${extensions.map(({pkg}) => pkg.name).join(', ')}`);
 
         debug('loading built-in commands');
         // Load built-in commands first
@@ -131,7 +131,7 @@ const bootstrap = {
             const commandName = abbreviations[firstArg];
             const commandPath = commands[commandName];
             // Get aliases of the command (so it will show up in yargs help)
-            const aliases = Object.keys(abbreviations).filter((key) => abbreviations[key] === commandName);
+            const aliases = Object.keys(abbreviations).filter(key => abbreviations[key] === commandName);
             bootstrap.loadCommand(commandName, commandPath, yargs, aliases, extensions);
             // Put the first arg back into the array
             argv.unshift(commandName);

--- a/lib/command.js
+++ b/lib/command.js
@@ -179,7 +179,7 @@ class Command {
         return precheck.then(() => {
             // Run ze command
             debug(`running command ${commandName}`);
-            return Promise.resolve(commandInstance.run(argv))
+            return Promise.resolve(commandInstance.run(argv));
         }).catch((error) => {
             debug(`command ${commandName} failed!`);
 

--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -39,18 +39,17 @@ module.exports = {
     port: {
         description: 'Port ghost should listen on',
         configPath: 'server.port',
-        validate: value => {
+        validate: (value) => {
             value = toString(value);
 
             if (!validator.isInt(value, {allow_leading_zeros: false})) {
                 return 'Port must be an integer.';
             }
 
-            return portfinder.getPortPromise({port: parseInt(value)}).then((port) => {
-                return (parseInt(port) === parseInt(value)) || `Port '${value}' is in use.`;
-            });
+            return portfinder.getPortPromise({port: parseInt(value)})
+                .then(port => (parseInt(port) === parseInt(value)) || `Port '${value}' is in use.`);
         },
-        defaultValue: config => {
+        defaultValue: (config) => {
             const port = parseInt(url.parse(config.get('url')).port || BASE_PORT);
             return portfinder.getPortPromise({port: port});
         },
@@ -169,7 +168,10 @@ module.exports = {
     // Customise how Ghost-CLI runs
     process: {
         description: 'Type of process manager to run Ghost with',
-        defaultValue: (c, env) => env === 'production' ? 'systemd' : 'local',
+        // eslint-disable-next-line arrow-body-style
+        defaultValue: (c, env) => {
+            return env === 'production' ? 'systemd' : 'local';
+        },
         type: 'string',
         group: 'Service Options:'
     }

--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -1,19 +1,19 @@
 'use strict';
-const url           = require('url');
+const url = require('url');
 
-const Command           = require('../../command');
-const advancedOptions   = require('./advanced');
+const Command = require('../../command');
+const advancedOptions = require('./advanced');
 
 class ConfigCommand extends Command {
     static configureSubcommands(commandName, commandArgs, extensions) {
         return commandArgs.command({
             command: 'get <key>',
             describe: 'Get a specific value from the configuration file',
-            handler: (argv) => this._run(`${commandName} get`, argv, extensions)
+            handler: argv => this._run(`${commandName} get`, argv, extensions)
         }).command({
             command: 'set <key> <value>',
             describe: 'Set a specific value in the configuration file',
-            handler: (argv) => this._run(`${commandName} set`, argv, extensions)
+            handler: argv => this._run(`${commandName} set`, argv, extensions)
         });
     }
 
@@ -125,7 +125,7 @@ class ConfigCommand extends Command {
                     name: 'dbuser',
                     message: 'Enter your MySQL username:',
                     default: this.instance.config.get('database.connection.user'),
-                    validate: (val) => Boolean(val) || 'You must supply a MySQL username.'
+                    validate: val => Boolean(val) || 'You must supply a MySQL username.'
                 });
             }
 
@@ -146,7 +146,7 @@ class ConfigCommand extends Command {
                     name: 'dbname',
                     message: 'Enter your Ghost database name:',
                     default: this.instance.config.get('database.connection.database', `${sanitizedDirName}_${shortenedEnv}`),
-                    validate: (val) => !/[^a-zA-Z0-9_]/.test(val) || 'MySQL database names may consist of only alphanumeric characters and underscores.'
+                    validate: val => !/[^a-zA-Z0-9_]/.test(val) || 'MySQL database names may consist of only alphanumeric characters and underscores.'
                 });
             }
         }

--- a/lib/commands/doctor/checks/check-directory.js
+++ b/lib/commands/doctor/checks/check-directory.js
@@ -24,4 +24,4 @@ This can cause issues with the CLI, please either make this directory readable b
 
         return checkDirectoryAndAbove(path.join(dir, '../'), extra);
     });
-}
+};

--- a/lib/commands/doctor/checks/check-permissions.js
+++ b/lib/commands/doctor/checks/check-permissions.js
@@ -37,10 +37,10 @@ module.exports = function checkPermissions(type, task) {
         errMsg = `Your installation folder contains ${dirWording} with incorrect permissions:\n`;
 
         resultDirs.forEach((folder) => {
-            errMsg += `- ${folder}\n`
+            errMsg += `- ${folder}\n`;
         });
 
-        errMsg += checkTypes[type].help
+        errMsg += checkTypes[type].help;
 
         return Promise.reject(new errors.SystemError({
             message: errMsg,
@@ -67,4 +67,4 @@ module.exports = function checkPermissions(type, task) {
         error.task = task;
         return Promise.reject(new errors.ProcessError(error));
     });
-}
+};

--- a/lib/commands/doctor/checks/file-permissions.js
+++ b/lib/commands/doctor/checks/file-permissions.js
@@ -6,7 +6,7 @@ const taskTitle = 'Checking file permissions';
 
 module.exports = {
     title: taskTitle,
-    enabled: (ctx) => ctx.instance && ctx.instance.process.name !== 'local',
+    enabled: ({instance}) => instance && instance.process.name !== 'local',
     task: () => checkPermissions('files', taskTitle),
     category: ['start', 'update']
 };

--- a/lib/commands/doctor/checks/folder-permissions.js
+++ b/lib/commands/doctor/checks/folder-permissions.js
@@ -6,7 +6,7 @@ const taskTitle = 'Checking folder permissions';
 
 module.exports = {
     title: taskTitle,
-    enabled: (ctx) => ctx.instance && ctx.instance.process.name !== 'local',
+    enabled: ({instance}) => instance && instance.process.name !== 'local',
     task: () => checkPermissions('folder', taskTitle),
     category: ['start', 'update']
 };

--- a/lib/commands/doctor/checks/install-folder-permissions.js
+++ b/lib/commands/doctor/checks/install-folder-permissions.js
@@ -9,13 +9,13 @@ const checkDirectoryAndAbove = require('./check-directory');
 const taskTitle = 'Checking current folder permissions';
 
 function installFolderPermissions(ctx) {
-    return fs.access(process.cwd(), constants.R_OK | constants.W_OK).catch(() => {
-        return Promise.reject(new errors.SystemError({
+    return fs.access(process.cwd(), constants.R_OK | constants.W_OK).catch(
+        () => Promise.reject(new errors.SystemError({
             message: 'The current directory is not writable. Please fix the permissions of your install directory.',
             help: `${chalk.green('https://docs.ghost.org/docs/install#section-your-user-must-own-this-directory')}`,
             task: taskTitle
-        }));
-    }).then(() => {
+        }))
+    ).then(() => {
         const isLocal = ctx.local || (ctx.instance && ctx.instance.process.name === 'local');
 
         if (isLocal || !ctx.system.platform.linux || (ctx.argv && ctx.argv['setup-linux-user'] === false)) {

--- a/lib/commands/doctor/checks/logged-in-ghost-user.js
+++ b/lib/commands/doctor/checks/logged-in-ghost-user.js
@@ -31,7 +31,7 @@ function loggedInGhostUser() {
 module.exports = {
     title: taskTitle,
     task: loggedInGhostUser,
-    enabled: (ctx) => ctx.system.platform.linux,
-    skip: (ctx) => ctx.instance && ctx.instance.process.name === 'local',
+    enabled: ({system}) => system.platform.linux,
+    skip: ({instance}) => instance && instance.process.name === 'local',
     category: ['start', 'update']
-}
+};

--- a/lib/commands/doctor/checks/logged-in-user-owner.js
+++ b/lib/commands/doctor/checks/logged-in-user-owner.js
@@ -29,7 +29,7 @@ Please log in with the user that owns the directory or add your user to the same
 module.exports = {
     title: taskTitle,
     task: loggedInUserOwner,
-    enabled: (ctx) => ctx.system.platform.linux,
-    skip: (ctx) => ctx.instance && ctx.instance.process.name === 'local',
+    enabled: ({system}) => system.platform.linux,
+    skip: ({instance}) => instance && instance.process.name === 'local',
     category: ['start', 'update']
-}
+};

--- a/lib/commands/doctor/checks/logged-in-user.js
+++ b/lib/commands/doctor/checks/logged-in-user.js
@@ -23,6 +23,6 @@ function loggedInUser() {
 module.exports = {
     title: taskTitle,
     task: loggedInUser,
-    enabled: (ctx) => !ctx.local && !(ctx.instance && ctx.instance.process.name === 'local') && ctx.system.platform.linux && !(ctx.argv && ctx.argv.process === 'local'),
+    enabled: ctx => !ctx.local && !(ctx.instance && ctx.instance.process.name === 'local') && ctx.system.platform.linux && !(ctx.argv && ctx.argv.process === 'local'),
     category: ['install']
 };

--- a/lib/commands/doctor/checks/system-stack.js
+++ b/lib/commands/doctor/checks/system-stack.js
@@ -34,7 +34,7 @@ function systemStack(ctx, task) {
                 renderer: ctx.ui.verbose ? 'verbose' : 'silent'
             }).catch(error => Promise.reject({
                 message: `Missing package(s): ${error.errors.map(e => e.missing).join(', ')}`
-            }))
+            }));
         });
     }
 
@@ -63,7 +63,7 @@ For local installs we recommend using \`ghost install local\` instead.`,
 module.exports = {
     title: taskTitle,
     task: systemStack,
-    enabled: (ctx) => !ctx.local && !(ctx.instance && ctx.instance.process.name === 'local'),
-    skip: (ctx) => !ctx.isDoctorCommand && ctx.argv && !ctx.argv.stack,
+    enabled: ctx => !ctx.local && !(ctx.instance && ctx.instance.process.name === 'local'),
+    skip: ctx => !ctx.isDoctorCommand && ctx.argv && !ctx.argv.stack,
     category: ['install']
-}
+};

--- a/lib/commands/doctor/checks/validate-config.js
+++ b/lib/commands/doctor/checks/validate-config.js
@@ -2,7 +2,7 @@
 const get = require('lodash/get');
 const path = require('path');
 const filter = require('lodash/filter');
-const Promise = require('bluebird')
+const Promise = require('bluebird');
 
 const errors = require('../../../errors');
 const Config = require('../../../utils/config');
@@ -33,7 +33,7 @@ function validateConfig(ctx, task) {
         const configValidations = filter(advancedOptions, cfg => cfg.validate);
 
         return Promise.each(configValidations, (configItem) => {
-            const key = configItem.configPath || configItem.name
+            const key = configItem.configPath || configItem.name;
             const value = get(config, key);
 
             if (!value) {
@@ -60,4 +60,4 @@ module.exports = {
     title: taskTitle,
     task: validateConfig,
     category: ['start']
-}
+};

--- a/lib/commands/doctor/index.js
+++ b/lib/commands/doctor/index.js
@@ -11,7 +11,7 @@ class DoctorCommand extends Command {
             const combinedChecks = checks.concat(flatten(extensionChecks).filter(Boolean));
 
             const checksToRun = argv.categories && argv.categories.length ?
-                combinedChecks.filter((check) => intersection(argv.categories, check.category || []).length) :
+                combinedChecks.filter(check => intersection(argv.categories, check.category || []).length) :
                 combinedChecks;
 
             if (!checksToRun.length) {
@@ -53,7 +53,7 @@ class DoctorCommand extends Command {
 }
 
 DoctorCommand.description = 'Check the system for any potential hiccups when installing/updating Ghost';
-DoctorCommand.longDescription = '$0 doctor [categories..]\n Run various checks to determine potential problems with your environment.'
+DoctorCommand.longDescription = '$0 doctor [categories..]\n Run various checks to determine potential problems with your environment.';
 DoctorCommand.params = '[categories..]';
 DoctorCommand.global = true;
 DoctorCommand.options = {
@@ -63,6 +63,6 @@ DoctorCommand.options = {
         type: 'boolean',
         default: true
     }
-}
+};
 
 module.exports = DoctorCommand;

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -23,7 +23,7 @@ class InstallCommand extends Command {
         const filesInDir = fs.readdirSync(process.cwd());
 
         // Check if there are existing files that *aren't* ghost-cli debug log files
-        if (filesInDir.length && !every(filesInDir, (file) => file.match(/^ghost-cli-debug-.*\.log$/i))) {
+        if (filesInDir.length && !every(filesInDir, file => file.match(/^ghost-cli-debug-.*\.log$/i))) {
             return Promise.reject(new errors.SystemError('Current directory is not empty, Ghost cannot be installed here.'));
         }
 
@@ -41,35 +41,33 @@ class InstallCommand extends Command {
             categories: ['install'],
             skipInstanceCheck: true,
             quiet: true
-        }, argv, {local})).then(() => {
-            return this.ui.listr([{
-                title: 'Checking for latest Ghost version',
-                task: this.version
+        }, argv, {local})).then(() => this.ui.listr([{
+            title: 'Checking for latest Ghost version',
+            task: this.version
+        }, {
+            title: 'Setting up install directory',
+            task: ensureStructure
+        }, {
+            title: 'Downloading and installing Ghost',
+            task: (ctx, task) => {
+                task.title = `Downloading and installing Ghost v${ctx.version}`;
+                return yarnInstall(ctx.ui, ctx.zip);
+            }
+        }, {
+            title: 'Finishing install process',
+            task: () => this.ui.listr([{
+                title: 'Linking latest Ghost and recording versions',
+                task: this.link.bind(this)
             }, {
-                title: 'Setting up install directory',
-                task: ensureStructure
-            }, {
-                title: 'Downloading and installing Ghost',
-                task: (ctx, task) => {
-                    task.title = `Downloading and installing Ghost v${ctx.version}`;
-                    return yarnInstall(ctx.ui, ctx.zip);
-                }
-            }, {
-                title: 'Finishing install process',
-                task: () => this.ui.listr([{
-                    title: 'Linking latest Ghost and recording versions',
-                    task: this.link.bind(this)
-                }, {
-                    title: 'Linking latest Casper',
-                    task: this.casper
-                }], false)
-            }], {
-                version,
-                zip: argv.zip,
-                v1: argv.v1,
-                cliVersion: this.system.cliVersion
-            })
-        }).then(() => {
+                title: 'Linking latest Casper',
+                task: this.casper
+            }], false)
+        }], {
+            version,
+            zip: argv.zip,
+            v1: argv.v1,
+            cliVersion: this.system.cliVersion
+        })).then(() => {
             if (!argv.setup) {
                 return Promise.resolve();
             }

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -65,7 +65,7 @@ class LogCommand extends Command {
                     const Tail = require('tail').Tail;
 
                     const tail = new Tail(logFileName);
-                    tail.on('line', (line) => prettyStream.write(line, 'utf8'));
+                    tail.on('line', line => prettyStream.write(line, 'utf8'));
                 }
             });
         });

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -6,17 +6,19 @@ class LsCommand extends Command {
         const chalk = require('chalk');
         const Promise = require('bluebird');
 
-        return this.system.getAllInstances().then((instances) => {
-            return Promise.map(instances, (instance) => {
-                return instance.summary().then((summary) => {
-                    if (!summary.running) {
-                        return [summary.name, summary.dir, summary.version, chalk.red('stopped'), chalk.red('n/a'), chalk.red('n/a'), chalk.red('n/a')];
-                    }
+        function makeRow(summary) {
+            const {running, name, dir, version, mode, url, port, process} = summary;
 
-                    return [summary.name, summary.dir, summary.version, `${chalk.green('running')} (${summary.mode})`, summary.url, summary.port, summary.process];
-                });
-            });
-        }).then((rows) => {
+            if (!running) {
+                return [name, dir, version, chalk.red('stopped'), chalk.red('n/a'), chalk.red('n/a'), chalk.red('n/a')];
+            }
+
+            return [name, dir, version, `${chalk.green('running')} (${mode})`, url, port, process];
+        }
+
+        return this.system.getAllInstances().then(
+            instances => Promise.map(instances, instance => instance.summary().then(makeRow))
+        ).then((rows) => {
             if (rows.length) {
                 this.ui.table(['Name', 'Location', 'Version', 'Status', 'URL', 'Port', 'Process Manager'], rows, {
                     style: {head: ['cyan']}

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -25,7 +25,7 @@ class MigrateCommand extends Command {
                 return Promise.resolve();
             }
 
-            return this.ui.listr(neededMigrations, {instance: instance})
+            return this.ui.listr(neededMigrations, {instance: instance});
         }).then(() => {
             // Update the cli version in the cli config file
             instance.cliConfig.set('cli-version', this.system.cliVersion).save();

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -68,7 +68,9 @@ class RunCommand extends Command {
             }
 
             // NOTE: Backwards compatibility of https://github.com/TryGhost/Ghost/pull/9440
-            setTimeout(() => {instance.process.error({message: message.error})}, 1000);
+            setTimeout(() => {
+                instance.process.error({message: message.error});
+            }, 1000);
         });
     }
 

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -1,7 +1,7 @@
 'use strict';
-const Command        = require('../command');
-const StartCommand   = require('./start');
-const ConfigCommand  = require('./config');
+const Command = require('../command');
+const StartCommand = require('./start');
+const ConfigCommand = require('./config');
 
 class SetupCommand extends Command {
     static configureOptions(commandName, yargs, extensions, onlyOptions) {
@@ -39,7 +39,7 @@ class SetupCommand extends Command {
 
     run(argv) {
         const os = require('os');
-        const url  = require('url');
+        const url = require('url');
         const path = require('path');
         const semver = require('semver');
 
@@ -74,16 +74,14 @@ class SetupCommand extends Command {
             instance.checkEnvironment();
 
             return this.system.hook('setup', this, argv).then(() => {
-                const tasks = this.stages.filter((stage) => argv.stages.includes(stage.name)).map((stage) => {
-                    return {
-                        title: `Setting up ${stage.description}`,
-                        task: (ctx, task) => stage.fn(argv, ctx, task)
-                    };
-                });
+                const tasks = this.stages.filter(stage => argv.stages.includes(stage.name)).map(stage => ({
+                    title: `Setting up ${stage.description}`,
+                    task: (ctx, task) => stage.fn(argv, ctx, task)
+                }));
 
                 // Special-case migrations
                 if (argv.stages.includes('migrate')) {
-                    tasks.push({title: 'Running database migrations', task: migrator.migrate})
+                    tasks.push({title: 'Running database migrations', task: migrator.migrate});
                 }
 
                 if (argv.stages.includes('linux-user')) {
@@ -131,45 +129,43 @@ class SetupCommand extends Command {
         ).then(() => {
             const taskMap = {};
 
-            const tasks = initialStages.concat(this.stages.map((stage) => {
-                return {
-                    title: `Setting up ${stage.description}`,
-                    task: (ctx, task) => {
-                        taskMap[stage.name] = task;
+            const tasks = initialStages.concat(this.stages.map(stage => ({
+                title: `Setting up ${stage.description}`,
+                task: (ctx, task) => {
+                    taskMap[stage.name] = task;
 
-                        if (stage.dependencies) {
-                            // TODO: this depends on Listr private API, probably should find a better way
-                            const skipped = stage.dependencies.filter(
-                                dep => !taskMap[dep] || taskMap[dep]._task.isSkipped()
-                            );
+                    if (stage.dependencies) {
+                        // TODO: this depends on Listr private API, probably should find a better way
+                        const skipped = stage.dependencies.filter(
+                            dep => !taskMap[dep] || taskMap[dep]._task.isSkipped()
+                        );
 
-                            if (skipped && skipped.length) {
-                                const plural = skipped.length > 1;
-                                this.ui.log(`Task ${stage.name} depends on the '${skipped.join('\', \'')}' ${plural ? 'stages' : 'stage'}, which ${plural ? 'were' : 'was'} skipped.`, 'gray');
-                                return task.skip();
-                            }
+                        if (skipped && skipped.length) {
+                            const plural = skipped.length > 1;
+                            this.ui.log(`Task ${stage.name} depends on the '${skipped.join('\', \'')}' ${plural ? 'stages' : 'stage'}, which ${plural ? 'were' : 'was'} skipped.`, 'gray');
+                            return task.skip();
                         }
+                    }
 
-                        if (argv[`setup-${stage.name}`] === false) {
+                    if (argv[`setup-${stage.name}`] === false) {
+                        return task.skip();
+                    }
+
+                    if (!argv.prompt) {
+                        // Prompt has been disabled and there has not been a `--no-setup-<stagename>`
+                        // flag passed, so we will automatically run things
+                        return stage.fn(argv, ctx, task);
+                    }
+
+                    return this.ui.confirm(`Do you wish to set up ${stage.description}?`, true).then((confirmed) => {
+                        if (!confirmed) {
                             return task.skip();
                         }
 
-                        if (!argv.prompt) {
-                            // Prompt has been disabled and there has not been a `--no-setup-<stagename>`
-                            // flag passed, so we will automatically run things
-                            return stage.fn(argv, ctx, task);
-                        }
-
-                        return this.ui.confirm(`Do you wish to set up ${stage.description}?`, true).then((confirmed) => {
-                            if (!confirmed) {
-                                return task.skip();
-                            }
-
-                            return stage.fn(argv, ctx, task);
-                        });
-                    }
-                };
-            }));
+                        return stage.fn(argv, ctx, task);
+                    });
+                }
+            })));
 
             if (argv.migrate !== false) {
                 const instance = this.system.getInstance();
@@ -203,9 +199,7 @@ class SetupCommand extends Command {
                 }
 
                 return this.ui.confirm('Do you want to start Ghost?', true);
-            }).then((confirmed) => {
-                return confirmed && this.runCommand(StartCommand, argv);
-            });
+            }).then(confirmed => confirmed && this.runCommand(StartCommand, argv));
         });
     }
 }

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -41,10 +41,10 @@ class StartCommand extends Command {
             }, argv)).then(() => {
                 const processInstance = instance.process;
 
-                const start = () => {
-                    return Promise.resolve(processInstance.start(process.cwd(), this.system.environment))
-                        .then(() => { instance.running(this.system.environment); });
-                };
+                const start = () => Promise.resolve(processInstance.start(process.cwd(), this.system.environment))
+                    .then(() => {
+                        instance.running(this.system.environment); 
+                    });
 
                 return this.ui.run(start, 'Starting Ghost', runOptions).then(() => {
                     if (!argv.enable || !ProcessManager.supportsEnableBehavior(processInstance)) {

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -23,18 +23,16 @@ class UninstallCommand extends Command {
 
             return this.ui.listr([{
                 title: 'Stopping Ghost',
-                task: (_, task) => {
-                    return instance.running().then((isRunning) => {
-                        if (!isRunning) {
-                            return task.skip('Instance is not running');
-                        }
+                task: (_, task) => instance.running().then((isRunning) => {
+                    if (!isRunning) {
+                        return task.skip('Instance is not running');
+                    }
 
-                        instance.loadRunningEnvironment(true);
-                        // If the instance is currently running we need to make sure
-                        // it gets stopped and disabled if possible
-                        return this.runCommand(StopCommand, {quiet: true, disable: true});
-                    });
-                }
+                    instance.loadRunningEnvironment(true);
+                    // If the instance is currently running we need to make sure
+                    // it gets stopped and disabled if possible
+                    return this.runCommand(StopCommand, {quiet: true, disable: true});
+                })
             }, {
                 title: 'Removing content folder',
                 enabled: () => ghostUser.shouldUseGhostUser(path.join(instance.dir, 'content')),

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -65,7 +65,7 @@ class UpdateCommand extends Command {
             // TODO: add meaningful update checks after this task
             const tasks = [{
                 title: 'Downloading and updating Ghost',
-                skip: (ctx) => ctx.rollback,
+                skip: ({rollback}) => rollback,
                 task: this.downloadAndUpdate
             }, {
                 title: 'Updating to a major version',
@@ -85,14 +85,14 @@ class UpdateCommand extends Command {
                 task: this.stop.bind(this)
             }, {
                 title: 'Rolling back database migrations',
-                enabled: (ctx) => ctx.rollback,
+                enabled: ({rollback}) => rollback,
                 task: migrator.rollback
             }, {
                 title: 'Linking latest Ghost and recording versions',
                 task: this.link
             }, {
                 title: 'Running database migrations',
-                skip: (ctx) => ctx.rollback,
+                skip: ({rollback}) => rollback,
                 task: migrator.migrate,
                 // CASE: We have moved the execution of knex-migrator into Ghost 2.0.0.
                 //       If you are already on v2 or you update from v1 to v2, then skip the task.
@@ -111,18 +111,18 @@ class UpdateCommand extends Command {
                 task: this.restart.bind(this)
             }, {
                 title: 'Removing old Ghost versions',
-                skip: (ctx) => ctx.rollback,
+                skip: ({rollback}) => rollback,
                 task: this.removeOldVersions
             }];
 
             return this.runCommand(DoctorCommand, Object.assign(
                 {quiet: true, categories: ['update']},
                 argv
-            )).then(() => {
-                return this.runCommand(MigrateCommand, {quiet: true})
-            }).then(() => {
-                return this.ui.run(() => this.version(context), 'Checking for latest Ghost version');
-            }).then((result) => {
+            )).then(
+                () => this.runCommand(MigrateCommand, {quiet: true})
+            ).then(
+                () => this.ui.run(() => this.version(context), 'Checking for latest Ghost version')
+            ).then((result) => {
                 if (!result) {
                     this.ui.log('All up to date!', 'cyan');
                     return;
@@ -182,11 +182,13 @@ class UpdateCommand extends Command {
                 return;
             }
 
-            versions.sort((a, b) => semver.lt(a, b) ? -1 : 1);
-
-            const promises = versions.slice(0, -5).map((version) => {
-                return fs.remove(path.join(process.cwd(), 'versions', version));
+            // eslint-disable-next-line arrow-body-style
+            versions.sort((a, b) => {
+                return semver.lt(a, b) ? -1 : 1;
             });
+
+            const promises = versions.slice(0, -5)
+                .map(version => fs.remove(path.join(process.cwd(), 'versions', version)));
 
             return Promise.all(promises);
         });
@@ -230,7 +232,7 @@ class UpdateCommand extends Command {
             });
         }
 
-        return this.ui.confirm(question, true).then(answer => {
+        return this.ui.confirm(question, true).then((answer) => {
             if (!answer) {
                 return Promise.resolve();
             }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -27,7 +27,7 @@ class CliError extends Error {
         this.options = options;
         this.logMessageOnly = options.logMessageOnly;
 
-        this.help = 'Please refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.'
+        this.help = 'Please refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.';
 
         if (options.err) {
             if (typeof options.err === 'string') {
@@ -96,11 +96,11 @@ class CliError extends Error {
             output += `${chalk.yellow('Stack:')} ${this.stack}\n\n`;
 
             if (this.err && this.err.message) {
-                output += `${chalk.green('Original Error Message:')}\n`
-                output += `${chalk.gray('Message:')} ${this.err.message}\n`
+                output += `${chalk.green('Original Error Message:')}\n`;
+                output += `${chalk.gray('Message:')} ${this.err.message}\n`;
                 /* istanbul ignore next */
                 if (this.err.stack) {
-                    output += `${chalk.gray('Stack:')} ${this.err.stack}\n`
+                    output += `${chalk.gray('Stack:')} ${this.err.stack}\n`;
                 }
             }
         }

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -24,9 +24,7 @@ class Extension {
             return {};
         }
 
-        return mapValues(this.pkg['ghost-cli']['process-managers'], (relPath) => {
-            return path.join(this.dir, relPath);
-        });
+        return mapValues(this.pkg['ghost-cli']['process-managers'], relPath => path.join(this.dir, relPath));
     }
 
     /**
@@ -129,9 +127,7 @@ class Extension {
             promises.push(() => this.ui.sudo(`ln -sf ${tmplFile} ${outputLocation}`));
         }
 
-        return Promise.each(promises, (fn) => fn()).then(() => {
-            return Promise.resolve(true);
-        });
+        return Promise.each(promises, fn => fn()).then(() => Promise.resolve(true));
     }
 
     /**

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -81,11 +81,7 @@ class ProcessManager {
 
         return portPolling(options).catch((err) => {
             if (options.stopOnError) {
-                return this.stop().catch(() => {
-                    return Promise.reject(err);
-                }).then(() => {
-                    return Promise.reject(err);
-                });
+                return this.stop().catch(() => Promise.reject(err)).then(() => Promise.reject(err));
             }
 
             return Promise.reject(err);
@@ -108,7 +104,7 @@ function isValid(SubClass) {
         return false;
     }
 
-    const missing = requiredMethods.filter((method) => !SubClass.prototype.hasOwnProperty(method));
+    const missing = requiredMethods.filter(method => !SubClass.prototype.hasOwnProperty(method));
 
     if (!missing.length) {
         return true;
@@ -118,9 +114,9 @@ function isValid(SubClass) {
 }
 
 function supportsEnableBehavior(processInstance) {
-    return every(enableMethods, (method) => processInstance[method]);
+    return every(enableMethods, method => processInstance[method]);
 }
 
-module.exports = ProcessManager
+module.exports = ProcessManager;
 module.exports.isValid = isValid;
 module.exports.supportsEnableBehavior = supportsEnableBehavior;

--- a/lib/system.js
+++ b/lib/system.js
@@ -153,9 +153,7 @@ class System {
      */
     addInstance(instance) {
         const instances = this.globalConfig.get('instances', {});
-        const existingInstance = findKey(instances, (cfg) => {
-            return cfg.cwd === instance.dir;
-        });
+        const existingInstance = findKey(instances, cfg => cfg.cwd === instance.dir);
 
         if (existingInstance) {
             instance.name = existingInstance;
@@ -233,7 +231,7 @@ class System {
         }).filter(Boolean);
 
         if (namesToRemove.length) {
-            namesToRemove.forEach((name) => delete instances[name]);
+            namesToRemove.forEach(name => delete instances[name]);
             this.globalConfig.set('instances', instances).save();
         }
 
@@ -243,7 +241,7 @@ class System {
         }
 
         // Return the result filtered by whether or not the instance is running
-        return Promise.filter(result, (instance) => instance.running());
+        return Promise.filter(result, instance => instance.running());
     }
 
     /**

--- a/lib/tasks/major-update/data.js
+++ b/lib/tasks/major-update/data.js
@@ -7,13 +7,13 @@ module.exports = function getData(options = {}) {
     if (!options.dir) {
         return Promise.reject(new errors.CliError({
             message: '`dir` is required.'
-        }))
+        }));
     }
 
     if (!options.database) {
         return Promise.reject(new errors.CliError({
             message: '`database` is required.'
-        }))
+        }));
     }
 
     const knexPath = path.resolve(options.dir, options.version, 'node_modules', 'knex');
@@ -47,7 +47,7 @@ module.exports = function getData(options = {}) {
         .then((report) => {
             gscanReport = gscan.format(report, {sortByFiles: true});
 
-            return connection.raw('SELECT uuid FROM posts WHERE slug="v2-demo-post";')
+            return connection.raw('SELECT uuid FROM posts WHERE slug="v2-demo-post";');
         })
         .then((response) => {
             let demoPost;
@@ -63,18 +63,14 @@ module.exports = function getData(options = {}) {
                 demoPost: demoPost
             };
         })
-        .then((response) => {
-            return new Promise((resolve) => {
-                connection.destroy(() => {
-                    resolve(response);
-                });
+        .then(response => new Promise((resolve) => {
+            connection.destroy(() => {
+                resolve(response);
             });
-        })
-        .catch((err) => {
-            return new Promise((resolve, reject) => {
-                connection.destroy(() => {
-                    reject(err);
-                });
+        }))
+        .catch(err => new Promise((resolve, reject) => {
+            connection.destroy(() => {
+                reject(err);
             });
-        });
+        }));
 };

--- a/lib/tasks/migrator.js
+++ b/lib/tasks/migrator.js
@@ -48,7 +48,7 @@ const errorHandler = (context) => {
         }
 
         return Promise.reject(error);
-    }
+    };
 };
 
 module.exports.migrate = function runMigrations(context) {

--- a/lib/tasks/yarn-install.js
+++ b/lib/tasks/yarn-install.js
@@ -10,63 +10,59 @@ const errors = require('../errors');
 const yarn = require('../utils/yarn');
 
 const subTasks = {
-    dist: (ctx) => {
-        return yarn(['info', `ghost@${ctx.version}`, '--json']).then((result) => {
-            let data;
+    dist: ctx => yarn(['info', `ghost@${ctx.version}`, '--json']).then((result) => {
+        let data;
 
-            try {
-                const parsed = JSON.parse(result.stdout);
-                data = parsed && parsed.data;
-            } catch (e) {
-                // invalid response from yarn command, ignore JSON parse error
-            }
+        try {
+            const parsed = JSON.parse(result.stdout);
+            data = parsed && parsed.data;
+        } catch (e) {
+            // invalid response from yarn command, ignore JSON parse error
+        }
 
-            if (!data || !data.dist) {
-                return Promise.reject(new errors.CliError('Ghost download information could not be read correctly.'));
-            }
+        if (!data || !data.dist) {
+            return Promise.reject(new errors.CliError('Ghost download information could not be read correctly.'));
+        }
 
-            if (
-                process.env.GHOST_NODE_VERSION_CHECK !== 'false' &&
+        if (
+            process.env.GHOST_NODE_VERSION_CHECK !== 'false' &&
                 data.engines && data.engines.node && !semver.satisfies(process.versions.node, data.engines.node)
-            ) {
-                return Promise.reject(new errors.SystemError(`Ghost v${ctx.version} is not compatible with the current Node version.`));
-            }
+        ) {
+            return Promise.reject(new errors.SystemError(`Ghost v${ctx.version} is not compatible with the current Node version.`));
+        }
 
-            if (data.engines && data.engines.cli && !semver.satisfies(cliPackage.version, data.engines.cli)) {
-                return Promise.reject(new errors.SystemError(`Ghost v${ctx.version} is not compatible with this version of the CLI.`));
-            }
+        if (data.engines && data.engines.cli && !semver.satisfies(cliPackage.version, data.engines.cli)) {
+            return Promise.reject(new errors.SystemError(`Ghost v${ctx.version} is not compatible with this version of the CLI.`));
+        }
 
-            ctx.shasum = data.dist.shasum;
-            ctx.tarball = data.dist.tarball;
-        });
-    },
-    download: (ctx) => {
-        return download(ctx.tarball).then((data) => {
-            if (shasum(data) !== ctx.shasum) {
-                // shasums don't match - this is not good
-                return Promise.reject(new errors.CliError('Ghost download integrity compromised.' +
+        ctx.shasum = data.dist.shasum;
+        ctx.tarball = data.dist.tarball;
+    }),
+    download: ctx => download(ctx.tarball).then((data) => {
+        if (shasum(data) !== ctx.shasum) {
+            // shasums don't match - this is not good
+            return Promise.reject(new errors.CliError('Ghost download integrity compromised.' +
                     'Cancelling install because of potential security issues'));
-            }
+        }
 
-            fs.ensureDirSync(ctx.installPath);
-            return decompress(data, ctx.installPath, {
-                map: (file) => {
-                    file.path = file.path.replace('package/', '');
-                    return file;
-                }
-            }).catch((error) => {
-                // Clean up the install folder since the decompress failed
-                fs.removeSync(ctx.installPath);
-                return Promise.reject(error);
-            });
+        fs.ensureDirSync(ctx.installPath);
+        return decompress(data, ctx.installPath, {
+            map: (file) => {
+                file.path = file.path.replace('package/', '');
+                return file;
+            }
+        }).catch((error) => {
+            // Clean up the install folder since the decompress failed
+            fs.removeSync(ctx.installPath);
+            return Promise.reject(error);
         });
-    }
+    })
 };
 
 module.exports = function yarnInstall(ui, zipFile) {
     const tasks = zipFile ? [{
         title: 'Extracting release from local zip',
-        task: (ctx) => decompress(zipFile, ctx.installPath)
+        task: ctx => decompress(zipFile, ctx.installPath)
     }] : [{
         title: 'Getting download information',
         task: subTasks.dist
@@ -77,17 +73,15 @@ module.exports = function yarnInstall(ui, zipFile) {
 
     tasks.push({
         title: 'Installing dependencies',
-        task: (ctx) => {
-            return yarn(['install', '--no-emoji', '--no-progress'], {
-                cwd: ctx.installPath,
-                env: {NODE_ENV: 'production'},
-                observe: true
-            }).catch((error) => {
-                // Add error catcher so we can cleanup the install path if an error occurs
-                fs.removeSync(ctx.installPath);
-                return Promise.reject(error);
-            });
-        }
+        task: ctx => yarn(['install', '--no-emoji', '--no-progress'], {
+            cwd: ctx.installPath,
+            env: {NODE_ENV: 'production'},
+            observe: true
+        }).catch((error) => {
+            // Add error catcher so we can cleanup the install path if an error occurs
+            fs.removeSync(ctx.installPath);
+            return Promise.reject(error);
+        })
     });
 
     return ui.listr(tasks, false);

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -1,13 +1,13 @@
 'use strict';
-const ora       = require('ora');
-const omit      = require('lodash/omit');
-const chalk     = require('chalk');
-const execa     = require('execa');
-const Listr     = require('listr');
-const Table     = require('cli-table3');
-const Promise   = require('bluebird');
-const inquirer  = require('inquirer');
-const isObject  = require('lodash/isObject');
+const ora = require('ora');
+const omit = require('lodash/omit');
+const chalk = require('chalk');
+const execa = require('execa');
+const Listr = require('listr');
+const Table = require('cli-table3');
+const Promise = require('bluebird');
+const inquirer = require('inquirer');
+const isObject = require('lodash/isObject');
 const stripAnsi = require('strip-ansi');
 const ListrError = require('listr/lib/listr-error');
 const logSymbols = require('log-symbols');
@@ -155,9 +155,7 @@ class UI {
             message: question,
             default: defaultAnswer,
             prefix: options.prefix
-        }).then((answer) => {
-            return answer.yes;
-        });
+        }).then(answer => answer.yes);
     }
 
     /**

--- a/lib/ui/renderer.js
+++ b/lib/ui/renderer.js
@@ -20,7 +20,7 @@ class Renderer {
      * @param {Object} options Options
      */
     constructor(ui, tasks, options) {
-        this.tasks = (tasks || []).filter((task) => task.isEnabled());
+        this.tasks = (tasks || []).filter(task => task.isEnabled());
         this.options = Object.assign({}, defaultOptions, options);
 
         this.ui = ui;
@@ -66,7 +66,7 @@ class Renderer {
      */
     frame() {
         const text = this.tasks
-            .filter((task) => task.isPending())
+            .filter(task => task.isPending())
             .map(this.buildText.bind(this)).join(' | ');
 
         if (text && text !== this.previousFrame && !this.spinner.paused) {
@@ -90,8 +90,8 @@ class Renderer {
         }
 
         const subtaskText = task.subtasks
-            .filter((subtask) => subtask.isPending())
-            .map((subtask) => this.buildText(subtask))
+            .filter(subtask => subtask.isPending())
+            .map(subtask => this.buildText(subtask))
             .join('/');
 
         return `${task.title} ${this.options.separator} ${subtaskText}`;
@@ -114,10 +114,10 @@ class Renderer {
     }
 }
 
-module.exports = (ui) => class extends Renderer {
+module.exports = ui => class extends Renderer {
     constructor(...args) {
         super(ui, ...args);
     }
-}
+};
 
 module.exports.Renderer = Renderer;

--- a/lib/utils/check-root-user.js
+++ b/lib/utils/check-root-user.js
@@ -9,7 +9,7 @@ const isRootInstall = function isRootInstall() {
     const cliFile = path.join(process.cwd(), '.ghost-cli');
 
     return fs.existsSync(cliFile) && fs.statSync(cliFile).uid === 0;
-}
+};
 
 function checkRootUser(command) {
     const allowedCommands = ['stop', 'start', 'restart'];

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -1,9 +1,9 @@
 'use strict';
 const isPlainObject = require('lodash/isPlainObject');
-const _get          = require('lodash/get');
-const _set          = require('lodash/set');
-const _has          = require('lodash/has');
-const fs            = require('fs-extra');
+const _get = require('lodash/get');
+const _set = require('lodash/set');
+const _has = require('lodash/has');
+const fs = require('fs-extra');
 
 /**
  * Config class. Basic wrapper around a json file, but handles

--- a/lib/utils/find-extensions.js
+++ b/lib/utils/find-extensions.js
@@ -10,7 +10,7 @@ const localExtensions = [
     'mysql',
     'nginx',
     'systemd'
-].map((local) => path.join(__dirname, '..', '..', 'extensions', local));
+].map(local => path.join(__dirname, '..', '..', 'extensions', local));
 
 /**
  * Finds available extensions in the system. Checks both the local CLI install
@@ -42,4 +42,4 @@ module.exports = function findExtensions() {
 
         return ext;
     });
-}
+};

--- a/lib/utils/local-process.js
+++ b/lib/utils/local-process.js
@@ -124,7 +124,9 @@ Please ensure the content folder has correct permissions and try again.`));
      */
     success() {
         /* istanbul ignore else */
-        if (process.send) {process.send({started: true});}
+        if (process.send) {
+            process.send({started: true});
+        }
     }
 
     /**
@@ -138,7 +140,9 @@ Please ensure the content folder has correct permissions and try again.`));
      */
     error(error) {
         /* istanbul ignore else */
-        if (process.send) {process.send({error: true, message: error.message});}
+        if (process.send) {
+            process.send({error: true, message: error.message});
+        }
     }
 
     /**

--- a/lib/utils/port-polling.js
+++ b/lib/utils/port-polling.js
@@ -6,65 +6,63 @@ const errors = require('../errors');
  * @TODO: in theory it could happen that other clients connect, but tbh even with the port polling it was possible: you
  *        could just start a server on the Ghost port
  */
-const useNetServer = (options)=> {
-    return new Promise((resolve, reject)=> {
-        const net = require('net');
-        let waitTimeout = null;
-        let ghostSocket = null;
+const useNetServer = options => new Promise((resolve, reject) => {
+    const net = require('net');
+    let waitTimeout = null;
+    let ghostSocket = null;
 
-        const server = net.createServer((socket)=> {
-            ghostSocket = socket;
+    const server = net.createServer((socket) => {
+        ghostSocket = socket;
 
-            socket.on('data', (data) => {
-                let message;
+        socket.on('data', (data) => {
+            let message;
 
-                try {
-                    message = JSON.parse(data);
-                } catch (err) {
-                    message = {started: false, error: err};
-                }
-
-                if (waitTimeout) {
-                    clearTimeout(waitTimeout);
-                }
-
-                socket.destroy();
-                ghostSocket = null;
-
-                server.close(() => {
-                    if (message.started) {
-                        resolve();
-                    } else {
-                        reject(new errors.GhostError({
-                            message: message.error.message,
-                            help: message.error.help,
-                            suggestion: options.logSuggestion
-                        }));
-                    }
-                });
-            });
-        });
-
-        waitTimeout = setTimeout(() => {
-            if (ghostSocket) {
-                ghostSocket.destroy();
+            try {
+                message = JSON.parse(data);
+            } catch (err) {
+                message = {started: false, error: err};
             }
 
+            if (waitTimeout) {
+                clearTimeout(waitTimeout);
+            }
+
+            socket.destroy();
             ghostSocket = null;
 
             server.close(() => {
-                reject(new errors.GhostError({
-                    message: 'Could not communicate with Ghost',
-                    suggestion: options.logSuggestion
-                }));
+                if (message.started) {
+                    resolve();
+                } else {
+                    reject(new errors.GhostError({
+                        message: message.error.message,
+                        help: message.error.help,
+                        suggestion: options.logSuggestion
+                    }));
+                }
             });
-        }, options.netServerTimeoutInMS);
-
-        server.listen({host: options.socketAddress.host, port: options.socketAddress.port});
+        });
     });
-};
 
-const usePortPolling = (options)=> {
+    waitTimeout = setTimeout(() => {
+        if (ghostSocket) {
+            ghostSocket.destroy();
+        }
+
+        ghostSocket = null;
+
+        server.close(() => {
+            reject(new errors.GhostError({
+                message: 'Could not communicate with Ghost',
+                suggestion: options.logSuggestion
+            }));
+        });
+    }, options.netServerTimeoutInMS);
+
+    server.listen({host: options.socketAddress.host, port: options.socketAddress.port});
+});
+
+const usePortPolling = (options) => {
     const net = require('net');
 
     if (!options.port) {
@@ -73,92 +71,88 @@ const usePortPolling = (options)=> {
         }));
     }
 
-    const connectToGhostSocket = () => {
-        return new Promise((resolve, reject) => {
-            // if host is specified and is *not* 0.0.0.0 (listen on all ips), use the custom host
-            const host = options.host && options.host !== '0.0.0.0' ? options.host : 'localhost';
-            const ghostSocket = net.connect(options.port, host);
-            let delayOnConnectTimeout;
+    const connectToGhostSocket = () => new Promise((resolve, reject) => {
+        // if host is specified and is *not* 0.0.0.0 (listen on all ips), use the custom host
+        const host = options.host && options.host !== '0.0.0.0' ? options.host : 'localhost';
+        const ghostSocket = net.connect(options.port, host);
+        let delayOnConnectTimeout;
 
-            // inactivity timeout
-            ghostSocket.setTimeout(options.socketTimeoutInMS);
-            ghostSocket.on('timeout', (() => {
-                if (delayOnConnectTimeout) {
-                    clearTimeout(delayOnConnectTimeout);
-                }
+        // inactivity timeout
+        ghostSocket.setTimeout(options.socketTimeoutInMS);
+        ghostSocket.on('timeout', (() => {
+            if (delayOnConnectTimeout) {
+                clearTimeout(delayOnConnectTimeout);
+            }
 
-                ghostSocket.destroy();
+            ghostSocket.destroy();
 
-                // force retry
-                const err = new Error('Socket timed out.');
-                err.retry = true;
-                reject(err);
-            }));
+            // force retry
+            const err = new Error('Socket timed out.');
+            err.retry = true;
+            reject(err);
+        }));
 
-            ghostSocket.on('connect', (() => {
-                if (options.delayOnConnectInMS) {
-                    let ghostDied = false;
+        ghostSocket.on('connect', (() => {
+            if (options.delayOnConnectInMS) {
+                let ghostDied = false;
 
-                    // CASE: client closes socket
-                    ghostSocket.on('close', (() => {
-                        ghostDied = true;
-                    }));
+                // CASE: client closes socket
+                ghostSocket.on('close', (() => {
+                    ghostDied = true;
+                }));
 
-                    delayOnConnectTimeout = setTimeout(() => {
-                        ghostSocket.destroy();
+                delayOnConnectTimeout = setTimeout(() => {
+                    ghostSocket.destroy();
 
-                        if (ghostDied) {
-                            reject(new Error('Ghost died.'));
-                        } else {
-                            resolve();
-                        }
-                    }, options.delayOnConnectInMS);
-
-                    return;
-                }
-
-                ghostSocket.destroy();
-                resolve();
-            }));
-
-            ghostSocket.on('error', ((err) => {
-                ghostSocket.destroy();
-
-                err.retry = true;
-                reject(err);
-            }));
-        });
-    };
-
-    const startPolling = (() => {
-        return new Promise((resolve, reject) => {
-            let tries = 0;
-
-            (function retry() {
-                connectToGhostSocket()
-                    .then(() => {
+                    if (ghostDied) {
+                        reject(new Error('Ghost died.'));
+                    } else {
                         resolve();
-                    })
-                    .catch((err) => {
-                        if (err.retry && tries < options.maxTries) {
-                            tries = tries + 1;
-                            setTimeout(retry, options.retryTimeoutInMS);
-                            return;
-                        }
+                    }
+                }, options.delayOnConnectInMS);
 
-                        if (err instanceof errors.CliError) {
-                            return reject(err);
-                        }
+                return;
+            }
 
-                        reject(new errors.GhostError({
-                            message: 'Ghost did not start.',
-                            suggestion: options.logSuggestion,
-                            err: err
-                        }));
-                    });
-            }());
-        });
+            ghostSocket.destroy();
+            resolve();
+        }));
+
+        ghostSocket.on('error', ((err) => {
+            ghostSocket.destroy();
+
+            err.retry = true;
+            reject(err);
+        }));
     });
+
+    const startPolling = (() => new Promise((resolve, reject) => {
+        let tries = 0;
+
+        (function retry() {
+            connectToGhostSocket()
+                .then(() => {
+                    resolve();
+                })
+                .catch((err) => {
+                    if (err.retry && tries < options.maxTries) {
+                        tries = tries + 1;
+                        setTimeout(retry, options.retryTimeoutInMS);
+                        return;
+                    }
+
+                    if (err instanceof errors.CliError) {
+                        return reject(err);
+                    }
+
+                    reject(new errors.GhostError({
+                        message: 'Ghost did not start.',
+                        suggestion: options.logSuggestion,
+                        err: err
+                    }));
+                });
+        }());
+    }));
 
     return startPolling();
 };

--- a/lib/utils/resolve-version.js
+++ b/lib/utils/resolve-version.js
@@ -1,6 +1,6 @@
 'use strict';
-const semver    = require('semver');
-const Promise   = require('bluebird');
+const semver = require('semver');
+const Promise = require('bluebird');
 
 const yarn = require('./yarn');
 const errors = require('../errors');

--- a/lib/utils/use-ghost-user.js
+++ b/lib/utils/use-ghost-user.js
@@ -29,7 +29,7 @@ const getGhostUid = function getGhostUid() {
         uid: ghostuid,
         gid: ghostgid
     };
-}
+};
 
 const shouldUseGhostUser = function shouldUseGhostUser(contentDir) {
     if (os.platform() !== 'linux') {
@@ -50,9 +50,9 @@ const shouldUseGhostUser = function shouldUseGhostUser(contentDir) {
     }
 
     return process.getuid() !== ghostUser.uid;
-}
+};
 
 module.exports = {
     getGhostUid: getGhostUid,
     shouldUseGhostUser: shouldUseGhostUser
-}
+};

--- a/lib/utils/yarn.js
+++ b/lib/utils/yarn.js
@@ -24,13 +24,11 @@ module.exports = function yarn(yarnArgs, options) {
     const cp = execa('yarn', yarnArgs, execaOpts);
 
     if (!observe) {
-        return cp.catch((error) => {
-            // execa augments the error object with
-            // some other properties, so we just pass
-            // the entire error object in as options to
-            // the ProcessError
-            return Promise.reject(new errors.ProcessError(error));
-        });
+        // execa augments the error object with
+        // some other properties, so we just pass
+        // the entire error object in as options to
+        // the ProcessError
+        return cp.catch(error => Promise.reject(new errors.ProcessError(error)));
     }
 
     return new Observable((observer) => {
@@ -45,11 +43,10 @@ module.exports = function yarn(yarnArgs, options) {
         }).catch((error) => {
             observer.error(error);
         });
-    }).catch((error) => {
+
         // execa augments the error object with
         // some other properties, so we just pass
         // the entire error object in as options to
         // the ProcessError
-        return Promise.reject(new errors.ProcessError(error));
-    });
+    }).catch(error => Promise.reject(new errors.ProcessError(error)));
 };

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "chai": "4.1.2",
     "coveralls": "3.0.2",
     "eslint": "5.3.0",
+    "eslint-plugin-ghost": "0.0.26",
     "has-ansi": "3.0.0",
     "mocha": "5.2.0",
     "nyc": "12.0.2",

--- a/test/acceptance/install-local-spec.js
+++ b/test/acceptance/install-local-spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {expect} = require('chai');
-const fs  = require('fs-extra');
+const fs = require('fs-extra');
 
 const AcceptanceTest = require('../utils/acceptance-test');
 

--- a/test/fixtures/TestExtension/index.js
+++ b/test/fixtures/TestExtension/index.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 const Extension = require('../../../lib/extension');
 

--- a/test/fixtures/classes/test-process-missing-methods.js
+++ b/test/fixtures/classes/test-process-missing-methods.js
@@ -2,4 +2,4 @@
 
 const cli = require('../../../lib/index');
 
-module.exports = class TestProcess extends cli.ProcessManager {}
+module.exports = class TestProcess extends cli.ProcessManager {};

--- a/test/fixtures/classes/test-process-wont-run.js
+++ b/test/fixtures/classes/test-process-wont-run.js
@@ -6,4 +6,4 @@ module.exports = class TestProcess extends cli.ProcessManager {
     static willRun() {
         return false;
     }
-}
+};

--- a/test/unit/bootstrap-spec.js
+++ b/test/unit/bootstrap-spec.js
@@ -155,7 +155,7 @@ describe('Unit: Bootstrap', function () {
 
         it('logs promise if no reason given', function () {
             const handler = process.listeners('unhandledRejection')[0];
-            const p = new Promise((resolve) => resolve());
+            const p = new Promise(resolve => resolve());
 
             try {
                 handler(null, p);

--- a/test/unit/command-spec.js
+++ b/test/unit/command-spec.js
@@ -14,7 +14,7 @@ describe('Unit: Command', function () {
         const Command = require(modulePath);
 
         it('throws if command class doesn\'t have a description', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
 
             try {
                 TestCommand.configure('test', [], {});
@@ -25,7 +25,7 @@ describe('Unit: Command', function () {
         });
 
         it('adds params to command name if params exist', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
             TestCommand.params = '<arg1> [arg2]';
             TestCommand.description = 'a command';
             const commandStub = sinon.stub();
@@ -39,7 +39,7 @@ describe('Unit: Command', function () {
         });
 
         it('sets up command builder correctly', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
             TestCommand.configureOptions = sinon.stub().returns({c: 'd'});
             TestCommand.description = 'a command';
             const commandStub = sinon.stub();
@@ -56,7 +56,7 @@ describe('Unit: Command', function () {
         });
 
         it('calls configureSubcommands if it exists', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
             TestCommand.configureOptions = sinon.stub().returns({a: 'b'});
             TestCommand.configureSubcommands = sinon.stub();
             TestCommand.description = 'a command';
@@ -74,7 +74,7 @@ describe('Unit: Command', function () {
         });
 
         it('creates a handler map to the _run method', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
             TestCommand.description = 'a command';
             TestCommand._run = sinon.stub();
             const commandStub = sinon.stub();
@@ -94,7 +94,7 @@ describe('Unit: Command', function () {
         const Command = require(modulePath);
 
         it('adds usage if a longDescription exists', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
             TestCommand.longDescription = 'a long description here';
             const usageStub = sinon.stub();
             const epilogueStub = sinon.stub();
@@ -106,7 +106,7 @@ describe('Unit: Command', function () {
         });
 
         it('doesn\'t add options if no options defined', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
             const optionStub = sinon.stub();
             const epilogueStub = sinon.stub();
 
@@ -116,7 +116,7 @@ describe('Unit: Command', function () {
         });
 
         it('calls option once for each option defined', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
             TestCommand.options = {
                 flag: {
                     alias: 'f',
@@ -145,7 +145,7 @@ describe('Unit: Command', function () {
         });
 
         it('skips adding epilogue and usage if onlyOptions is true', function () {
-            const TestCommand = class extends Command {}
+            const TestCommand = class extends Command {};
             TestCommand.options = {
                 flag: {
                     alias: 'f',

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -23,7 +23,7 @@ describe('Unit: Command > Config', function () {
         expect(yargsStub.command.calledTwice).to.be.true;
 
         const command1 = yargsStub.command.args[0][0];
-        expect(command1.command).to.equal('get <key>')
+        expect(command1.command).to.equal('get <key>');
         expect(command1.handler).to.be.a('function');
         command1.handler({args: true});
         expect(runStub.calledOnce).to.be.true;
@@ -32,7 +32,7 @@ describe('Unit: Command > Config', function () {
         runStub.reset();
 
         const command2 = yargsStub.command.args[1][0];
-        expect(command2.command).to.equal('set <key> <value>')
+        expect(command2.command).to.equal('set <key> <value>');
         expect(command2.handler).to.be.a('function');
         command2.handler({args: true});
         expect(runStub.calledOnce).to.be.true;
@@ -183,7 +183,7 @@ describe('Unit: Command > Config', function () {
         });
 
         it('returns url prompt with validator if url is not provided and db is sqlite3', function () {
-            const expectedValidator = require('../../../lib/utils/validate-instance-url')
+            const expectedValidator = require('../../../lib/utils/validate-instance-url');
             const argv = {db: 'sqlite3'};
             const result = config.getConfigPrompts(argv);
 

--- a/test/unit/commands/doctor/checks/check-memory-spec.js
+++ b/test/unit/commands/doctor/checks/check-memory-spec.js
@@ -36,7 +36,7 @@ describe('Unit: Doctor Checks > Memory', function () {
         const memStub = sinon.stub(sysinfo, 'mem').rejects(new Error('systeminformation'));
         const memCheck = require(modulePath);
 
-        return memCheck.task().catch(error => {
+        return memCheck.task().catch((error) => {
             expect(error).to.be.an('error');
             expect(error.message).to.equal('systeminformation');
             expect(memStub.calledOnce).to.be.true;

--- a/test/unit/commands/doctor/checks/logged-in-ghost-user-spec.js
+++ b/test/unit/commands/doctor/checks/logged-in-ghost-user-spec.js
@@ -31,7 +31,7 @@ describe('Unit: Doctor Checks > loggedInGhostUser', function () {
         const fsStub = sinon.stub(fs, 'lstatSync').returns({uid: 1002, gid: 1002});
 
         try {
-            loggedInGhostUser.task()
+            loggedInGhostUser.task();
             expect(false, 'error should have been thrown').to.be.true;
         } catch (error) {
             expect(error).to.exist;

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -37,7 +37,7 @@ describe('Unit: Commands > Install', function () {
     describe('run', function () {
         afterEach(() => {
             sinon.restore();
-        })
+        });
 
         it('rejects if directory is not empty', function () {
             const readdirStub = sinon.stub().returns([
@@ -130,7 +130,7 @@ describe('Unit: Commands > Install', function () {
                 expect(false, 'run should have rejected').to.be.true;
             }).catch(() => {
                 expect(readdirStub.calledOnce).to.be.true;
-                expect(runCommandStub.calledOnce).to.be.true
+                expect(runCommandStub.calledOnce).to.be.true;
                 expect(listrStub.calledOnce).to.be.true;
                 expect(listrStub.args[0][1]).to.deep.equal({
                     version: '1.5.0',
@@ -147,9 +147,7 @@ describe('Unit: Commands > Install', function () {
             const readdirStub = sinon.stub().returns([]);
             const yarnInstallStub = sinon.stub().resolves();
             const ensureStructureStub = sinon.stub().resolves();
-            const listrStub = sinon.stub().callsFake((tasks, ctx) => {
-                return Promise.each(tasks, task => task.task(ctx, {}));
-            });
+            const listrStub = sinon.stub().callsFake((tasks, ctx) => Promise.each(tasks, task => task.task(ctx, {})));
 
             const InstallCommand = proxyquire(modulePath, {
                 'fs-extra': {readdirSync: readdirStub},

--- a/test/unit/commands/log-spec.js
+++ b/test/unit/commands/log-spec.js
@@ -20,7 +20,7 @@ function proxyLog(proxyOptions) {
 
 function configGet(what) {
     if (what === 'url') {
-        return 'https://dev.ghost.org'
+        return 'https://dev.ghost.org';
     } else if (what === 'logging.transports') {
         return ['file'];
     }
@@ -46,7 +46,7 @@ describe('Unit: Commands > Log', function () {
             es: sinon.stub(),
             // thrown to stop execution
             cvi: sinon.stub().throws(new Error())
-        }
+        };
     });
 
     describe('run', function () {
@@ -140,7 +140,7 @@ describe('Unit: Commands > Log', function () {
             ext.run({name: 'ghost_org', error: true}).then(() => {
                 expect(false, 'existsSync should have thrown').to.be.true;
             }).catch((error) => {
-                const fileName = 'https___dev_ghost_org_dev.error.log'
+                const fileName = 'https___dev_ghost_org_dev.error.log';
                 const expectedFilePath = `/var/www/ghost/content/logs/${fileName}`;
                 expect(error).to.be.ok;
                 expect(error.message).to.equal('SHORT_CIRCUIT');
@@ -165,7 +165,7 @@ describe('Unit: Commands > Log', function () {
             stubs.log = sinon.stub();
             const ext = proxyLog({fs: {existsSync: stubs.es}});
             ext.system = defaultSystem;
-            ext.ui = {log: stubs.log}
+            ext.ui = {log: stubs.log};
 
             return ext.run({name: 'ghost_org', follow: true}).then(() => {
                 expect(stubs.es.calledOnce).to.be.true;
@@ -176,7 +176,7 @@ describe('Unit: Commands > Log', function () {
 
         it('Passes unknown PrettyStream errors through', function () {
             class PrettyStream {}
-            PrettyStream.prototype.on = sinon.stub().callsFake((event, callback) =>{
+            PrettyStream.prototype.on = sinon.stub().callsFake((event, callback) => {
                 expect(event).to.equal('error');
                 callback(new Error('test error'));
             });
@@ -196,7 +196,7 @@ describe('Unit: Commands > Log', function () {
 
         it('Ignores PrettyStream syntax errors', function () {
             class PrettyStream {}
-            PrettyStream.prototype.on = sinon.stub().callsFake((event, callback) =>{
+            PrettyStream.prototype.on = sinon.stub().callsFake((event, callback) => {
                 expect(event).to.equal('error');
                 callback(new SyntaxError('bad error'));
                 throw new Error('break the code');

--- a/test/unit/commands/ls-spec.js
+++ b/test/unit/commands/ls-spec.js
@@ -76,6 +76,6 @@ describe('Unit: Commands > ls', function () {
             expect(tableStub.called).to.be.false;
             expect(logStub.calledOnce).to.be.true;
             expect(logStub.args[0][0]).to.equal('No installed ghost instances found');
-        })
-    })
+        });
+    });
 });

--- a/test/unit/commands/restart-spec.js
+++ b/test/unit/commands/restart-spec.js
@@ -13,7 +13,7 @@ describe('Unit: Command > Restart', function () {
             ui: {log: logStub},
             system: {getInstance: () => instance},
             runCommand: sinon.stub().resolves()
-        }
+        };
         const command = new RestartCommand({}, {});
 
         return command.run.call(ctx).then(() => {

--- a/test/unit/commands/run-spec.js
+++ b/test/unit/commands/run-spec.js
@@ -92,7 +92,7 @@ describe('Unit: Commands > Run', function () {
             child_process: {spawn: spawnStub}
         });
         const failStub = sinon.stub();
-        const logStub = sinon.stub()
+        const logStub = sinon.stub();
         const instance = new RunCommand({fail: failStub, log: logStub}, {});
         const exitStub = sinon.stub(process, 'exit');
 

--- a/test/unit/commands/setup-spec.js
+++ b/test/unit/commands/setup-spec.js
@@ -85,7 +85,9 @@ describe('Unit: Commands > Setup', function () {
                 db: 'mysql'
             };
 
-            const setup = new SetupCommand({}, {setEnvironment: () => {throw new Error('Take a break')}});
+            const setup = new SetupCommand({}, {setEnvironment: () => {
+                throw new Error('Take a break');
+            }});
 
             try {
                 setup.run(Object.assign(argVSpy, argvA));
@@ -115,12 +117,16 @@ describe('Unit: Commands > Setup', function () {
         });
 
         it('Hooks when stages are passed through', function () {
-            let stages = []
+            let stages = [];
             const stubs = {
                 noCall: sinon.stub().resolves(),
                 important: sinon.stub().resolves(),
-                hook: sinon.stub().callsFake((n, ths) => {ths.stages = stages; return Promise.resolve()}),
-                listr: sinon.stub().callsFake((tasks) => {tasks.forEach((task) => task.task())})
+                hook: sinon.stub().callsFake((n, ths) => {
+                    ths.stages = stages; return Promise.resolve();
+                }),
+                listr: sinon.stub().callsFake((tasks) => {
+                    tasks.forEach(task => task.task());
+                })
             };
             stages = [{name: 'nocall', fn: stubs.noCall}, {name: 'important', fn: stubs.important}];
             const system = {
@@ -242,15 +248,13 @@ describe('Unit: Commands > Setup', function () {
             config.has.returns(false);
 
             const system = {
-                getInstance: () => {
-                    return {
-                        checkEnvironment: () => true,
-                        apples: true,
-                        config,
-                        dir: '/var/www/ghost',
-                        cliConfig: cliConfigStub
-                    };
-                },
+                getInstance: () => ({
+                    checkEnvironment: () => true,
+                    apples: true,
+                    config,
+                    dir: '/var/www/ghost',
+                    cliConfig: cliConfigStub
+                }),
                 addInstance: aIstub,
                 hook: () => Promise.resolve()
             };
@@ -264,15 +268,13 @@ describe('Unit: Commands > Setup', function () {
                 'setup-linux-user': false
             };
 
-            ui.listr.callsFake((tasks, ctx) => {
-                return Promise.each(tasks, (task) => {
-                    if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
-                        return;
-                    }
+            ui.listr.callsFake((tasks, ctx) => Promise.each(tasks, (task) => {
+                if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
+                    return;
+                }
 
-                    return task.task(ctx);
-                });
-            });
+                return task.task(ctx);
+            }));
 
             const setup = new SetupCommand(ui, system);
             return setup.run(argv).then(() => {
@@ -294,15 +296,13 @@ describe('Unit: Commands > Setup', function () {
             config.has.returns(false);
 
             const system = {
-                getInstance: () => {
-                    return {
-                        checkEnvironment: () => true,
-                        apples: true,
-                        config,
-                        dir: '/var/www/ghost',
-                        cliConfig: cliConfigStub
-                    };
-                },
+                getInstance: () => ({
+                    checkEnvironment: () => true,
+                    apples: true,
+                    config,
+                    dir: '/var/www/ghost',
+                    cliConfig: cliConfigStub
+                }),
                 addInstance: aIstub,
                 hook: () => Promise.resolve()
             };
@@ -350,14 +350,12 @@ describe('Unit: Commands > Setup', function () {
             config.has.returns(true);
 
             const system = {
-                getInstance: () => {
-                    return {
-                        checkEnvironment: () => true,
-                        apples: true,
-                        config,
-                        dir: '/var/www/ghost'
-                    };
-                },
+                getInstance: () => ({
+                    checkEnvironment: () => true,
+                    apples: true,
+                    config,
+                    dir: '/var/www/ghost'
+                }),
                 addInstance: aIstub,
                 hook: () => Promise.resolve()
             };
@@ -514,7 +512,7 @@ describe('Unit: Commands > Setup', function () {
 
         it('honors stage skipping via arguments', function () {
             const ui = {
-                run: (a) => a(),
+                run: a => a(),
                 listr: sinon.stub().resolves()
             };
             const skipStub = sinon.stub();
@@ -541,7 +539,7 @@ describe('Unit: Commands > Setup', function () {
                 return Promise.resolve(a.indexOf('Z') < 0);
             }
             const ui = {
-                run: (a) => a(),
+                run: a => a(),
                 log: () => true,
                 listr: sinon.stub().resolves(),
                 confirm: sinon.stub().callsFake(confirm)

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -28,7 +28,7 @@ describe('Unit: Commands > Start', function () {
         });
 
         it('gracefully notifies of already running instance', function () {
-            const runningStub = sinon.stub().resolves(true)
+            const runningStub = sinon.stub().resolves(true);
             const logStub = sinon.stub();
             const ui = {log: logStub};
             const start = new StartCommand(ui, mySystem);
@@ -103,7 +103,7 @@ describe('Unit: Commands > Start', function () {
                     listr: () => Promise.resolve()
                 };
                 ui.run.onFirstCall().resolves();
-                ui.run.onSecondCall().callsFake((fn) => Promise.resolve(fn()));
+                ui.run.onSecondCall().callsFake(fn => Promise.resolve(fn()));
                 myInstance.process = {
                     isEnabled: sinon.stub().resolves(false),
                     enable: sinon.stub().resolves(),
@@ -230,7 +230,7 @@ describe('Unit: Commands > Start', function () {
 
         it('shows custom admin url', function () {
             const oldArgv = process.argv;
-            process.argv = ['', '', 'start']
+            process.argv = ['', '', 'start'];
             myInstance.config.get.withArgs('url').returns('https://my-amazing.blog.com');
             myInstance.config.get.withArgs('admin.url').returns('https://admin.my-amazing.blog.com');
             myInstance.process = {};
@@ -255,7 +255,7 @@ describe('Unit: Commands > Start', function () {
 
         it('shows different message after fresh install', function () {
             const oldArgv = process.argv;
-            process.argv = ['', '', 'install']
+            process.argv = ['', '', 'install'];
             myInstance.config.get.withArgs('url').returns('https://my-amazing.blog.com');
             myInstance.process = {};
             const ui = {

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -8,7 +8,7 @@ const errors = require('../../../lib/errors');
 const StopCommand = require(modulePath);
 
 function proxiedCommand() {
-    return new(proxyquire(modulePath, {'../utils/check-valid-install': () => true}))();
+    return new (proxyquire(modulePath, {'../utils/check-valid-install': () => true}))();
 }
 
 describe('Unit: Commands > Stop', function () {
@@ -90,7 +90,7 @@ describe('Unit: Commands > Stop', function () {
                     expect(runningStub.calledTwice).to.be.true;
                     expect(runningStub.args[1][0]).to.equal(null);
                 });
-            }
+            };
 
             const context = {
                 system: {getInstance: gIstub},
@@ -221,7 +221,7 @@ describe('Unit: Commands > Stop', function () {
 
     it('stopAll stops all instances', function () {
         const stop = new StopCommand();
-        const runStub = sinon.stub().callsFake((fn) => fn.call(stop));
+        const runStub = sinon.stub().callsFake(fn => fn.call(stop));
         const cases = 'abcdefgh'.split('');
         const instances = [];
         cases.forEach((cse) => {

--- a/test/unit/commands/uninstall-spec.js
+++ b/test/unit/commands/uninstall-spec.js
@@ -15,7 +15,7 @@ const fileList = [
     '.ghost-cli',
     'config.production.json',
     'config.development.json'
-]
+];
 
 describe('Unit: Commands > Uninstall', function () {
     afterEach(() => {
@@ -33,7 +33,7 @@ describe('Unit: Commands > Uninstall', function () {
             instance: instance,
             ui: ui,
             system: system
-        }
+        };
     }
 
     describe('run', function () {

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -67,19 +67,21 @@ describe('Unit: Commands > Update', function () {
             const system = {getInstance: sinon.stub()};
 
             ui.run.callsFake(fn => fn());
-            ui.listr.callsFake((tasks, ctx) => {
-                return Promise.each(tasks, (task) => {
-                    if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
-                        return;
-                    }
+            ui.listr.callsFake((tasks, ctx) => Promise.each(tasks, (task) => {
+                if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
+                    return;
+                }
 
-                    return task.task(ctx);
-                });
-            });
+                return task.task(ctx);
+            }));
 
             class TestInstance extends Instance {
-                get cliConfig() { return cliConfig; }
-                get config() { return ghostConfig; }
+                get cliConfig() {
+                    return cliConfig; 
+                }
+                get config() {
+                    return ghostConfig; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -148,19 +150,21 @@ describe('Unit: Commands > Update', function () {
             const system = {getInstance: sinon.stub()};
 
             ui.run.callsFake(fn => fn());
-            ui.listr.callsFake((tasks, ctx) => {
-                return Promise.each(tasks, (task) => {
-                    if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
-                        return;
-                    }
+            ui.listr.callsFake((tasks, ctx) => Promise.each(tasks, (task) => {
+                if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
+                    return;
+                }
 
-                    return task.task(ctx);
-                });
-            });
+                return task.task(ctx);
+            }));
 
             class TestInstance extends Instance {
-                get cliConfig() { return cliConfig; }
-                get config() { return ghostConfig; }
+                get cliConfig() {
+                    return cliConfig; 
+                }
+                get config() {
+                    return ghostConfig; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -213,7 +217,9 @@ describe('Unit: Commands > Update', function () {
             ui.run.callsFake(fn => fn());
 
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -255,7 +261,9 @@ describe('Unit: Commands > Update', function () {
             ui.run.callsFake(fn => fn());
 
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -288,7 +296,9 @@ describe('Unit: Commands > Update', function () {
             ui.run.callsFake(fn => fn());
 
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -340,18 +350,18 @@ describe('Unit: Commands > Update', function () {
             const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
             const system = {getInstance: sinon.stub()};
             ui.run.callsFake(fn => fn());
-            ui.listr.callsFake((tasks, ctx) => {
-                return Promise.each(tasks, (task) => {
-                    if (task.skip && task.skip(ctx) || (task.enabled && !task.enabled(ctx))) {
-                        return;
-                    }
+            ui.listr.callsFake((tasks, ctx) => Promise.each(tasks, (task) => {
+                if (task.skip && task.skip(ctx) || (task.enabled && !task.enabled(ctx))) {
+                    return;
+                }
 
-                    return task.task(ctx);
-                });
-            });
+                return task.task(ctx);
+            }));
 
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -404,18 +414,18 @@ describe('Unit: Commands > Update', function () {
             const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
             const system = {getInstance: sinon.stub()};
             ui.run.callsFake(fn => fn());
-            ui.listr.callsFake((tasks, ctx) => {
-                return Promise.each(tasks, (task) => {
-                    if (task.skip && task.skip(ctx) || (task.enabled && !task.enabled(ctx))) {
-                        return;
-                    }
+            ui.listr.callsFake((tasks, ctx) => Promise.each(tasks, (task) => {
+                if (task.skip && task.skip(ctx) || (task.enabled && !task.enabled(ctx))) {
+                    return;
+                }
 
-                    return task.task(ctx);
-                });
-            });
+                return task.task(ctx);
+            }));
 
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -473,18 +483,18 @@ describe('Unit: Commands > Update', function () {
             const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
             const system = {getInstance: sinon.stub()};
             ui.run.callsFake(fn => fn());
-            ui.listr.callsFake((tasks, ctx) => {
-                return Promise.each(tasks, (task) => {
-                    if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
-                        return;
-                    }
+            ui.listr.callsFake((tasks, ctx) => Promise.each(tasks, (task) => {
+                if ((task.skip && task.skip(ctx)) || (task.enabled && !task.enabled(ctx))) {
+                    return;
+                }
 
-                    return task.task(ctx);
-                });
-            });
+                return task.task(ctx);
+            }));
 
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -537,7 +547,9 @@ describe('Unit: Commands > Update', function () {
             };
             const system = {getInstance: sinon.stub()};
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -546,14 +558,14 @@ describe('Unit: Commands > Update', function () {
             const cmdInstance = new UpdateCommand(ui, system);
             const rollback = cmdInstance.rollbackFromFail = sinon.stub().rejects(new Error('rollback_successful'));
             cmdInstance.runCommand = sinon.stub().resolves(true);
-            cmdInstance.version = sinon.stub().callsFake(context => {
+            cmdInstance.version = sinon.stub().callsFake((context) => {
                 context.version = '1.1.1';
                 return true;
             });
 
             return cmdInstance.run({}).then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
-            }).catch(error => {
+            }).catch((error) => {
                 expect(error.message).to.equal('rollback_successful');
                 expect(rollback.calledOnce).to.be.true;
                 expect(rollback.calledWithExactly(errObj, '1.1.1', undefined)).to.be.true;
@@ -575,7 +587,9 @@ describe('Unit: Commands > Update', function () {
             };
             const system = {getInstance: sinon.stub()};
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -584,14 +598,14 @@ describe('Unit: Commands > Update', function () {
             const cmdInstance = new UpdateCommand(ui, system);
             const rollback = cmdInstance.rollbackFromFail = sinon.stub();
             cmdInstance.runCommand = sinon.stub().resolves(true);
-            cmdInstance.version = sinon.stub().callsFake(context => {
+            cmdInstance.version = sinon.stub().callsFake((context) => {
                 context.version = '1.1.1';
                 return true;
             });
 
             return cmdInstance.run({}).then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
-            }).catch(error => {
+            }).catch((error) => {
                 expect(error.message).to.equal('do_nothing');
                 expect(rollback.called).to.be.false;
             });
@@ -612,7 +626,9 @@ describe('Unit: Commands > Update', function () {
             };
             const system = {getInstance: sinon.stub()};
             class TestInstance extends Instance {
-                get cliConfig() { return config; }
+                get cliConfig() {
+                    return config; 
+                }
             }
             const fakeInstance = sinon.stub(new TestInstance(ui, system, '/var/www/ghost'));
             system.getInstance.returns(fakeInstance);
@@ -621,14 +637,14 @@ describe('Unit: Commands > Update', function () {
             const cmdInstance = new UpdateCommand(ui, system);
             const rollback = cmdInstance.rollbackFromFail = sinon.stub();
             cmdInstance.runCommand = sinon.stub().resolves(true);
-            cmdInstance.version = sinon.stub().callsFake(context => {
+            cmdInstance.version = sinon.stub().callsFake((context) => {
                 context.version = '1.1.1';
                 return true;
             });
 
             return cmdInstance.run({rollback: true}).then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
-            }).catch(error => {
+            }).catch((error) => {
                 expect(error.message).to.equal('do_nothing');
                 expect(rollback.called).to.be.false;
             });
@@ -921,11 +937,8 @@ describe('Unit: Commands > Update', function () {
         });
 
         it('re-throws non CliErrors from resolveVersion util', function () {
-            const resolveVersion = sinon.stub().callsFake(() => {
-                // sinon's reject handling doesn't work quite well enough
-                // for this so we do it manually
-                return Promise.reject(new Error('something bad'));
-            });
+            const resolveVersion = sinon.stub().callsFake(() => Promise.reject(new Error('something bad'))
+            );
             const UpdateCommand = proxyquire(modulePath, {
                 '../utils/resolve-version': resolveVersion
             });
@@ -953,7 +966,7 @@ describe('Unit: Commands > Update', function () {
         let ui, system;
 
         beforeEach(function () {
-            const cliConfig = {get: () => '1.0.0'}
+            const cliConfig = {get: () => '1.0.0'};
             ui = {
                 log: sinon.stub(),
                 confirm: sinon.stub(),
@@ -969,7 +982,7 @@ describe('Unit: Commands > Update', function () {
 
         it('Asks to rollback by default', function () {
             const UpdateCommand = require(modulePath);
-            const expectedQuestion = 'Unable to upgrade Ghost from v1.0.0 to v1.1.1. Would you like to revert back to v1.0.0?'
+            const expectedQuestion = 'Unable to upgrade Ghost from v1.0.0 to v1.1.1. Would you like to revert back to v1.0.0?';
             const update = new UpdateCommand(ui, system, '/var/www/ghost');
             ui.confirm.resolves(true);
             update.run = sinon.stub().resolves();
@@ -1037,7 +1050,7 @@ describe('Unit: Commands > Update', function () {
             const envCfg = {
                 dirs: ['versions/1.0.0', 'versions/1.0.1'],
                 links: [['versions/1.0.0', 'current']]
-            }
+            };
             const env = setupTestFolder(envCfg);
             sinon.stub(process, 'cwd').returns(env.dir);
             const config = configStub();
@@ -1064,7 +1077,7 @@ describe('Unit: Commands > Update', function () {
             const envCfg = {
                 dirs: ['versions/1.0.0', 'versions/1.0.1'],
                 links: [['versions/1.0.1', 'current']]
-            }
+            };
             const env = setupTestFolder(envCfg);
             sinon.stub(process, 'cwd').returns(env.dir);
             const config = configStub();

--- a/test/unit/errors-spec.js
+++ b/test/unit/errors-spec.js
@@ -200,7 +200,7 @@ describe('Unit: Errors', function () {
             expect(errorOutput).to.match(/database\.connection\.username/);
             expect(errorOutput).to.match(/database\.connection\.password/);
             expect(errorOutput).to.match(/root \/ password/);
-            expect(errorOutput).to.match(/Help: Run `ghost config <key> <new value>/)
+            expect(errorOutput).to.match(/Help: Run `ghost config <key> <new value>/);
         });
     });
 });

--- a/test/unit/instance-spec.js
+++ b/test/unit/instance-spec.js
@@ -39,7 +39,9 @@ describe('Unit: Instance', function () {
         it('returns name value in cliConfig if it exists', function () {
             const getStub = sinon.stub().withArgs('name').returns('testing');
             class TestInstance extends Instance {
-                get cliConfig() { return {get: getStub} }
+                get cliConfig() {
+                    return {get: getStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
             const name = testInstance.name;
@@ -52,8 +54,12 @@ describe('Unit: Instance', function () {
             const cliConfigGetStub = sinon.stub().withArgs('name').returns(null);
             const configGetStub = sinon.stub().withArgs('pname').returns('testing');
             class TestInstance extends Instance {
-                get cliConfig() { return {get: cliConfigGetStub}; }
-                get config() { return {get: configGetStub}; }
+                get cliConfig() {
+                    return {get: cliConfigGetStub}; 
+                }
+                get config() {
+                    return {get: configGetStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
             const name = testInstance.name;
@@ -69,7 +75,9 @@ describe('Unit: Instance', function () {
             const setStub = sinon.stub().withArgs('name', 'testing').returnsThis();
             const saveStub = sinon.stub().returnsThis();
             class TestInstance extends Instance {
-                get cliConfig() { return {set: setStub, save: saveStub} }
+                get cliConfig() {
+                    return {set: setStub, save: saveStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
             testInstance.name = 'testing';
@@ -119,7 +127,9 @@ describe('Unit: Instance', function () {
         it('returns cached process instance if it exists', function () {
             const getStub = sinon.stub().withArgs('process', 'local').returns('local');
             class TestInstance extends Instance {
-                get config() { return {get: getStub}; }
+                get config() {
+                    return {get: getStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
             const testProcess = testInstance._process = {
@@ -138,7 +148,9 @@ describe('Unit: Instance', function () {
             const getStub = sinon.stub().withArgs('process', 'local').returns('local');
             const procManagerStub = sinon.stub().withArgs('local').returns({Class: ProcessManager});
             class TestInstance extends Instance {
-                get config() { return {get: getStub}; }
+                get config() {
+                    return {get: getStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {
                 getProcessManager: procManagerStub
@@ -165,7 +177,9 @@ describe('Unit: Instance', function () {
             const setStub = sinon.stub().withArgs('running', 'testing').returnsThis();
             const saveStub = sinon.stub();
             class TestInstance extends Instance {
-                get cliConfig() { return {set: setStub, save: saveStub}; }
+                get cliConfig() {
+                    return {set: setStub, save: saveStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
 
@@ -178,7 +192,9 @@ describe('Unit: Instance', function () {
         it('returns false if running property not set in config & neither config exists', function () {
             const hasStub = sinon.stub().withArgs('running').returns(false);
             class TestInstance extends Instance {
-                get cliConfig() { return {has: hasStub} }
+                get cliConfig() {
+                    return {has: hasStub}; 
+                }
             }
             const setEnvironmentStub = sinon.stub();
             const testInstance = new TestInstance({}, {development: true, setEnvironment: setEnvironmentStub}, '');
@@ -197,8 +213,12 @@ describe('Unit: Instance', function () {
             const configStub = createConfigStub();
             const isRunningStub = sinon.stub().returns(true);
             class TestInstance extends Instance {
-                get cliConfig() { return configStub; }
-                get process() { return {isRunning: isRunningStub}; }
+                get cliConfig() {
+                    return configStub; 
+                }
+                get process() {
+                    return {isRunning: isRunningStub}; 
+                }
             }
 
             const existsStub = sinon.stub(Config, 'exists').returns(true);
@@ -221,8 +241,12 @@ describe('Unit: Instance', function () {
             const configStub = createConfigStub();
             const isRunningStub = sinon.stub().returns(true);
             class TestInstance extends Instance {
-                get cliConfig() { return configStub; }
-                get process() { return {isRunning: isRunningStub}; }
+                get cliConfig() {
+                    return configStub; 
+                }
+                get process() {
+                    return {isRunning: isRunningStub}; 
+                }
             }
 
             const existsStub = sinon.stub(Config, 'exists');
@@ -251,8 +275,12 @@ describe('Unit: Instance', function () {
             isRunningStub.onFirstCall().returns(false);
             isRunningStub.onSecondCall().returns(true);
             class TestInstance extends Instance {
-                get cliConfig() { return configStub; }
-                get process() { return {isRunning: isRunningStub}; }
+                get cliConfig() {
+                    return configStub; 
+                }
+                get process() {
+                    return {isRunning: isRunningStub}; 
+                }
             }
 
             const existsStub = sinon.stub(Config, 'exists').returns(true);
@@ -276,8 +304,12 @@ describe('Unit: Instance', function () {
             const configStub = createConfigStub();
             const isRunningStub = sinon.stub().returns(false);
             class TestInstance extends Instance {
-                get cliConfig() { return configStub; }
-                get process() { return {isRunning: isRunningStub}; }
+                get cliConfig() {
+                    return configStub; 
+                }
+                get process() {
+                    return {isRunning: isRunningStub}; 
+                }
             }
 
             const existsStub = sinon.stub(Config, 'exists').returns(true);
@@ -302,8 +334,12 @@ describe('Unit: Instance', function () {
             const hasStub = sinon.stub().withArgs('running').returns(true);
             const isRunningStub = sinon.stub().returns(true);
             class TestInstance extends Instance {
-                get cliConfig() { return {has: hasStub}; }
-                get process() { return {isRunning: isRunningStub} }
+                get cliConfig() {
+                    return {has: hasStub}; 
+                }
+                get process() {
+                    return {isRunning: isRunningStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
             const loadRunEnvStub = sinon.stub(testInstance, 'loadRunningEnvironment');
@@ -322,8 +358,12 @@ describe('Unit: Instance', function () {
             const saveStub = sinon.stub().returnsThis();
             const isRunningStub = sinon.stub().returns(false);
             class TestInstance extends Instance {
-                get cliConfig() { return {has: hasStub, set: setStub, save: saveStub}; }
-                get process() { return {isRunning: isRunningStub}; }
+                get cliConfig() {
+                    return {has: hasStub, set: setStub, save: saveStub}; 
+                }
+                get process() {
+                    return {isRunning: isRunningStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
             const loadRunEnvStub = sinon.stub(testInstance, 'loadRunningEnvironment');
@@ -396,7 +436,9 @@ describe('Unit: Instance', function () {
         it('throws error if instance is not running', function () {
             const getStub = sinon.stub().withArgs('running').returns(null);
             class TestInstance extends Instance {
-                get cliConfig() { return {get: getStub}; }
+                get cliConfig() {
+                    return {get: getStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
 
@@ -413,7 +455,9 @@ describe('Unit: Instance', function () {
             const getStub = sinon.stub().withArgs('running').returns('development');
             const envStub = sinon.stub();
             class TestInstance extends Instance {
-                get cliConfig() { return {get: getStub}; }
+                get cliConfig() {
+                    return {get: getStub}; 
+                }
             }
             const testInstance = new TestInstance({}, {
                 setEnvironment: envStub
@@ -430,9 +474,15 @@ describe('Unit: Instance', function () {
         it('returns shortened object if running is false', function () {
             const getStub = sinon.stub().withArgs('active-version').returns('1.0.0');
             class TestInstance extends Instance {
-                get name() { return 'testing'; }
-                get cliConfig() { return {get: getStub}; }
-                running() { return Promise.resolve(false); }
+                get name() {
+                    return 'testing'; 
+                }
+                get cliConfig() {
+                    return {get: getStub}; 
+                }
+                running() {
+                    return Promise.resolve(false); 
+                }
             }
             const testInstance = new TestInstance({}, {}, '');
 
@@ -451,11 +501,21 @@ describe('Unit: Instance', function () {
             getStub.withArgs('server.port').returns(1234);
 
             class TestInstance extends Instance {
-                get name() { return 'testing'; }
-                get cliConfig() { return {get: cliGetStub}; }
-                get config() { return {get: getStub}; }
-                get process() { return {name: 'local'}; }
-                running() { return Promise.resolve(true); }
+                get name() {
+                    return 'testing'; 
+                }
+                get cliConfig() {
+                    return {get: cliGetStub}; 
+                }
+                get config() {
+                    return {get: getStub}; 
+                }
+                get process() {
+                    return {name: 'local'}; 
+                }
+                running() {
+                    return Promise.resolve(true); 
+                }
             }
             const testInstance = new TestInstance({}, {environment: 'testing'}, '');
 

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -28,9 +28,15 @@ describe('Unit: Process Manager', function () {
 
         it('returns true if class exists and implements all the right methods', function () {
             class TestProcess extends ProcessManager {
-                start() { return Promise.resolve(); }
-                stop() { return Promise.resolve(); }
-                isRunning() { return true; }
+                start() {
+                    return Promise.resolve(); 
+                }
+                stop() {
+                    return Promise.resolve(); 
+                }
+                isRunning() {
+                    return true; 
+                }
             }
             const result = ProcessManager.isValid(TestProcess);
             expect(result).to.be.true;
@@ -186,7 +192,7 @@ describe('Unit: Process Manager', function () {
             expect(stopStub.calledOnce).to.be.true;
             expect(startStub.calledOnce).to.be.true;
             expect(stopStub.calledBefore(startStub)).to.be.true;
-        })
+        });
     });
 
     it('base start implementation returns a promise', function () {

--- a/test/unit/tasks/ensure-structure-spec.js
+++ b/test/unit/tasks/ensure-structure-spec.js
@@ -9,7 +9,7 @@ const ensureStructure = require('../../../lib/tasks/ensure-structure');
 
 describe('Unit: Tasks > ensure-structure', function () {
     after(() => {
-        cleanupTestFolders()
+        cleanupTestFolders();
     });
 
     it('works', function () {

--- a/test/unit/tasks/yarn-install-spec.js
+++ b/test/unit/tasks/yarn-install-spec.js
@@ -25,7 +25,7 @@ describe('Unit: Tasks > yarn-install', function () {
         const listrStub = sinon.stub().callsFake((tasks) => {
             expect(tasks).to.have.length(3);
 
-            return Promise.each(tasks, (task) => task.task(ctx));
+            return Promise.each(tasks, task => task.task(ctx));
         });
 
         const distTaskStub = sinon.stub(subTasks, 'dist').resolves();
@@ -77,7 +77,7 @@ describe('Unit: Tasks > yarn-install', function () {
         const listrStub = sinon.stub().callsFake((tasks) => {
             expect(tasks).to.have.length(3);
 
-            return Promise.each(tasks, (task) => task.task(ctx));
+            return Promise.each(tasks, task => task.task(ctx));
         });
 
         const distTaskStub = sinon.stub(subTasks, 'dist').resolves();

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -248,7 +248,7 @@ describe('Unit: UI', function () {
         it('passes options to prompt method', function () {
             const ui = new UI();
             ui.allowPrompt = true;
-            const noSpinStub = sinon.stub(ui, 'noSpin').callsFake((fn) => fn());
+            const noSpinStub = sinon.stub(ui, 'noSpin').callsFake(fn => fn());
             const inquirerStub = sinon.stub(ui, 'inquirer').resolves();
 
             const prompt = {

--- a/test/unit/ui/pretty-stream-spec.js
+++ b/test/unit/ui/pretty-stream-spec.js
@@ -170,7 +170,7 @@ describe('Unit: UI > PrettyStream', function () {
                     time: '2016-07-01 00:00:00',
                     level: 30,
                     msg: 'Ghost starts now.'
-                }, '[2016-07-01 00:00:00] \u001b[36mINFO\u001b[39m Ghost starts now.\n')
+                }, '[2016-07-01 00:00:00] \u001b[36mINFO\u001b[39m Ghost starts now.\n');
             });
 
             it('data.err', function () {

--- a/test/unit/utils/check-valid-install-spec.js
+++ b/test/unit/utils/check-valid-install-spec.js
@@ -9,7 +9,7 @@ const fs = require('fs-extra');
 describe('Unit: Utils > checkValidInstall', function () {
     afterEach(() => {
         sinon.restore();
-    })
+    });
 
     it('throws error if config.js present', function () {
         const existsStub = sinon.stub(fs, 'existsSync');

--- a/test/unit/utils/find-extensions-spec.js
+++ b/test/unit/utils/find-extensions-spec.js
@@ -51,7 +51,7 @@ describe('Unit: Utils > find-extensions', function () {
             sort: true
         };
 
-        const extensions = args.include.map((ext) => ext.split('extensions/')[1]);
+        const extensions = args.include.map(ext => ext.split('extensions/')[1]);
         delete args.include;
         expect(extensions).to.deep.equal(localExtensions);
         expect(args).to.deep.equal(expected);
@@ -71,7 +71,7 @@ describe('Unit: Utils > find-extensions', function () {
             sort: true
         };
 
-        const extensions = args.include.map((ext) => ext.split('extensions/')[1]);
+        const extensions = args.include.map(ext => ext.split('extensions/')[1]);
         delete args.include;
         expect(extensions).to.deep.equal(localExtensions);
         expect(args).to.deep.equal(expected);
@@ -79,7 +79,7 @@ describe('Unit: Utils > find-extensions', function () {
 
     it('generates proper extension names', function () {
         existsStub.returns(true);
-        const names = findExtensions().map((ext) => ext.name);
+        const names = findExtensions().map(ext => ext.name);
         const expectedNames = ['test', 'rest', undefined];
         expect(names).to.deep.equal(expectedNames);
     });

--- a/test/unit/utils/get-os-spec.js
+++ b/test/unit/utils/get-os-spec.js
@@ -52,7 +52,7 @@ describe('Unit: Utils > getOS', function () {
 
     it('returns default os.platform if OS is not Mac, Linux, or Windows', function () {
         platformStub.returns('freebsd');
-        versionStub.returns('1.0.0')
+        versionStub.returns('1.0.0');
         const osResult = getOS({
             linux: false,
             macos: false,

--- a/test/unit/utils/local-process-spec.js
+++ b/test/unit/utils/local-process-spec.js
@@ -314,7 +314,7 @@ describe('Unit: Utils > local-process', function () {
             }, {});
 
             instance.stop('/var/www/ghost').then(() => {
-                done(new Error('stop should have rejected'))
+                done(new Error('stop should have rejected'));
             }).catch((error) => {
                 expect(error).to.be.an.instanceof(errors.CliError);
                 expect(error.message).to.equal('An unexpected error occurred while stopping Ghost.');

--- a/test/unit/utils/port-polling-spec.js
+++ b/test/unit/utils/port-polling-spec.js
@@ -34,7 +34,7 @@ describe('Unit: Utils > portPolling', function () {
             socketStub.destroy = sinon.stub();
 
             netStub.listen = sinon.stub();
-            netStub.close = sinon.stub().callsFake((cb)=> {
+            netStub.close = sinon.stub().callsFake((cb) => {
                 cb();
             });
 
@@ -75,7 +75,7 @@ describe('Unit: Utils > portPolling', function () {
             socketStub.destroy = sinon.stub();
 
             netStub.listen = sinon.stub();
-            netStub.close = sinon.stub().callsFake((cb)=> {
+            netStub.close = sinon.stub().callsFake((cb) => {
                 cb();
             });
 
@@ -112,13 +112,11 @@ describe('Unit: Utils > portPolling', function () {
             socketStub.destroy = sinon.stub();
 
             netStub.listen = sinon.stub();
-            netStub.close = sinon.stub().callsFake((cb)=> {
+            netStub.close = sinon.stub().callsFake((cb) => {
                 cb();
             });
 
-            sinon.stub(net, 'createServer').callsFake(() => {
-                return netStub;
-            });
+            sinon.stub(net, 'createServer').callsFake(() => netStub);
 
             return portPolling({
                 netServerTimeoutInMS: 500,
@@ -145,7 +143,7 @@ describe('Unit: Utils > portPolling', function () {
             socketStub.destroy = sinon.stub();
 
             netStub.listen = sinon.stub();
-            netStub.close = sinon.stub().callsFake((cb)=> {
+            netStub.close = sinon.stub().callsFake((cb) => {
                 cb();
             });
 

--- a/test/unit/utils/update-check-spec.js
+++ b/test/unit/utils/update-check-spec.js
@@ -11,7 +11,7 @@ describe('Unit: Utils > update-check', function () {
         const pkg = {name: 'ghost', version: '1.0.0'};
         const testError = new Error('update check');
         const latestVersion = sinon.stub().rejects(testError);
-        const ui = {run: sinon.stub().callsFake(fn => fn())}
+        const ui = {run: sinon.stub().callsFake(fn => fn())};
 
         const updateCheck = proxyquire(modulePath, {
             '../../package.json': pkg,
@@ -64,7 +64,6 @@ describe('Unit: Utils > update-check', function () {
         return updateCheck(ui).then(() => {
             expect(ui.run.calledOnce).to.be.true;
             expect(ui.log.calledOnce).to.be.true;
-
 
             const log = ui.log.args[0][0];
 

--- a/test/unit/utils/version-from-zip-spec.js
+++ b/test/unit/utils/version-from-zip-spec.js
@@ -82,7 +82,7 @@ describe('Unit: Utils > versionFromZip', function () {
 
         return versionFromZip(path.join(__dirname, '../../fixtures/ghost-2.0-rc.2.zip'), '2.0.0').then(() => {
             expect(false, 'error should have been thrown').to.be.true;
-        }).catch(error => {
+        }).catch((error) => {
             expect(error.message).to.equal('No valid versions found.');
         });
     });
@@ -96,7 +96,7 @@ describe('Unit: Utils > versionFromZip', function () {
 
         return versionFromZip(path.join(__dirname, '../../fixtures/ghost-2.0-rc.2.zip'), '2.0.0-rc.3').then(() => {
             expect(false, 'error should have been thrown').to.be.true;
-        }).catch(error => {
+        }).catch((error) => {
             expect(error.message).to.equal('No valid versions found.');
         });
     });
@@ -180,9 +180,7 @@ describe('Unit: Utils > versionFromZip', function () {
 
         return versionFromZip(path.join(__dirname, '../../fixtures/ghost-invalid-node.zip')).then((version) => {
             expect(version).to.equal('1.0.0');
-        }).catch((error) => {
-            return Promise.reject(error);
-        });
+        }).catch(error => Promise.reject(error));
     });
 
     it('rejects if a CLI version is specified in package.json and is not compatible with the current CLI version', function () {

--- a/test/unit/utils/yarn-spec.js
+++ b/test/unit/utils/yarn-spec.js
@@ -85,7 +85,7 @@ describe('Unit: yarn', function () {
             expect(error).to.be.ok;
             expect(error).to.be.instanceOf(ProcessError);
         });
-    })
+    });
 
     describe('can return observables', function () {
         let stubs;
@@ -125,7 +125,7 @@ describe('Unit: yarn', function () {
                 execa: execa,
                 rxjs: {Observable: TestClass}
             });
-        })
+        });
 
         it('ends properly', function () {
             const res = yarn([], {observe: true});
@@ -170,7 +170,7 @@ describe('Unit: yarn', function () {
             onFn('\nbest\n');
             onFn('run');
 
-            const next = stubs.observer.next
+            const next = stubs.observer.next;
             expect(next.callCount).to.equal(4);
             expect(next.args[0][0]).to.equal('\n\n');
             expect(next.args[1][0]).to.equal('test');
@@ -187,7 +187,7 @@ describe('Unit: yarn', function () {
             }).catch((e) => {
                 expect(e).to.be.ok;
                 expect(e).to.be.instanceOf(ProcessError);
-            })
+            });
         });
     });
 });

--- a/test/utils/acceptance-test.js
+++ b/test/utils/acceptance-test.js
@@ -121,7 +121,7 @@ module.exports = class AcceptanceTest {
                 const chunk = d.toString();
 
                 if (options.stdin) {
-                    const stdin = find(options.stdin, (obj) => obj.when.test(chunk));
+                    const stdin = find(options.stdin, obj => obj.when.test(chunk));
 
                     if (stdin) {
                         this.spawnedCommand.stdin.write(`${stdin.write}\n`);
@@ -162,7 +162,7 @@ module.exports = class AcceptanceTest {
                     process.removeListener('exit', cleanup);
                     this.cleanup();
                     const error = new Error(`'${this.command}' printed to stderr with failOnStderr enabled:\n`);
-                    error.message += `cwd: ${this.dir} \nstdout: ${stdoutBuffer} \nstderr: ${stderrBuffer};`
+                    error.message += `cwd: ${this.dir} \nstdout: ${stdoutBuffer} \nstderr: ${stderrBuffer};`;
                     reject(error);
                 }
                 const passed = options.checkOutput(stdoutBuffer, stderrBuffer, this.dir);
@@ -181,7 +181,7 @@ module.exports = class AcceptanceTest {
                 this.cleanup();
                 let message = `Timeout of ${(timeout / 1000) / 60} minutes exceeded for spawned command: ${this.command}\n`;
 
-                message += `stdout: ${stdoutBuffer} \nstderr: ${stderrBuffer}`
+                message += `stdout: ${stdoutBuffer} \nstderr: ${stderrBuffer}`;
                 reject(new Error(message));
             }, timeout);
         });
@@ -195,4 +195,4 @@ module.exports = class AcceptanceTest {
         clearInterval(this.pollOutput);
         clearTimeout(this.fallbackTimeout);
     }
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,13 +119,23 @@ abbrev@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
 acorn-jsx@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
   dependencies:
     acorn "^5.0.3"
 
-acorn@^5.0.3, acorn@^5.6.0:
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+acorn@^5.0.3, acorn@^5.5.0, acorn@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
@@ -140,11 +150,15 @@ aggregate-error@^1.0.0:
     clean-stack "^1.0.0"
     indent-string "^3.0.0"
 
+ajv-keywords@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
+
 ajv-keywords@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
-ajv@^5.3.0:
+ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -306,7 +320,7 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
-babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -703,7 +717,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.10:
+concat-stream@^1.4.10, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -900,7 +914,7 @@ cross-spawn@^4:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1173,6 +1187,10 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
+ember-rfc176-data@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.3.tgz#27fba08d540a7463a4366c48eaa19c5a44971a39"
+
 end-of-stream@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -1206,6 +1224,33 @@ es-to-primitive@^1.1.1:
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+eslint-plugin-ember@^5.0.3:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-5.2.0.tgz#fa436e0497dfc01d1d38608229cd616e7c5b6067"
+  dependencies:
+    ember-rfc176-data "^0.3.3"
+    snake-case "^2.1.0"
+
+eslint-plugin-ghost@0.0.26:
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ghost/-/eslint-plugin-ghost-0.0.26.tgz#0f37a4deb7157a33c1c9284b1e944d03c7bb7693"
+  dependencies:
+    eslint-plugin-ember "^5.0.3"
+    eslint-plugin-sort-imports-es6-autofix "0.2.2"
+
+eslint-plugin-sort-imports-es6-autofix@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.2.2.tgz#6d8512bde75142c188a0695db55d442d7f7e011d"
+  dependencies:
+    eslint "^4.15.0"
+
+eslint-scope@^3.7.1:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0:
   version "4.0.0"
@@ -1266,6 +1311,56 @@ eslint@5.3.0:
     table "^4.0.3"
     text-table "^0.2.0"
 
+eslint@^4.15.0:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
+
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  dependencies:
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
 espree@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
@@ -1277,7 +1372,7 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
-esquery@^1.0.1:
+esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
@@ -1393,7 +1488,7 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
-external-editor@^2.1.0:
+external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
   dependencies:
@@ -1766,7 +1861,7 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.0.1, globals@^11.1.0, globals@^11.7.0:
   version "11.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
@@ -1939,6 +2034,10 @@ ieee754@^1.1.4:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
 
+ignore@^3.3.3:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
 ignore@^4.0.2:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -1986,6 +2085,25 @@ inquirer@6.1.0:
     mute-stream "0.0.7"
     run-async "^2.2.0"
     rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^3.0.6:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -2183,7 +2301,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-resolvable@^1.1.0:
+is-resolvable@^1.0.0, is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
@@ -2317,7 +2435,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.11.0:
+js-yaml@^3.11.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -2604,6 +2722,10 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+
 lowercase-keys@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
@@ -2734,7 +2856,7 @@ mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
 
-minimatch@3.0.4, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -2875,6 +2997,12 @@ nise@^1.4.2:
     lolex "^2.3.2"
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
+
+no-case@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  dependencies:
+    lower-case "^1.1.1"
 
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
   version "2.4.0"
@@ -3439,6 +3567,10 @@ regexp.prototype.flags@^1.2.0:
   dependencies:
     define-properties "^1.1.2"
 
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
 regexpp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.0.tgz#b2a7534a85ca1b033bcf5ce9ff8e56d4e0755365"
@@ -3591,6 +3723,16 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
 rxjs@5.5.11, rxjs@^5.5.2:
   version "5.5.11"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
@@ -3634,6 +3776,10 @@ seek-bzip@^1.0.5:
 "semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.1.0, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^5.3.0:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -3712,6 +3858,12 @@ slice-ansi@1.0.0:
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+snake-case@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"
+  dependencies:
+    no-case "^2.2.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4003,6 +4155,17 @@ systeminformation@3.42.9:
   version "3.42.9"
   resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-3.42.9.tgz#1e1d187829da711e06597010252965d02dd520ff"
 
+table@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+  dependencies:
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
 table@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
@@ -4063,7 +4226,7 @@ text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
 
-text-table@^0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 


### PR DESCRIPTION
no issue
- switch to eslint-plugin-ghost for linting rules
- fix issues from changing lint rules

@kirrg001 @AileenCGN @ErisDS wasn't sure if eslint-plugin-ghost was ready for use here or not...but since Ghost-Admin was using it I thought i'd go ahead and align Ghost-CLI's linting config with that one.