### PR TITLE
[HOLD] feat(stack): add support for ubuntu 18

### DIFF
--- a/lib/commands/doctor/checks/system-stack.js
+++ b/lib/commands/doctor/checks/system-stack.js
@@ -14,10 +14,10 @@ function systemStack(ctx, task) {
     } else {
         // TODO: refactor to use ctx.system.operatingSystem
         promise = execa.shell('lsb_release -a').catch(
-            () => Promise.reject({message: 'Linux version is not Ubuntu 16'})
+            () => Promise.reject({message: 'Linux version is not Ubuntu 16 or 18'})
         ).then((result) => {
-            if (!result.stdout || !result.stdout.match(/Ubuntu 16/)) {
-                return Promise.reject({message: 'Linux version is not Ubuntu 16'});
+            if (!result.stdout || !result.stdout.match(/Ubuntu (?:16|18)/)) {
+                return Promise.reject({message: 'Linux version is not Ubuntu 16 or 18'});
             }
 
             return ctx.ui.listr([{

--- a/test/unit/commands/doctor/checks/system-stack-spec.js
+++ b/test/unit/commands/doctor/checks/system-stack-spec.js
@@ -87,7 +87,7 @@ describe('Unit: Doctor Checks > systemStack', function () {
             expect(false, 'error should have been thrown').to.be.true;
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.SystemError);
-            expect(error.message).to.equal('System stack checks failed with message: \'Linux version is not Ubuntu 16\'');
+            expect(error.message).to.equal('System stack checks failed with message: \'Linux version is not Ubuntu 16 or 18\'');
             expect(execaStub.calledOnce).to.be.true;
             expect(logStub.calledOnce).to.be.true;
             expect(logStub.args[0][0]).to.match(/failed with message/);
@@ -110,7 +110,7 @@ describe('Unit: Doctor Checks > systemStack', function () {
             expect(false, 'error should have been thrown').to.be.true;
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.SystemError);
-            expect(error.message).to.equal('System stack checks failed with message: \'Linux version is not Ubuntu 16\'');
+            expect(error.message).to.equal('System stack checks failed with message: \'Linux version is not Ubuntu 16 or 18\'');
             expect(execaStub.calledOnce).to.be.true;
             expect(logStub.calledOnce).to.be.true;
             expect(logStub.args[0][0]).to.match(/failed with message/);
@@ -205,6 +205,26 @@ describe('Unit: Doctor Checks > systemStack', function () {
         const confirmStub = sinon.stub().resolves(false);
 
         execaStub.withArgs('lsb_release -a').resolves({stdout: 'Ubuntu 16'});
+        const listrStub = sinon.stub().resolves();
+
+        const ctx = {
+            ui: {log: logStub, confirm: confirmStub, listr: listrStub, allowPrompt: true},
+            system: {platform: {linux: true}}
+        };
+
+        return systemStack.task(ctx).then(() => {
+            expect(listrStub.calledOnce).to.be.true;
+            expect(logStub.called).to.be.false;
+            expect(confirmStub.called).to.be.false;
+        });
+    });
+
+    it('resolves if all stack conditions are met (ubuntu 18)', function () {
+        const execaStub = sinon.stub(execa, 'shell');
+        const logStub = sinon.stub();
+        const confirmStub = sinon.stub().resolves(false);
+
+        execaStub.withArgs('lsb_release -a').resolves({stdout: 'Ubuntu 18'});
         const listrStub = sinon.stub().resolves();
 
         const ctx = {


### PR DESCRIPTION
closes #794
- update system-stack check to account for ubuntu 18

this implements the basic code changes for ubuntu 18 - need to do manual testing to ensure nothing else is needed.