### PR TITLE
"clone-theme" command to help developers to get started with themes 

### DIFF
--- a/lib/commands/clone-theme.js
+++ b/lib/commands/clone-theme.js
@@ -1,0 +1,87 @@
+'use strict';
+const Command = require('../command');
+
+class CloneTheme extends Command {
+    run(argv) {
+        const decompress = require('decompress');
+        const download = require('download');
+        const fs = require('fs-extra');
+        const path = require('path');
+        const slugify = require('slugify');
+
+        const currentPath = process.cwd();
+        const temporalZipFilename = Math.random().toString(36).substr(2, 9) + '.zip';
+        const friendlyThemeName = slugify(argv.name);
+
+        // Consider current path as "themes" folder, overide if needed
+        // with the logic in the next conditions
+        let workingPath = currentPath;
+        if (currentPath.endsWith('/content')) { // If working path is ghost/content folder
+            workingPath = path.join(currentPath, '/themes');
+        } else if (fs.existsSync(path.join(currentPath, '/content/themes'))) { // If working path is ghost root folder
+            workingPath = path.join(currentPath, '/content/themes');
+        }
+
+        const themePath = path.join(workingPath, friendlyThemeName);
+
+        // Check if directory exists
+        if (fs.existsSync(themePath)) {
+            // Check if there are existing files that *aren't* ghost-cli debug log files
+            const filesInDir = fs.readdirSync(themePath);
+
+            // If so then return an error
+            if (filesInDir.length) {
+                this.ui.log('ERROR: Target directory is not empty, the new theme cannot be installed in the desired path.', 'red');
+
+                process.exit(1);
+            }
+        }
+
+        this.ui.log('Downloading base theme, this may take some time...', 'green');
+
+        return download(argv.source, workingPath, {filename: temporalZipFilename})
+            .then(() => {
+                this.ui.log('"Unziping" base theme...', 'green');
+
+                return decompress(temporalZipFilename, friendlyThemeName, {strip: 1});
+            }).then(() => {
+                const packageJsonFile = path.join(themePath, '/package.json');
+                let packageJsonConfig = require(packageJsonFile);
+
+                packageJsonConfig.name = friendlyThemeName;
+                packageJsonConfig.version = '0.0.1';
+                fs.writeFileSync(packageJsonFile, JSON.stringify(packageJsonConfig, null, '    '), (err) => {
+                    if (err) throw err;
+                });
+
+                this.ui.log('All set, happy coding!', 'green');
+            }).catch((error) => {
+                this.ui.log(error, 'red');
+            }).then(() => {
+                if (fs.existsSync(path.join(workingPath, temporalZipFilename))) {
+                    fs.unlink(path.join(workingPath, temporalZipFilename));
+                }
+
+                process.exit(1);
+            });
+    }
+}
+
+CloneTheme.global = true;
+CloneTheme.description = 'Clones a theme so you to get started and modify or create your own Ghost theme from other';
+CloneTheme.options = {
+    name: {
+        alias: 'n',
+        description: 'Desired name for your new theme',
+        required: true,
+        type: 'string'
+    },
+    source: {
+        alias: 's',
+        default: 'https://github.com/TryGhost/Casper/archive/master.zip',
+        description: 'URL (must be a .zip file) to pull the base theme from',
+        type: 'string'
+    },
+};
+
+module.exports = CloneTheme;

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "rxjs": "5.5.11",
     "semver": "5.5.0",
     "shasum": "1.0.2",
+    "slugify": "^1.3.1",
     "stat-mode": "0.2.2",
     "strip-ansi": "4.0.0",
     "symlink-or-copy": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3859,6 +3859,10 @@ slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
+slugify@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.1.tgz#f572127e8535329fbc6c1edb74ab856b61ad7de2"
+
 snake-case@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"


### PR DESCRIPTION
So I wanted to get started building some themes, but I figured out I've to build "a skeleton" by my own.

Well, later I came with the idea to "**create a skeleton theme**" (which will contain ALL the minimal files required, which are around 3 files and 2 folders) to build a Ghost theme. However, later I figured out that this command was to "pull my basic theme" and just decompress it into the local folder so anyone can get started with it.

Starting from there, I figured out I could improve the command a little bit to actually use ANY available theme as "base" for your own theme. This is how `clone-theme` was created, and its main purpose is to allow theme-developers to spin up a skeleton quickly to build their own theme from there.

This command has some "tweaks" implemented, like detect if you're inside the root of your ghost installation, or maybe inside the "content" or "content/themes" folder, if so then the ghost/content/themes is the place where this script is going to install the theme for you. For other scenarios, `clone-theme` is going to install the cloned theme whenever you run this command.

My goal is to build some basic re-usable base templates like a plain very minimalist (just 100% required files) theme, a bootstrap 4 based one and more.

### The currently supported parameters are:

- **name** | **n**: The name of the theme.
- **source** | **s**: The URL to the .ZIP file where your base theme is. The default value is the URL Casper theme (https://github.com/TryGhost/Casper/archive/master.zip).

### Your feedback is gold to me!

If you have any feedback on this please let me know, any sort of improvement I could make on this will help me to get involved with the Ghost community and improve the quality of the code I contribute to you guys.

## To-Dos:

- tests (once I get the feature approved by the core team I'll start working with the tests).
- anything else?
