### PR TITLE
fix(ui): make sudo prompt more clear

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -210,7 +210,7 @@ class UI {
                 this.prompt({
                     type: 'password',
                     name: 'password',
-                    message: 'Password'
+                    message: 'Sudo Password'
                 }).then((answers) => {
                     cp.stdin.write(`${answers.password}\n`);
                 });


### PR DESCRIPTION
closes #797
- say "Sudo Password" instead of "Password" to be more clear