### PR TITLE
cleanup: convert cliConfig usage to get/set usage

### DIFF
--- a/extensions/systemd/index.js
+++ b/extensions/systemd/index.js
@@ -29,7 +29,7 @@ class SystemdExtension extends Extension {
 
         const serviceFilename = `ghost_${instance.name}.service`;
 
-        if (instance.cliConfig.get('extension.systemd', false) || fs.existsSync(path.join('/lib/systemd/system', serviceFilename))) {
+        if (fs.existsSync(path.join('/lib/systemd/system', serviceFilename))) {
             this.ui.log('Systemd service has already been set up. Skipping Systemd setup');
             return task.skip();
         }

--- a/extensions/systemd/test/extension-spec.js
+++ b/extensions/systemd/test/extension-spec.js
@@ -72,29 +72,6 @@ describe('Unit: Systemd > Extension', function () {
             expect(skipStub.calledOnce).to.be.true;
         });
 
-        it('skips stage if "extension.systemd" property in cliConfig is true', function () {
-            const uidStub = sinon.stub().returns(true);
-
-            const SystemdExtension = proxyquire(modulePath, {
-                './get-uid': uidStub
-            });
-
-            const logStub = sinon.stub();
-            const skipStub = sinon.stub();
-            const getStub = sinon.stub().returns(true);
-            const testInstance = new SystemdExtension({log: logStub}, {}, {}, path.join(__dirname, '..'));
-            const instance = {dir: '/some/dir', cliConfig: {get: getStub}};
-
-            testInstance._setup({}, {instance: instance}, {skip: skipStub});
-            expect(uidStub.calledOnce).to.be.true;
-            expect(uidStub.calledWithExactly('/some/dir')).to.be.true;
-            expect(getStub.calledOnce).to.be.true;
-            expect(getStub.calledWithExactly('extension.systemd', false)).to.be.true;
-            expect(logStub.calledOnce).to.be.true;
-            expect(logStub.args[0][0]).to.match(/Systemd service has already been set up/);
-            expect(skipStub.calledOnce).to.be.true;
-        });
-
         it('skips stage if systemd file already exists', function () {
             const uidStub = sinon.stub().returns(true);
             const existsStub = sinon.stub().returns(true);
@@ -106,14 +83,12 @@ describe('Unit: Systemd > Extension', function () {
 
             const logStub = sinon.stub();
             const skipStub = sinon.stub();
-            const getStub = sinon.stub().returns(false);
             const testInstance = new SystemdExtension({log: logStub}, {}, {}, path.join(__dirname, '..'));
-            const instance = {dir: '/some/dir', cliConfig: {get: getStub}, name: 'test'};
+            const instance = {dir: '/some/dir', name: 'test'};
 
             testInstance._setup({}, {instance: instance}, {skip: skipStub});
             expect(uidStub.calledOnce).to.be.true;
             expect(uidStub.calledWithExactly('/some/dir')).to.be.true;
-            expect(getStub.calledOnce).to.be.true;
             expect(existsStub.calledOnce).to.be.true;
             expect(existsStub.calledWithExactly('/lib/systemd/system/ghost_test.service')).to.be.true;
             expect(logStub.calledOnce).to.be.true;
@@ -134,15 +109,13 @@ describe('Unit: Systemd > Extension', function () {
             const logStub = sinon.stub();
             const sudoStub = sinon.stub().resolves();
             const skipStub = sinon.stub();
-            const getStub = sinon.stub().returns(false);
             const testInstance = new SystemdExtension({log: logStub, sudo: sudoStub}, {}, {}, path.join(__dirname, '..'));
-            const instance = {dir: '/some/dir', cliConfig: {get: getStub}, name: 'test'};
+            const instance = {dir: '/some/dir', name: 'test'};
             const templateStub = sinon.stub(testInstance, 'template').resolves();
 
             return testInstance._setup({}, {instance: instance}, {skip: skipStub}).then(() => {
                 expect(uidStub.calledOnce).to.be.true;
                 expect(uidStub.calledWithExactly('/some/dir')).to.be.true;
-                expect(getStub.calledOnce).to.be.true;
                 expect(existsStub.calledOnce).to.be.true;
                 expect(readFileSyncStub.calledOnce).to.be.true;
                 expect(templateStub.calledOnce).to.be.true;
@@ -167,10 +140,9 @@ describe('Unit: Systemd > Extension', function () {
             const logStub = sinon.stub();
             const sudoStub = sinon.stub().rejects({stderr: 'something went wrong'});
             const skipStub = sinon.stub();
-            const getStub = sinon.stub().returns(false);
             const testInstance = new SystemdExtension({log: logStub, sudo: sudoStub}, {}, {}, path.join(__dirname, '..'));
             const templateStub = sinon.stub(testInstance, 'template').resolves();
-            const instance = {dir: '/some/dir', cliConfig: {get: getStub}, name: 'test'};
+            const instance = {dir: '/some/dir', name: 'test'};
 
             return testInstance._setup({}, {instance: instance}, {skip: skipStub}).then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
@@ -180,7 +152,6 @@ describe('Unit: Systemd > Extension', function () {
                 expect(error.options.stderr).to.be.equal('something went wrong');
                 expect(uidStub.calledOnce).to.be.true;
                 expect(uidStub.calledWithExactly('/some/dir')).to.be.true;
-                expect(getStub.calledOnce).to.be.true;
                 expect(existsStub.calledOnce).to.be.true;
                 expect(readFileSyncStub.calledOnce).to.be.true;
                 expect(templateStub.calledOnce).to.be.true;

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -102,12 +102,10 @@ class InstallCommand extends Command {
     link(ctx) {
         symlinkSync(ctx.installPath, path.join(process.cwd(), 'current'));
 
-        // Make sure we save the current cli version to the config
-        // also - this ensures the config exists so the config command
-        // doesn't throw errors
-        this.system.getInstance().cliConfig
-            .set('cli-version', this.system.cliVersion)
-            .set('active-version', ctx.version).save();
+        const instance = this.system.getInstance();
+
+        instance.version = ctx.version;
+        instance.cliVersion = this.system.cliVersion;
     }
 }
 

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -12,7 +12,7 @@ class MigrateCommand extends Command {
             'Checking for available migrations'
         ).then((extensionMigrations) => {
             const neededMigrations = parseNeededMigrations(
-                instance.cliConfig.get('cli-version'),
+                instance.cliVersion,
                 this.system.cliVersion,
                 extensionMigrations
             );
@@ -28,7 +28,7 @@ class MigrateCommand extends Command {
             return this.ui.listr(neededMigrations, {instance: instance});
         }).then(() => {
             // Update the cli version in the cli config file
-            instance.cliConfig.set('cli-version', this.system.cliVersion).save();
+            instance.cliVersion = this.system.cliVersion;
         });
     }
 }

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -175,7 +175,7 @@ class SetupCommand extends Command {
                     title: 'Running database migrations',
                     task: migrator.migrate,
                     // CASE: We are about to install Ghost 2.0. We moved the execution of knex-migrator into Ghost.
-                    enabled: () => semver.major(instance.cliConfig.get('active-version')) < 2
+                    enabled: () => semver.major(instance.version) < 2
                 });
             }
 

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -24,9 +24,9 @@ class UpdateCommand extends Command {
         const instance = this.system.getInstance();
 
         // If installed with a version < 1.0
-        if (semver.lt(instance.cliConfig.get('cli-version'), '1.0.0')) {
+        if (semver.lt(instance.cliVersion, '1.0.0')) {
             this.ui.log(
-                `Ghost was installed with Ghost-CLI v${instance.cliConfig.get('cli-version')}, which is a pre-release version.\n` +
+                `Ghost was installed with Ghost-CLI v${instance.cliVersion}, which is a pre-release version.\n` +
                 'Your Ghost install is using out-of-date configuration & requires manual changes.\n' +
                 `Please visit ${chalk.blue.underline('https://docs.ghost.org/v1/docs/how-to-upgrade-ghost#section-upgrading-ghost-cli')}\n` +
                 'for instructions on how to upgrade your instance.\n',
@@ -39,19 +39,19 @@ class UpdateCommand extends Command {
         const context = {
             instance,
             force,
-            activeVersion: instance.cliConfig.get('active-version'),
+            activeVersion: instance.version,
             version,
             zip,
             v1
         };
 
         if (argv.rollback) {
-            if (!instance.cliConfig.get('previous-version')) {
+            if (!instance.previousVersion) {
                 return Promise.reject(new Error('No previous version found'));
             }
 
             context.rollback = true;
-            context.version = instance.cliConfig.get('previous-version');
+            context.version = instance.previousVersion;
             context.installPath = path.join(process.cwd(), 'versions', context.version);
         }
 
@@ -72,7 +72,7 @@ class UpdateCommand extends Command {
                 task: majorUpdate,
                 // CASE: Skip if you are already on ^2 or you update from v1 to v1.
                 enabled: () => {
-                    if (semver.major(instance.cliConfig.get('active-version')) === 2 ||
+                    if (semver.major(instance.version) === 2 ||
                         semver.major(context.version) === 1) {
                         return false;
                     }
@@ -98,7 +98,7 @@ class UpdateCommand extends Command {
                 //       If you are already on v2 or you update from v1 to v2, then skip the task.
                 //       We compare the major versions, otherwise pre-releases won't match.
                 enabled: () => {
-                    if (semver.major(instance.cliConfig.get('active-version')) === 2 ||
+                    if (semver.major(instance.version) === 2 ||
                         semver.major(context.version) === 2) {
                         return false;
                     }
@@ -219,7 +219,7 @@ class UpdateCommand extends Command {
     }
 
     rollbackFromFail(error, newVer, force = false) {
-        const oldVer = this.system.getInstance().cliConfig.get('previous-version');
+        const oldVer = this.system.getInstance().previousVersion;
         const question = `Unable to upgrade Ghost from v${oldVer} to v${newVer}. Would you like to revert back to v${oldVer}?`;
 
         this.ui.error(error, this.system);
@@ -244,14 +244,14 @@ class UpdateCommand extends Command {
         });
     }
 
-    link(context) {
+    link({instance, installPath, version, rollback}) {
         const symlinkSync = require('symlink-or-copy').sync;
 
         fs.removeSync(path.join(process.cwd(), 'current'));
-        symlinkSync(context.installPath, path.join(process.cwd(), 'current'));
+        symlinkSync(installPath, path.join(process.cwd(), 'current'));
 
-        context.instance.cliConfig.set('previous-version', context.rollback ? null : context.instance.cliConfig.get('active-version'))
-            .set('active-version', context.version).save();
+        instance.previousVersion = rollback ? null : instance.version;
+        instance.version = version;
     }
 }
 

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -11,9 +11,9 @@ class VersionCommand extends Command {
 
         const instance = this.system.getInstance();
         // This will be false if we're not in a Ghost instance folder
-        if (instance.cliConfig.has('active-version')) {
+        if (instance.version) {
             const dir = chalk.gray(`(at ${instance.dir.replace(os.homedir(), '~')})`);
-            this.ui.log(`Ghost version: ${chalk.cyan(instance.cliConfig.get('active-version'))} ${dir}`);
+            this.ui.log(`Ghost version: ${chalk.cyan(instance.version)} ${dir}`);
         }
     }
 }

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -11,22 +11,6 @@ const Config = require('./utils/config');
  */
 class Instance {
     /**
-     * Local instance config (.ghost-cli)
-     * Contains some instance-specific variables
-     *
-     * @property
-     * @type Config
-     * @public
-     */
-    get cliConfig() {
-        if (!this._cliConfig) {
-            this._cliConfig = new Config(path.join(this.dir, '.ghost-cli'));
-        }
-
-        return this._cliConfig;
-    }
-
-    /**
      * Process name (makes the instance identifiable on the system)
      *
      * @property name
@@ -34,10 +18,10 @@ class Instance {
      * @public
      */
     get name() {
-        return this.cliConfig.get('name') || this.config.get('pname');
+        return this._cliConfig.get('name') || this.config.get('pname');
     }
     set name(value) {
-        this.cliConfig.set('name', value).save();
+        this._cliConfig.set('name', value).save();
         return true;
     }
 
@@ -79,6 +63,51 @@ class Instance {
     }
 
     /**
+     * Instance version
+     *
+     * @property version
+     * @type string
+     * @public
+     */
+    get version() {
+        return this._cliConfig.get('active-version', null);
+    }
+    set version(value) {
+        this._cliConfig.set('active-version', value).save();
+        return true;
+    }
+
+    /**
+     * Version of Ghost-CLI the instance was created/migrated with
+     *
+     * @property cliVersion
+     * @type string
+     * @public
+     */
+    get cliVersion() {
+        return this._cliConfig.get('cli-version', null);
+    }
+    set cliVersion(value) {
+        this._cliConfig.set('cli-version', value).save();
+        return true;
+    }
+
+    /**
+     * Previously running version of the instance
+     *
+     * @property previousVersion
+     * @type string
+     * @public
+     */
+    get previousVersion() {
+        return this._cliConfig.get('previous-version', null);
+    }
+    set previousVersion(value) {
+        this._cliConfig.set('previous-version', value).save();
+        return true;
+    }
+
+    /**
      * Constructs the instance
      *
      * @param {UI} ui UI instance
@@ -89,6 +118,8 @@ class Instance {
         this.ui = ui;
         this.system = system;
         this.dir = dir;
+
+        this._cliConfig = new Config(path.join(this.dir, '.ghost-cli'));
     }
 
     /**
@@ -104,11 +135,11 @@ class Instance {
     running(environment) {
         if (environment !== undefined) {
             // setter
-            this.cliConfig.set('running', environment).save();
+            this._cliConfig.set('running', environment).save();
             return Promise.resolve(true);
         }
 
-        if (!this.cliConfig.has('running')) {
+        if (!this._cliConfig.has('running')) {
             const currentEnvironment = this.system.development;
 
             const envIsRunning = (environment) => {
@@ -119,7 +150,7 @@ class Instance {
                 this.system.setEnvironment(environment === 'development');
                 return Promise.resolve(this.process.isRunning(this.dir)).then((running) => {
                     if (running) {
-                        this.cliConfig.set('running', environment).save();
+                        this._cliConfig.set('running', environment).save();
                     }
 
                     return running;
@@ -148,7 +179,7 @@ class Instance {
 
         return Promise.resolve(this.process.isRunning(this.dir)).then((running) => {
             if (!running) {
-                this.cliConfig.set('running', null).save();
+                this._cliConfig.set('running', null).save();
             }
 
             return running;
@@ -187,7 +218,7 @@ class Instance {
      * @public
      */
     loadRunningEnvironment(setNodeEnv) {
-        const env = this.cliConfig.get('running');
+        const env = this._cliConfig.get('running');
 
         if (!env) {
             throw new Error('This instance is not running.');
@@ -210,7 +241,7 @@ class Instance {
                 return {
                     name: this.name,
                     dir: this.dir.replace(os.homedir(), '~'),
-                    version: this.cliConfig.get('active-version'),
+                    version: this.version,
                     running: false
                 };
             }
@@ -219,7 +250,7 @@ class Instance {
                 name: this.name,
                 dir: this.dir.replace(os.homedir(), '~'),
                 running: true,
-                version: this.cliConfig.get('active-version'),
+                version: this.version,
                 mode: this.system.environment,
                 url: this.config.get('url'),
                 port: this.config.get('server.port'),

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -76,7 +76,7 @@ class ProcessManager {
             stopOnError: true,
             port: this.instance.config.get('server.port'),
             host: this.instance.config.get('server.host', 'localhost'),
-            useNetServer: semver.major(this.instance.cliConfig.get('active-version')) === 2
+            useNetServer: semver.major(this.instance.version) === 2
         }, options || {});
 
         return portPolling(options).catch((err) => {

--- a/lib/tasks/migrator.js
+++ b/lib/tasks/migrator.js
@@ -76,7 +76,7 @@ module.exports.migrate = function runMigrations(context) {
 };
 
 module.exports.rollback = function runRollback(context) {
-    const {dir} = context.instance;
+    const {dir, version, previousVersion} = context.instance;
     const semver = require('semver');
 
     const contentDir = path.join(dir, 'content');
@@ -85,8 +85,8 @@ module.exports.rollback = function runRollback(context) {
 
     // Ghost 2.0.0 uses the new knex-migrator version. We have to ensure you can still use CLI 1.9 with an older blog, because
     // we haven't restricted a CLI version range in Ghost (we only used cli: > X.X.X)
-    if (semver.major(context.instance.cliConfig.get('active-version')) === 2) {
-        args = ['--force', '--v', context.instance.cliConfig.get('previous-version'), '--mgpath', currentDir];
+    if (semver.major(version) === 2) {
+        args = ['--force', '--v', previousVersion, '--mgpath', currentDir];
     } else {
         args = ['--force', '--mgpath', currentDir];
     }

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -255,14 +255,10 @@ describe('Unit: Commands > Install', function () {
     });
 
     describe('tasks > link', function () {
-        it('creates current link and updates cliConfig', function () {
+        it('creates current link and updates versions', function () {
             const symlinkSyncStub = sinon.stub();
-            const config = {
-                set: sinon.stub(),
-                save: sinon.stub()
-            };
-            config.set.returns(config);
-            const getInstanceStub = sinon.stub().returns({cliConfig: config});
+            const config = {};
+            const getInstanceStub = sinon.stub().returns(config);
 
             const InstallCommand = proxyquire(modulePath, {
                 'symlink-or-copy': {sync: symlinkSyncStub}
@@ -274,10 +270,10 @@ describe('Unit: Commands > Install', function () {
             expect(symlinkSyncStub.calledOnce).to.be.true;
             expect(symlinkSyncStub.calledWithExactly('/some/dir/1.5.0', path.join(process.cwd(), 'current')));
             expect(getInstanceStub.calledOnce).to.be.true;
-            expect(config.set.calledTwice).to.be.true;
-            expect(config.set.calledWithExactly('cli-version', '1.0.0')).to.be.true;
-            expect(config.set.calledWithExactly('active-version', '1.5.0')).to.be.true;
-            expect(config.save.calledOnce).to.be.true;
+            expect(config).to.deep.equal({
+                version: '1.5.0',
+                cliVersion: '1.0.0'
+            });
         });
     });
 });

--- a/test/unit/commands/migrate-spec.js
+++ b/test/unit/commands/migrate-spec.js
@@ -17,18 +17,14 @@ function build(migrations) {
         log: sinon.stub()
     };
 
-    const config = {
-        get: sinon.stub().returns('1.1.0'),
-        set: sinon.stub(),
-        save: sinon.stub()
+    const instance = {
+        cliVersion: '1.1.0'
     };
-
-    config.set.returns(config);
 
     const system = {
         cliVersion: '1.2.0',
         hook: sinon.stub().resolves(),
-        getInstance: sinon.stub().returns({cliConfig: config})
+        getInstance: sinon.stub().returns(instance)
     };
 
     const parseStub = sinon.stub().returns(migrations);
@@ -37,7 +33,7 @@ function build(migrations) {
 
     return {
         cmd: new Cmd(ui, system),
-        config: config,
+        instance,
         parse: parseStub
     };
 }
@@ -49,47 +45,41 @@ describe('Unit: Commands > Migrate', function () {
             task: () => {}
         }];
 
-        const built = build(migrations);
+        const {cmd, instance, parse} = build(migrations);
 
-        return built.cmd.run({}).then(() => {
-            expect(built.cmd.ui.run.calledOnce).to.be.true;
-            expect(built.cmd.system.hook.calledOnce).to.be.true;
-            expect(built.parse.calledOnce).to.be.true;
-            expect(built.cmd.ui.listr.calledOnce).to.be.true;
-            expect(built.cmd.ui.listr.calledWith(migrations)).to.be.true;
-            expect(built.config.get.calledOnce).to.be.true;
-            expect(built.config.set.calledOnce).to.be.true;
-            expect(built.config.set.calledWithExactly('cli-version', '1.2.0')).to.be.true;
+        return cmd.run({}).then(() => {
+            expect(cmd.ui.run.calledOnce).to.be.true;
+            expect(cmd.system.hook.calledOnce).to.be.true;
+            expect(parse.calledOnce).to.be.true;
+            expect(cmd.ui.listr.calledOnce).to.be.true;
+            expect(cmd.ui.listr.calledWith(migrations)).to.be.true;
+            expect(instance.cliVersion).to.equal('1.2.0');
         });
     });
 
     it('skips if no migrations', function () {
-        const built = build([]);
+        const {cmd, instance, parse} = build([]);
 
-        return built.cmd.run({}).then(() => {
-            expect(built.cmd.ui.run.calledOnce).to.be.true;
-            expect(built.cmd.system.hook.calledOnce).to.be.true;
-            expect(built.parse.calledOnce).to.be.true;
-            expect(built.cmd.ui.listr.calledOnce).to.be.false;
-            expect(built.cmd.ui.log.calledOnce).to.be.true;
-            expect(built.config.get.calledOnce).to.be.true;
-            expect(built.config.set.calledOnce).to.be.true;
-            expect(built.config.set.calledWithExactly('cli-version', '1.2.0')).to.be.true;
+        return cmd.run({}).then(() => {
+            expect(cmd.ui.run.calledOnce).to.be.true;
+            expect(cmd.system.hook.calledOnce).to.be.true;
+            expect(parse.calledOnce).to.be.true;
+            expect(cmd.ui.listr.calledOnce).to.be.false;
+            expect(cmd.ui.log.calledOnce).to.be.true;
+            expect(instance.cliVersion).to.equal('1.2.0');
         });
     });
 
     it('quiet supresses output', function () {
-        const built = build([]);
+        const {cmd, instance, parse} = build([]);
 
-        return built.cmd.run({quiet: true}).then(() => {
-            expect(built.cmd.ui.run.calledOnce).to.be.true;
-            expect(built.cmd.system.hook.calledOnce).to.be.true;
-            expect(built.parse.calledOnce).to.be.true;
-            expect(built.cmd.ui.listr.calledOnce).to.be.false;
-            expect(built.cmd.ui.log.calledOnce).to.be.false;
-            expect(built.config.get.calledOnce).to.be.true;
-            expect(built.config.set.calledOnce).to.be.true;
-            expect(built.config.set.calledWithExactly('cli-version', '1.2.0')).to.be.true;
+        return cmd.run({quiet: true}).then(() => {
+            expect(cmd.ui.run.calledOnce).to.be.true;
+            expect(cmd.system.hook.calledOnce).to.be.true;
+            expect(parse.calledOnce).to.be.true;
+            expect(cmd.ui.listr.calledOnce).to.be.false;
+            expect(cmd.ui.log.calledOnce).to.be.false;
+            expect(instance.cliVersion).to.equal('1.2.0');
         });
     });
 });

--- a/test/unit/commands/setup-spec.js
+++ b/test/unit/commands/setup-spec.js
@@ -240,9 +240,6 @@ describe('Unit: Commands > Setup', function () {
             const listr = sinon.stub();
             const aIstub = sinon.stub();
             const config = configStub();
-            const cliConfigStub = configStub();
-
-            cliConfigStub.get.withArgs('active-version').returns('2.0.0');
 
             config.get.withArgs('url').returns('https://ghost.org');
             config.has.returns(false);
@@ -253,7 +250,7 @@ describe('Unit: Commands > Setup', function () {
                     apples: true,
                     config,
                     dir: '/var/www/ghost',
-                    cliConfig: cliConfigStub
+                    version: '2.0.0'
                 }),
                 addInstance: aIstub,
                 hook: () => Promise.resolve()
@@ -288,9 +285,6 @@ describe('Unit: Commands > Setup', function () {
             const listr = sinon.stub().resolves();
             const aIstub = sinon.stub();
             const config = configStub();
-            const cliConfigStub = configStub();
-
-            cliConfigStub.get.withArgs('active-version').returns('1.25.0');
 
             config.get.withArgs('url').returns('https://ghost.org');
             config.has.returns(false);
@@ -301,7 +295,7 @@ describe('Unit: Commands > Setup', function () {
                     apples: true,
                     config,
                     dir: '/var/www/ghost',
-                    cliConfig: cliConfigStub
+                    version: '1.25.0'
                 }),
                 addInstance: aIstub,
                 hook: () => Promise.resolve()

--- a/test/unit/commands/version-spec.js
+++ b/test/unit/commands/version-spec.js
@@ -9,9 +9,8 @@ const modulePath = '../../../lib/commands/version';
 describe('Unit: Commands > Version', function () {
     it('only outputs ghost-cli version if not run in a ghost folder', function () {
         const VersionCommand = require(modulePath);
-        const hasStub = sinon.stub().returns(false);
         const logStub = sinon.stub();
-        const getInstanceStub = sinon.stub().returns({cliConfig: {has: hasStub}});
+        const getInstanceStub = sinon.stub().returns({version: null});
         const cliVersion = '1.0.0';
         const instance = new VersionCommand({log: logStub}, {getInstance: getInstanceStub, cliVersion: cliVersion});
 
@@ -19,15 +18,12 @@ describe('Unit: Commands > Version', function () {
         expect(logStub.calledOnce).to.be.true;
         expect(stripAnsi(logStub.args[0][0])).to.match(/Ghost-CLI version: 1\.0\.0/);
         expect(getInstanceStub.calledOnce).to.be.true;
-        expect(hasStub.calledOnce).to.be.true;
     });
 
     it('outputs both ghost-cli and ghost version if run in a ghost install folder', function () {
         const homedirStub = sinon.stub().returns('/var/www');
-        const hasStub = sinon.stub().returns(true);
-        const getStub = sinon.stub().returns('1.5.0');
         const logStub = sinon.stub();
-        const getInstanceStub = sinon.stub().returns({cliConfig: {has: hasStub, get: getStub}, dir: '/var/www/ghost'});
+        const getInstanceStub = sinon.stub().returns({version: '1.5.0', dir: '/var/www/ghost'});
         const cliVersion = '1.0.0';
         const VersionCommand = proxyquire(modulePath, {
             os: {homedir: homedirStub}
@@ -39,7 +35,5 @@ describe('Unit: Commands > Version', function () {
         expect(stripAnsi(logStub.args[0][0])).to.match(/Ghost-CLI version: 1\.0\.0/);
         expect(stripAnsi(logStub.args[1][0])).to.match(/Ghost version: 1\.5\.0 \(at ~\/ghost\)/);
         expect(getInstanceStub.calledOnce).to.be.true;
-        expect(hasStub.calledOnce).to.be.true;
-        expect(getStub.calledOnce).to.be.true;
     });
 });

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -29,13 +29,13 @@ describe('Unit: Process Manager', function () {
         it('returns true if class exists and implements all the right methods', function () {
             class TestProcess extends ProcessManager {
                 start() {
-                    return Promise.resolve(); 
+                    return Promise.resolve();
                 }
                 stop() {
-                    return Promise.resolve(); 
+                    return Promise.resolve();
                 }
                 isRunning() {
-                    return true; 
+                    return true;
                 }
             }
             const result = ProcessManager.isValid(TestProcess);
@@ -73,15 +73,13 @@ describe('Unit: Process Manager', function () {
         });
 
         it('calls portPolling with options', function () {
-            const cliConfig = getConfigStub();
             const config = getConfigStub();
 
-            cliConfig.get.withArgs('active-version').returns('1.25.0');
             config.get.withArgs('server.port').returns(2368);
             config.get.withArgs('server.host').returns('10.0.1.0');
             portPollingStub.resolves();
 
-            const instance = new ProcessManager({}, {}, {config, cliConfig});
+            const instance = new ProcessManager({}, {}, {config, version: '1.25.0'});
             const stopStub = sinon.stub(instance, 'stop').resolves();
 
             return instance.ensureStarted({logSuggestion: 'test'}).then(() => {
@@ -99,15 +97,13 @@ describe('Unit: Process Manager', function () {
         });
 
         it('throws error without stopping if stopOnError is false', function () {
-            const cliConfig = getConfigStub();
             const config = getConfigStub();
 
-            cliConfig.get.withArgs('active-version').returns('1.25.0');
             config.get.withArgs('server.port').returns(2368);
             config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
-            const instance = new ProcessManager({}, {}, {config, cliConfig});
+            const instance = new ProcessManager({}, {}, {config, version: '1.25.0'});
             const stopStub = sinon.stub(instance, 'stop').resolves();
 
             return instance.ensureStarted({stopOnError: false}).then(() => {
@@ -126,15 +122,13 @@ describe('Unit: Process Manager', function () {
         });
 
         it('throws error and calls stop if stopOnError is true', function () {
-            const cliConfig = getConfigStub();
             const config = getConfigStub();
 
-            cliConfig.get.withArgs('active-version').returns('1.25.0');
             config.get.withArgs('server.port').returns(2368);
             config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
-            const instance = new ProcessManager({}, {}, {config, cliConfig});
+            const instance = new ProcessManager({}, {}, {config, version: '1.25.0'});
             const stopStub = sinon.stub(instance, 'stop').resolves();
 
             return instance.ensureStarted({}).then(() => {
@@ -154,15 +148,13 @@ describe('Unit: Process Manager', function () {
         });
 
         it('throws error and calls stop (swallows stop error) if stopOnError is true', function () {
-            const cliConfig = getConfigStub();
             const config = getConfigStub();
 
-            cliConfig.get.withArgs('active-version').returns('1.25.0');
             config.get.withArgs('server.port').returns(2368);
             config.get.withArgs('server.host').returns('localhost');
             portPollingStub.rejects(new Error('test error'));
 
-            const instance = new ProcessManager({}, {}, {config, cliConfig});
+            const instance = new ProcessManager({}, {}, {config, version: '1.25.0'});
             const stopStub = sinon.stub(instance, 'stop').rejects(new Error('test error 2'));
 
             return instance.ensureStarted().then(() => {

--- a/test/unit/tasks/migrator-spec.js
+++ b/test/unit/tasks/migrator-spec.js
@@ -158,13 +158,6 @@ describe('Unit: Tasks > Migrator', function () {
     });
 
     describe('rollback', function () {
-        let cliConfig;
-
-        beforeEach(function () {
-            cliConfig = configStub();
-            cliConfig.get.withArgs('active-version').returns('1.25.3');
-        });
-
         it('runs direct command if useGhostUser returns false', function () {
             const config = configStub();
             const execaStub = sinon.stub().resolves();
@@ -177,7 +170,7 @@ describe('Unit: Tasks > Migrator', function () {
 
             const sudoStub = sinon.stub().resolves();
 
-            return migrator.rollback({instance: {config, cliConfig, dir: '/some-dir'}, ui: {sudo: sudoStub}}).then(() => {
+            return migrator.rollback({instance: {config, version: '1.25.3', dir: '/some-dir'}, ui: {sudo: sudoStub}}).then(() => {
                 expect(useGhostUserStub.calledOnce).to.be.true;
                 expect(useGhostUserStub.args[0][0]).to.equal('/some-dir/content');
                 expect(execaStub.calledOnce).to.be.true;
@@ -189,7 +182,6 @@ describe('Unit: Tasks > Migrator', function () {
 
         it('forward version option to knex-migrator if blog jumps from v1 to v2', function () {
             const config = configStub();
-            const cliConfig = configStub();
             const execaStub = sinon.stub().resolves();
             const useGhostUserStub = sinon.stub().returns(false);
 
@@ -200,10 +192,7 @@ describe('Unit: Tasks > Migrator', function () {
 
             const sudoStub = sinon.stub().resolves();
 
-            cliConfig.get.withArgs('active-version').returns('2.0.0');
-            cliConfig.get.withArgs('previous-version').returns('1.25.3');
-
-            return migrator.rollback({instance: {config, cliConfig, dir: '/some-dir'}, ui: {sudo: sudoStub}}).then(() => {
+            return migrator.rollback({instance: {config, version: '2.0.0', previousVersion: '1.25.3', dir: '/some-dir'}, ui: {sudo: sudoStub}}).then(() => {
                 expect(useGhostUserStub.calledOnce).to.be.true;
                 expect(useGhostUserStub.args[0][0]).to.equal('/some-dir/content');
                 expect(execaStub.calledOnce).to.be.true;
@@ -225,7 +214,7 @@ describe('Unit: Tasks > Migrator', function () {
 
             const sudoStub = sinon.stub().resolves();
 
-            return migrator.rollback({instance: {config, cliConfig, dir: '/some-dir'}, ui: {sudo: sudoStub}}).then(() => {
+            return migrator.rollback({instance: {config, version: '1.25.3', dir: '/some-dir'}, ui: {sudo: sudoStub}}).then(() => {
                 expect(useGhostUserStub.calledOnce).to.be.true;
                 expect(useGhostUserStub.args[0][0]).to.equal('/some-dir/content');
                 expect(execaStub.calledOnce).to.be.false;
@@ -243,7 +232,7 @@ describe('Unit: Tasks > Migrator', function () {
                 '../utils/use-ghost-user': {shouldUseGhostUser: useGhostUserStub}
             });
 
-            return migrator.rollback({instance: {config, cliConfig, dir: '/some-dir', system: {environment: 'testing'}}}).then(() => {
+            return migrator.rollback({instance: {config, version: '1.25.3', dir: '/some-dir', system: {environment: 'testing'}}}).then(() => {
                 expect(false, 'error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.an.instanceof(errors.ConfigError);
@@ -261,7 +250,7 @@ describe('Unit: Tasks > Migrator', function () {
                 '../utils/use-ghost-user': {shouldUseGhostUser: useGhostUserStub}
             });
 
-            return migrator.rollback({instance: {config, cliConfig, dir: '/some-dir', system: {environment: 'testing'}}}).then(() => {
+            return migrator.rollback({instance: {config, version: '1.25.3', dir: '/some-dir', system: {environment: 'testing'}}}).then(() => {
                 expect(false, 'error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.an.instanceof(errors.ConfigError);
@@ -279,7 +268,7 @@ describe('Unit: Tasks > Migrator', function () {
                 '../utils/use-ghost-user': {shouldUseGhostUser: useGhostUserStub}
             });
 
-            return migrator.rollback({instance: {config, cliConfig, dir: '/some-dir', system: {environment: 'testing'}}}).then(() => {
+            return migrator.rollback({instance: {config, version: '1.25.3', dir: '/some-dir', system: {environment: 'testing'}}}).then(() => {
                 expect(false, 'error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.an.instanceof(errors.SystemError);
@@ -297,7 +286,7 @@ describe('Unit: Tasks > Migrator', function () {
                 '../utils/use-ghost-user': {shouldUseGhostUser: useGhostUserStub}
             });
 
-            return migrator.rollback({instance: {config, cliConfig, dir: '/some-dir', system: {environment: 'testing'}}});
+            return migrator.rollback({instance: {config, version: '1.25.3', dir: '/some-dir', system: {environment: 'testing'}}});
         });
 
         it('error on `ghost update --rollback`', function () {
@@ -314,7 +303,7 @@ describe('Unit: Tasks > Migrator', function () {
                 '../utils/use-ghost-user': {shouldUseGhostUser: useGhostUserStub}
             });
 
-            return migrator.rollback({instance: {config, cliConfig, dir: '/some-dir', system: {environment: 'testing'}}}).then(() => {
+            return migrator.rollback({instance: {config, version: '1.25.3', dir: '/some-dir', system: {environment: 'testing'}}}).then(() => {
                 expect(false, 'error should have been thrown').to.be.true;
                 process.argv = originalArgv;
             }).catch((error) => {


### PR DESCRIPTION
refs #783
- replaces scattered usage of instance.cliConfig.x methods with standard getters/setters

todo:
- [x] manual testing