### PR TITLE
🛠  Moved yarn lint to posttest

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "release": "standard-version",
     "test:unit": "nyc --reporter=html --reporter=text mocha --recursive test/unit extensions/**/test",
     "test:acceptance": "mocha --timeout 10000 test/acceptance/**/*-spec.js",
-    "test:all": "yarn run test:unit && yarn run test:acceptance",
-    "test": "yarn run lint && yarn run test:all"
+    "test:all": "yarn test:unit && yarn test:acceptance",
+    "test": "yarn test:all",
+    "posttest": "yarn lint"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
We use the posttest script to make linting and testing a little easier during development.

Aside: it would be great to also get this repo using `yarn ship` to do a full release. @AileenCGN I think you have some docs somewhere for the release process?

----

- This little trick makes testing easier, as linting runs last
- Don't really care about linting til the tests pass!
- Standardised with other Ghost repos :)