### PR TITLE
feat(instance): traverse up directory tree to find instance

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -144,10 +144,8 @@ class Command {
         if (!this.global) {
             const findValidInstall = require('./utils/find-valid-install');
 
-            // CASE: directory was NOT specified (`-d /path/to/instance`)
-            // CASE: directory traversal is explicitly disabled
-            const shouldTraverse = !argv.dir && system.globalConfig.get('traverse_dirs', true);
-            findValidInstall(commandName, shouldTraverse);
+            // NOTE: we disable recursive searching when the cwd is supplied
+            findValidInstall(commandName, !argv.dir);
         }
 
         if (!this.allowRoot) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -139,10 +139,15 @@ class Command {
             debug('Finished updating directory');
         }
 
-        if (!this.global) {
-            const checkValidInstall = require('./utils/check-valid-install');
+        const system = new System(ui, extensions);
 
-            checkValidInstall(commandName);
+        if (!this.global) {
+            const findValidInstall = require('./utils/find-valid-install');
+
+            // CASE: directory was NOT specified (`-d /path/to/instance`)
+            // CASE: directory traversal is explicitly disabled
+            const shouldTraverse = !argv.dir && system.globalConfig.get('traverse_dirs', true);
+            findValidInstall(commandName, shouldTraverse);
         }
 
         if (!this.allowRoot) {
@@ -150,8 +155,6 @@ class Command {
             // Check if user is trying to install as `root`
             checkRootUser(commandName);
         }
-
-        const system = new System(ui, extensions);
 
         // Set the initial environment based on args or NODE_ENV
         system.setEnvironment(argv.development || process.env.NODE_ENV === 'development', true);

--- a/lib/command.js
+++ b/lib/command.js
@@ -139,8 +139,6 @@ class Command {
             debug('Finished updating directory');
         }
 
-        const system = new System(ui, extensions);
-
         if (!this.global) {
             const findValidInstall = require('./utils/find-valid-install');
 
@@ -153,6 +151,8 @@ class Command {
             // Check if user is trying to install as `root`
             checkRootUser(commandName);
         }
+
+        const system = new System(ui, extensions);
 
         // Set the initial environment based on args or NODE_ENV
         system.setEnvironment(argv.development || process.env.NODE_ENV === 'development', true);

--- a/lib/utils/check-valid-install.js
+++ b/lib/utils/check-valid-install.js
@@ -27,10 +27,10 @@ Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
     }
 
     /*
-    * We assume it's a Ghost development install if 3 things are true:
-    * 1) package.json exists
-    * 2) package.json "name" field is "ghost"
-    * 3) Gruntfile.js exists
+     * We assume it's a Ghost development install if 3 things are true:
+     * 1) package.json exists
+     * 2) package.json "name" field is "ghost"
+     * 3) Gruntfile.js exists
     */
     if (fs.existsSync(path.join(dir, 'package.json')) &&
         fs.readJsonSync(path.join(dir, 'package.json')).name === 'ghost' &&

--- a/lib/utils/check-valid-install.js
+++ b/lib/utils/check-valid-install.js
@@ -10,9 +10,9 @@ const chalk = require('chalk');
  * a helpful error message if so.
  *
  * @param {string} name Name of command, will be output if there's an issue
- * @param {bool} exitOnError Whether to exit or throw an error if there's an issue
+ * @returns {bool | null} If the directory contains a valid installation. Returns null for non-deterministic results
  */
-function checkValidInstall(name, exit = true) {
+function checkValidInstall(name) {
     /*
      * CASE: a `config.js` file exists, which means this is a LTS installation
      * which we don't support in the CLI
@@ -22,11 +22,7 @@ function checkValidInstall(name, exit = true) {
 If you are trying to upgrade Ghost LTS to 1.0.0, refer to ${chalk.blue.underline('https://ghost.org/faq/upgrade-to-ghost-1-0/')}.
 Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
 
-        if (exit) {
-            process.exit(1);
-        }
-
-        throw new Error('UNSUPPORTED');
+        return false;
     }
 
     /*
@@ -43,27 +39,17 @@ Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
 Perhaps you meant \`grunt ${name}\`?
 Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
 
-        if (exit) {
-            process.exit(1);
-        }
-
-        throw new Error('DEVELOPMENT');
+        return false;
     }
 
     /*
      * Assume it's not a valid CLI install if the `.ghost-cli` file doesn't exist
      */
     if (!fs.existsSync(path.join(process.cwd(), '.ghost-cli'))) {
-        // We only want to warn if we should exit - if we traverse up the filesystem, every directory
-        // that's not a valid ghost install will fail
-        if (exit) {
-            console.error(`${chalk.yellow('Working directory is not a recognisable Ghost installation.')}
-Run \`ghost ${name}\` again within a folder where Ghost was installed with Ghost-CLI.`);
-            process.exit(1);
-        }
-
-        throw new Error('NO_CONFIG');
+        return null;
     }
+
+    return true;
 }
 
 module.exports = checkValidInstall;

--- a/lib/utils/check-valid-install.js
+++ b/lib/utils/check-valid-install.js
@@ -10,14 +10,15 @@ const chalk = require('chalk');
  * a helpful error message if so.
  *
  * @param {string} name Name of command, will be output if there's an issue
- * @returns {bool | null} If the directory contains a valid installation. Returns null for non-deterministic results
+ * @param {boolean} dir directory to check
+ * @returns {boolean | null} If the directory contains a valid installation. Returns null for non-deterministic results
  */
-function checkValidInstall(name) {
+function checkValidInstall(name, dir = process.cwd()) {
     /*
      * CASE: a `config.js` file exists, which means this is a LTS installation
      * which we don't support in the CLI
      */
-    if (fs.existsSync(path.join(process.cwd(), 'config.js'))) {
+    if (fs.existsSync(path.join(dir, 'config.js'))) {
         console.error(`${chalk.yellow('Ghost-CLI only works with Ghost versions >= 1.0.0.')}
 If you are trying to upgrade Ghost LTS to 1.0.0, refer to ${chalk.blue.underline('https://ghost.org/faq/upgrade-to-ghost-1-0/')}.
 Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
@@ -31,9 +32,9 @@ Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
     * 2) package.json "name" field is "ghost"
     * 3) Gruntfile.js exists
     */
-    if (fs.existsSync(path.join(process.cwd(), 'package.json')) &&
-        fs.readJsonSync(path.join(process.cwd(), 'package.json')).name === 'ghost' &&
-        fs.existsSync(path.join(process.cwd(), 'Gruntfile.js'))
+    if (fs.existsSync(path.join(dir, 'package.json')) &&
+        fs.readJsonSync(path.join(dir, 'package.json')).name === 'ghost' &&
+        fs.existsSync(path.join(dir, 'Gruntfile.js'))
     ) {
         console.error(`${chalk.yellow('Ghost-CLI commands do not work inside of a git clone, zip download or with Ghost <1.0.0.')}
 Perhaps you meant \`grunt ${name}\`?
@@ -45,7 +46,7 @@ Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
     /*
      * Assume it's not a valid CLI install if the `.ghost-cli` file doesn't exist
      */
-    if (!fs.existsSync(path.join(process.cwd(), '.ghost-cli'))) {
+    if (!fs.existsSync(path.join(dir, '.ghost-cli'))) {
         return null;
     }
 

--- a/lib/utils/check-valid-install.js
+++ b/lib/utils/check-valid-install.js
@@ -9,9 +9,10 @@ const chalk = require('chalk');
  * directory contains a development install of ghost (e.g. a git clone), and outputs
  * a helpful error message if so.
  *
- * @param {string} name Name of command, will be output if there's an error
+ * @param {string} name Name of command, will be output if there's an issue
+ * @param {bool} exitOnError Whether to exit or throw an error if there's an issue
  */
-function checkValidInstall(name) {
+function checkValidInstall(name, exit = true) {
     /*
      * CASE: a `config.js` file exists, which means this is a LTS installation
      * which we don't support in the CLI
@@ -21,33 +22,47 @@ function checkValidInstall(name) {
 If you are trying to upgrade Ghost LTS to 1.0.0, refer to ${chalk.blue.underline('https://ghost.org/faq/upgrade-to-ghost-1-0/')}.
 Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
 
-        process.exit(1);
+        if (exit) {
+            process.exit(1);
+        }
+
+        throw new Error('UNSUPPORTED');
     }
 
     /*
-     * We assume it's a Ghost development install if 3 things are true:
-     * 1) package.json exists
-     * 2) package.json "name" field is "ghost"
-     * 3) Gruntfile.js exists
-     */
+    * We assume it's a Ghost development install if 3 things are true:
+    * 1) package.json exists
+    * 2) package.json "name" field is "ghost"
+    * 3) Gruntfile.js exists
+    */
     if (fs.existsSync(path.join(process.cwd(), 'package.json')) &&
         fs.readJsonSync(path.join(process.cwd(), 'package.json')).name === 'ghost' &&
-        fs.existsSync(path.join(process.cwd(), 'Gruntfile.js'))) {
+        fs.existsSync(path.join(process.cwd(), 'Gruntfile.js'))
+    ) {
         console.error(`${chalk.yellow('Ghost-CLI commands do not work inside of a git clone, zip download or with Ghost <1.0.0.')}
 Perhaps you meant \`grunt ${name}\`?
 Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
 
-        process.exit(1);
+        if (exit) {
+            process.exit(1);
+        }
+
+        throw new Error('DEVELOPMENT');
     }
 
     /*
      * Assume it's not a valid CLI install if the `.ghost-cli` file doesn't exist
      */
     if (!fs.existsSync(path.join(process.cwd(), '.ghost-cli'))) {
-        console.error(`${chalk.yellow('Working directory is not a recognisable Ghost installation.')}
+        // We only want to warn if we should exit - if we traverse up the filesystem, every directory
+        // that's not a valid ghost install will fail
+        if (exit) {
+            console.error(`${chalk.yellow('Working directory is not a recognisable Ghost installation.')}
 Run \`ghost ${name}\` again within a folder where Ghost was installed with Ghost-CLI.`);
+            process.exit(1);
+        }
 
-        process.exit(1);
+        throw new Error('NO_CONFIG');
     }
 }
 

--- a/lib/utils/find-valid-install.js
+++ b/lib/utils/find-valid-install.js
@@ -3,7 +3,7 @@ const debug = require('debug')('ghost-cli:find-instance');
 const chalk = require('chalk');
 const checkValidInstall = require('./check-valid-install');
 
-const isRoot = () => dirname(process.cwd()) === process.cwd();
+const isRoot = dir => dirname(dir) === dir;
 
 const die = (name) => {
     console.error(`${chalk.yellow('Working directory is not a recognisable Ghost installation.')}
@@ -12,11 +12,14 @@ Run \`ghost ${name}\` again within a folder where Ghost was installed with Ghost
 };
 
 function findValidInstallation(name = '', recursive = false) {
-    while (!isRoot()) {
-        debug(`Checking valid install: ${process.cwd()}`);
-        const isValidInstall = checkValidInstall(name);
+    let dir = process.cwd();
+
+    while (!isRoot(dir)) {
+        debug(`Checking valid install: ${dir}`);
+        const isValidInstall = checkValidInstall(name, dir);
 
         if (isValidInstall) {
+            process.chdir(dir);
             return;
         }
 
@@ -25,11 +28,12 @@ function findValidInstallation(name = '', recursive = false) {
         }
 
         if (!recursive) {
-            return die(name);
+            die(name);
+            return;
         }
 
         debug(`Going up...`);
-        process.chdir('..');
+        dir = dirname(dir);
     }
 
     die(name);

--- a/lib/utils/find-valid-install.js
+++ b/lib/utils/find-valid-install.js
@@ -5,11 +5,11 @@ const checkValidInstall = require('./check-valid-install');
 
 const isRoot = () => dirname(process.cwd()) === process.cwd();
 
-const die = name => {
+const die = (name) => {
     console.error(`${chalk.yellow('Working directory is not a recognisable Ghost installation.')}
 Run \`ghost ${name}\` again within a folder where Ghost was installed with Ghost-CLI.`);
     process.exit(1);
-}
+};
 
 function findValidInstallation(name = '', recursive = false) {
     while (!isRoot()) {

--- a/lib/utils/find-valid-install.js
+++ b/lib/utils/find-valid-install.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const {dirname} = require('path');
+const debug = require('debug')('ghost-cli:find-instance');
+const checkValidInstall = require('./check-valid-install');
+
+const isRoot = () => dirname(process.cwd()) === process.cwd();
+
+function findValidInstallation(name = '', recursive = false, exit = false) {
+    debug(`Checking valid install: ${process.cwd()}`);
+    try {
+        checkValidInstall(name, exit);
+        debug(`Found valid install!`);
+    } catch (error) {
+        /**
+         * Only move up a directory if
+         *  a) checkValidInstall failed because the `.ghost-cli` file wasn't found
+         *  b) we're supposed to find an installation recursively
+         *  c) we're not in the drive root (if we are, that's the furthest up we can go!)
+         */
+        if (error.message === 'NO_CONFIG' &&
+        recursive &&
+        !isRoot()
+        ) {
+            debug(`Going up...`);
+            process.chdir('..');
+            const shouldExit = isRoot();
+            return findValidInstallation(name, recursive, shouldExit);
+        }
+        debug('no valid installation found', error.message);
+
+        process.exit(1);
+    }
+}
+
+module.exports = findValidInstallation;

--- a/lib/utils/find-valid-install.js
+++ b/lib/utils/find-valid-install.js
@@ -1,36 +1,38 @@
-'use strict';
-
 const {dirname} = require('path');
 const debug = require('debug')('ghost-cli:find-instance');
+const chalk = require('chalk');
 const checkValidInstall = require('./check-valid-install');
 
 const isRoot = () => dirname(process.cwd()) === process.cwd();
 
-function findValidInstallation(name = '', recursive = false, exit = false) {
-    debug(`Checking valid install: ${process.cwd()}`);
-    try {
-        checkValidInstall(name, exit);
-        debug(`Found valid install!`);
-    } catch (error) {
-        /**
-         * Only move up a directory if
-         *  a) checkValidInstall failed because the `.ghost-cli` file wasn't found
-         *  b) we're supposed to find an installation recursively
-         *  c) we're not in the drive root (if we are, that's the furthest up we can go!)
-         */
-        if (error.message === 'NO_CONFIG' &&
-        recursive &&
-        !isRoot()
-        ) {
-            debug(`Going up...`);
-            process.chdir('..');
-            const shouldExit = isRoot();
-            return findValidInstallation(name, recursive, shouldExit);
-        }
-        debug('no valid installation found', error.message);
+const die = name => {
+    console.error(`${chalk.yellow('Working directory is not a recognisable Ghost installation.')}
+Run \`ghost ${name}\` again within a folder where Ghost was installed with Ghost-CLI.`);
+    process.exit(1);
+}
 
-        process.exit(1);
+function findValidInstallation(name = '', recursive = false) {
+    while (!isRoot()) {
+        debug(`Checking valid install: ${process.cwd()}`);
+        const isValidInstall = checkValidInstall(name);
+
+        if (isValidInstall) {
+            return;
+        }
+
+        if (isValidInstall === false) {
+            process.exit(1);
+        }
+
+        if (!recursive) {
+            return die(name);
+        }
+
+        debug(`Going up...`);
+        process.chdir('..');
     }
+
+    die(name);
 }
 
 module.exports = findValidInstallation;

--- a/test/unit/command-spec.js
+++ b/test/unit/command-spec.js
@@ -178,22 +178,22 @@ describe('Unit: Command', function () {
     });
 
     describe('_run', function () {
-        it('calls checkValidInstall when global option is not set', async function () {
-            const checkValidInstall = sinon.stub();
+        it('calls findValidInstall when global option is not set', async function () {
+            const findValidInstall = sinon.stub();
             const Command = proxyquire(modulePath, {
-                './utils/check-valid-install': checkValidInstall
+                './utils/find-valid-install': findValidInstall
             });
 
             const TestCommand = class extends Command {};
-            checkValidInstall.throws();
+            findValidInstall.throws();
 
             try {
                 await TestCommand._run('test', {});
-                throw new Error('checkValidInstall not called');
+                throw new Error('findValidInstall not called');
             } catch (e) {
-                expect(e.message).to.not.equal('checkValidInstall not called');
-                expect(checkValidInstall.calledOnce).to.be.true;
-                expect(checkValidInstall.args[0][0]).to.equal('test');
+                expect(e.message).to.not.equal('findValidInstall not called');
+                expect(findValidInstall.calledOnce).to.be.true;
+                expect(findValidInstall.args[0][0]).to.equal('test');
             }
         });
 

--- a/test/unit/utils/check-valid-install-spec.js
+++ b/test/unit/utils/check-valid-install-spec.js
@@ -1,4 +1,4 @@
-'use strict';
+// @ts-check
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
@@ -11,27 +11,20 @@ describe('Unit: Utils > checkValidInstall', function () {
         sinon.restore();
     });
 
-    it('throws error if config.js present', function () {
+    it('fails when config.js present', function () {
         const existsStub = sinon.stub(fs, 'existsSync');
         existsStub.withArgs(sinon.match(/config\.js/)).returns(true);
 
-        const exitStub = sinon.stub(process, 'exit').throws();
         const errorStub = sinon.stub(console, 'error');
 
-        try {
-            checkValidInstall('test');
-            throw new Error('should not be thrown');
-        } catch (e) {
-            expect(e.message).to.not.equal('should not be thrown');
-            expect(existsStub.calledOnce).to.be.true;
-            expect(errorStub.calledOnce).to.be.true;
-            expect(exitStub.calledOnce).to.be.true;
-            expect(existsStub.args[0][0]).to.match(/config\.js/);
-            expect(errorStub.args[0][0]).to.match(/Ghost-CLI only works with Ghost versions >= 1\.0\.0/);
-        }
+        expect(checkValidInstall('test')).to.equal(false);
+        expect(existsStub.calledOnce).to.be.true;
+        expect(errorStub.calledOnce).to.be.true;
+        expect(existsStub.args[0][0]).to.match(/config\.js/);
+        expect(errorStub.args[0][0]).to.match(/Ghost-CLI only works with Ghost versions >= 1\.0\.0/);
     });
 
-    it('throws error if within a Ghost git clone', function () {
+    it('fails within a Ghost git clone', function () {
         const existsStub = sinon.stub(fs, 'existsSync');
         const readJsonStub = sinon.stub(fs, 'readJsonSync');
 
@@ -40,58 +33,38 @@ describe('Unit: Utils > checkValidInstall', function () {
         existsStub.withArgs(sinon.match(/Gruntfile\.js/)).returns(true);
         readJsonStub.returns({name: 'ghost'});
 
-        const exitStub = sinon.stub(process, 'exit').throws();
         const errorStub = sinon.stub(console, 'error');
 
-        try {
-            checkValidInstall('test');
-            throw new Error('should not be thrown');
-        } catch (e) {
-            expect(e.message).to.not.equal('should not be thrown');
-            expect(existsStub.calledThrice).to.be.true;
-            expect(errorStub.calledOnce).to.be.true;
-            expect(exitStub.calledOnce).to.be.true;
-            expect(existsStub.args[1][0]).to.match(/package\.json/);
-            expect(errorStub.args[0][0]).to.match(/Ghost-CLI commands do not work inside of a git clone/);
-        }
+        expect(checkValidInstall('test')).to.equal(false);
+        expect(existsStub.calledThrice).to.be.true;
+        expect(errorStub.calledOnce).to.be.true;
+        expect(existsStub.args[1][0]).to.match(/package\.json/);
+        expect(errorStub.args[0][0]).to.match(/Ghost-CLI commands do not work inside of a git clone/);
     });
 
-    it('throws error if above two conditions don\'t exit and .ghost-cli file is missing', function () {
+    it('neither passes nor fails when .ghost-cli file is missing', function () {
         const existsStub = sinon.stub(fs, 'existsSync');
 
         existsStub.withArgs(sinon.match(/config\.js/)).returns(false);
         existsStub.withArgs(sinon.match(/package\.json/)).returns(false);
         existsStub.withArgs(sinon.match(/\.ghost-cli/)).returns(false);
 
-        const exitStub = sinon.stub(process, 'exit').throws();
-        const errorStub = sinon.stub(console, 'error');
-
-        try {
-            checkValidInstall('test');
-            throw new Error('should not be thrown');
-        } catch (e) {
-            expect(e.message).to.not.equal('should not be thrown');
-            expect(existsStub.calledThrice).to.be.true;
-            expect(errorStub.calledOnce).to.be.true;
-            expect(exitStub.calledOnce).to.be.true;
-            expect(existsStub.args[2][0]).to.match(/\.ghost-cli/);
-            expect(errorStub.args[0][0]).to.match(/Working directory is not a recognisable Ghost installation/);
-        }
+        expect(checkValidInstall('test')).to.equal(null);
+        expect(existsStub.calledThrice).to.be.true;
+        expect(existsStub.args[2][0]).to.match(/\.ghost-cli/);
     });
 
-    it('doesn\'t do anything if all conditions return false', function () {
+    it('passes in "valid" installation', function () {
         const existsStub = sinon.stub(fs, 'existsSync');
 
         existsStub.withArgs(sinon.match(/config\.js/)).returns(false);
         existsStub.withArgs(sinon.match(/package\.json/)).returns(false);
         existsStub.withArgs(sinon.match(/\.ghost-cli/)).returns(true);
 
-        const exitStub = sinon.stub(process, 'exit').throws();
         const errorStub = sinon.stub(console, 'error');
 
-        checkValidInstall('test');
+        expect(checkValidInstall('test')).to.equal(true);
         expect(existsStub.calledThrice).to.be.true;
         expect(errorStub.called).to.be.false;
-        expect(exitStub.called).to.be.false;
     });
 });


### PR DESCRIPTION
refs #800 

- Try to go up the directory tree to find a valid Ghost instance
- Can be disabled with global config ('traverse_dirs')
  - We need to determine if there's a better way of doing this, or how global config should work in general
  - I was thinking of adding a migration which prompts the user, but that feels overkill
- I want to get a code review before I write the tests 😄 