### PR TITLE
UI Tweaks

### DIFF
--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -60,7 +60,7 @@ class MySQLExtension extends cli.Extension {
                         'database.connection.port': dbconfig.port || '3306'
                     },
                     environment: this.system.environment,
-                    help: 'Please ensure that MySQL is installed and reachable. You can always re-run `ghost setup` to try again.'
+                    help: 'Ensure that MySQL is installed and reachable. You can always re-run `ghost setup` to try again.'
                 }));
             } else if (error.code === 'ER_ACCESS_DENIED_ERROR') {
                 return Promise.reject(new cli.errors.ConfigError({

--- a/extensions/nginx/acme.js
+++ b/extensions/nginx/acme.js
@@ -77,7 +77,7 @@ function generateCert(ui, domain, webroot, email, staging) {
 
         if (error.stderr.match(/Verify error:(Fetching|Invalid Response)/)) {
             // Domain verification failed
-            return Promise.reject(new SystemError('Your domain name is not pointing to the correct IP address of your server, please update it and run `ghost setup ssl` again'));
+            return Promise.reject(new SystemError('Your domain name is not pointing to the correct IP address of your server, check your DNS has propagated and run `ghost setup ssl` again'));
         }
 
         // It's not an error we expect might happen, throw a ProcessError instead.

--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -155,7 +155,7 @@ class NginxExtension extends Extension {
                     promise = this.ui.prompt({
                         name: 'email',
                         type: 'input',
-                        message: 'Enter your email (used for Let\'s Encrypt notifications)',
+                        message: 'Enter your email (For SSL Certificate)',
                         validate: value => Boolean(value) || 'You must supply an email'
                     }).then(({email}) => {
                         argv.sslemail = email;

--- a/extensions/systemd/index.js
+++ b/extensions/systemd/index.js
@@ -23,7 +23,7 @@ class SystemdExtension extends Extension {
 
         // getUid returns either the uid or null
         if (!uid) {
-            this.ui.log('The "ghost" user has not been created, please run `ghost setup linux-user` first', 'yellow');
+            this.ui.log('The "ghost" user has not been created, try running `ghost setup linux-user` first', 'yellow');
             return task.skip();
         }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -134,7 +134,7 @@ class Command {
             } catch (error) {
                 /* istanbul ignore next */
                 const err = error.message || error.code || error;
-                ui.log(`Unable to use "${dir}" (error ${err}). Please fix the issue and try again.`, 'red', true);
+                ui.log(`Unable to use "${dir}" (error ${err}). Create the directory and try again.`, 'red', true);
                 process.exit(1);
             }
 

--- a/lib/commands/config/advanced.js
+++ b/lib/commands/config/advanced.js
@@ -21,14 +21,14 @@ const knownMailServices = [
  */
 module.exports = {
     url: {
-        description: 'Blog URL with protocol E.g. http://loveghost.com',
+        description: 'Site domain E.g. loveghost.com',
         validate: urlUtils.validate,
         transform: urlUtils.ensureProtocol,
         type: 'string',
         group: 'Ghost Options:'
     },
     adminUrl: {
-        description: 'URL for the admin client, if different than the normal URL',
+        description: 'Admin client domain, if different to the site domain',
         configPath: 'admin.url',
         validate: urlUtils.validate,
         transform: urlUtils.ensureProtocol,
@@ -36,7 +36,7 @@ module.exports = {
         group: 'Ghost Options:'
     },
     port: {
-        description: 'Port ghost should listen on',
+        description: 'Port to listen on',
         configPath: 'server.port',
         validate: (value) => {
             value = toString(value);
@@ -56,7 +56,7 @@ module.exports = {
         group: 'Ghost Options:'
     },
     ip: {
-        description: 'IP ghost should listen on',
+        description: 'IP to listen on',
         configPath: 'server.host',
         default: '127.0.0.1',
         type: 'string',
@@ -65,7 +65,7 @@ module.exports = {
 
     // Database options
     db: {
-        description: 'Type of database Ghost should use E.g. mysql or sqlite3',
+        description: 'Type of database to use E.g. mysql or sqlite3',
         validate: value => ['sqlite3', 'mysql'].includes(value) ||
             'Invalid database type. Supported types are mysql and sqlite3',
         configPath: 'database.client',
@@ -157,7 +157,7 @@ module.exports = {
 
     // Log options
     log: {
-        description: 'Transport to send Ghost log output to',
+        description: 'Transport to send log output to',
         configPath: 'logging.transports',
         default: ['file', 'stdout'], // used for config command handling
         type: 'array',
@@ -166,7 +166,7 @@ module.exports = {
 
     // Customise how Ghost-CLI runs
     process: {
-        description: 'Type of process manager to run Ghost with',
+        description: 'Process manager to run with',
         // eslint-disable-next-line arrow-body-style
         defaultValue: (c, env) => {
             return env === 'production' ? 'systemd' : 'local';

--- a/lib/commands/config/index.js
+++ b/lib/commands/config/index.js
@@ -101,7 +101,7 @@ class ConfigCommand extends Command {
             prompts.push({
                 type: 'input',
                 name: 'url',
-                message: 'Enter your blog URL:',
+                message: 'Enter your domain:',
                 default: argv.auto ? null : this.instance.config.get('url', 'http://localhost:2368'),
                 validate: urlUtils.validate,
                 filter: urlUtils.ensureProtocol
@@ -146,7 +146,7 @@ class ConfigCommand extends Command {
                 prompts.push({
                     type: 'input',
                     name: 'dbname',
-                    message: 'Enter your Ghost database name:',
+                    message: 'Enter your database name:',
                     default: this.instance.config.get('database.connection.database', `${sanitizedDirName}_${shortenedEnv}`),
                     validate: val => !/[^a-zA-Z0-9_]/.test(val) || 'MySQL database names may consist of only alphanumeric characters and underscores.'
                 });

--- a/lib/commands/doctor/checks/check-directory.js
+++ b/lib/commands/doctor/checks/check-directory.js
@@ -16,8 +16,8 @@ module.exports = function checkDirectoryAndAbove(dir, extra, task) {
 
         if (!mode.others.read) {
             return Promise.reject(new errors.SystemError({
-                message: `The path ${dir} is not readable by other users on the system.
-This can cause issues with the CLI, please either make this directory readable by others or ${extra} in another location.`,
+                message: `The directory ${dir} is not readable by other users on the system.
+This can cause issues with the CLI, you must either make this directory readable by others or ${extra} in another location.`,
                 task: task
             }));
         }

--- a/lib/commands/doctor/checks/check-memory.js
+++ b/lib/commands/doctor/checks/check-memory.js
@@ -10,7 +10,7 @@ function checkMemory() {
         const availableMemory = memoryInfo.available / MB_IN_BYTES;
 
         if (availableMemory < MIN_MEMORY) {
-            return Promise.reject(new SystemError(`Ghost recommends you have at least ${MIN_MEMORY} MB of memory available for smooth operation. It looks like you have ~${parseInt(availableMemory)} MB available.`));
+            return Promise.reject(new SystemError(`You are recommended to have at least ${MIN_MEMORY} MB of memory available for smooth operation. It looks like you have ~${parseInt(availableMemory)} MB available.`));
         }
         return Promise.resolve();
     });

--- a/lib/commands/doctor/checks/install-folder-permissions.js
+++ b/lib/commands/doctor/checks/install-folder-permissions.js
@@ -11,7 +11,7 @@ const taskTitle = 'Checking current folder permissions';
 function installFolderPermissions(ctx) {
     return fs.access(process.cwd(), constants.R_OK | constants.W_OK).catch(
         () => Promise.reject(new errors.SystemError({
-            message: 'The current directory is not writable. Please fix the permissions of your install directory.',
+            message: `The directory ${process.cwd()} is not writable by your user. You must grant write access and try again.`,
             help: `${chalk.green('https://docs.ghost.org/docs/install#section-your-user-must-own-this-directory')}`,
             task: taskTitle
         }))

--- a/lib/commands/doctor/checks/logged-in-ghost-user.js
+++ b/lib/commands/doctor/checks/logged-in-ghost-user.js
@@ -20,7 +20,7 @@ function loggedInGhostUser() {
         // as the linux user and shall not be used as current user.
         if (contentDirStats.uid === ghostStats.uid) {
             throw new errors.SystemError({
-                message: 'You can\'t use Ghost with the ghost user. Please log in with your own user.',
+                message: 'You can\'t run commands with the "ghost" user. Switch to your own user and try again.',
                 help: `${chalk.green('https://docs.ghost.org/docs/install#section-create-a-new-user')}`,
                 task: taskTitle
             });

--- a/lib/commands/doctor/checks/logged-in-user-owner.js
+++ b/lib/commands/doctor/checks/logged-in-user-owner.js
@@ -7,22 +7,24 @@ const fs = require('fs');
 const taskTitle = 'Checking if logged in user is directory owner';
 
 function loggedInUserOwner(ctx) {
+    // TODO: switch to require('os').userInfo() and output username in errors
     const uid = process.getuid();
     const gid = process.getgroups();
-    const dirStats = fs.lstatSync(path.join(process.cwd()));
+    const dir = process.cwd();
+    const dirStats = fs.lstatSync(path.join(dir));
 
     // check if the current user is the owner of the current dir
     if (dirStats.uid !== uid) {
         if (gid.indexOf(dirStats.gid) < 0) {
             throw new errors.SystemError({
-                message: `Your current user is not the owner of the Ghost directory and also not part of the same group.
-Please log in with the user that owns the directory or add your user to the same group.`,
+                message: `Your user does not own the directory ${dir} and is also not a member of the owning group.
+You must either log in with the user that owns the directory or add your user to the owning group.`,
                 help: `${chalk.green('https://docs.ghost.org/docs/install#section-create-a-new-user')}`,
                 task: taskTitle
             });
         }
         // Yup current user is not the owner, but in the same group, so just show a warning
-        ctx.ui.log(`${chalk.yellow('The current user is not the owner of the Ghost directory. This might cause problems.')}`);
+        ctx.ui.log(`Your user does not own the directory ${dir}. This might cause permission issues.`, 'yellow');
     }
 }
 

--- a/lib/commands/doctor/checks/logged-in-user.js
+++ b/lib/commands/doctor/checks/logged-in-user.js
@@ -11,7 +11,7 @@ function loggedInUser() {
 
     if (ghostStats && ghostStats.uid === uid) {
         throw new errors.SystemError({
-            message: 'You can\'t install Ghost with a user called `ghost`. Please use a different user(name).',
+            message: 'You can\'t run install commands with a user called "ghost". Switch to a different user and try again.',
             help: `${chalk.green('https://docs.ghost.org/docs/install#section-create-a-new-user')}`,
             task: taskTitle
         });

--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -34,7 +34,7 @@ class LogCommand extends Command {
                         'logging.transports': instance.config.get('logging.transports').join(', ')
                     },
                     message: 'You have excluded file logging in your ghost config.' +
-                        'Please add it to your transport config to use this command.',
+                        'You need to add it to your transport config to use this command.',
                     environment: this.system.environment
                 }));
             }

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -26,7 +26,7 @@ class RunCommand extends Command {
     useGhostUser(instance) {
         const errors = require('../errors');
 
-        this.ui.log('Running sudo command: node current/index.js', 'gray');
+        this.ui.log('+ sudo node current/index.js', 'gray');
 
         this.child = spawn('sudo', `-E -u ghost ${process.execPath} current/index.js`.split(' '), {
             cwd: instance.dir,

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -1,6 +1,7 @@
 'use strict';
 const Command = require('../command');
 const DoctorCommand = require('./doctor');
+const urlUtils = require('../utils/url');
 
 class StartCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {
@@ -22,14 +23,13 @@ class StartCommand extends Command {
 
     run(argv) {
         const ProcessManager = require('../process-manager');
-        const chalk = require('chalk');
 
         const instance = this.system.getInstance();
         const runOptions = {quiet: argv.quiet};
 
         return instance.running().then((isRunning) => {
             if (isRunning) {
-                this.ui.log('Ghost is already running! Run `ghost ls` for more information', 'green');
+                this.ui.log('Ghost is already running! For more information, run', 'ghost ls', 'green', 'cmd', true);
                 return Promise.resolve();
             }
 
@@ -43,7 +43,7 @@ class StartCommand extends Command {
 
                 const start = () => Promise.resolve(processInstance.start(process.cwd(), this.system.environment))
                     .then(() => {
-                        instance.running(this.system.environment); 
+                        instance.running(this.system.environment);
                     });
 
                 return this.ui.run(start, 'Starting Ghost', runOptions).then(() => {
@@ -62,22 +62,21 @@ class StartCommand extends Command {
                     if (!argv.quiet) {
                         const isInstall = process.argv[2] === 'install';
                         let adminUrl = instance.config.get('admin.url') || instance.config.get('url');
-
                         // Strip the trailing slash and add the admin path
                         adminUrl = `${adminUrl.replace(/\/$/,'')}/ghost/`;
 
-                        this.ui.log(`You can access your publication at ${chalk.cyan(instance.config.get('url'))}`, 'white');
+                        // Show a warning about direct mail - but in grey, it's not the most important message here
+                        if (isInstall && instance.config.get('mail.transport') === 'Direct') {
+                            this.ui.log('\nGhost uses direct mail by default. To set up an alternative email method read our docs at https://ghost.org/mail', 'gray');
+                        }
+
+                        this.ui.log('\n------------------------------------------------------------------------------', 'white');
 
                         if (isInstall) {
                             // Show a different message after a fresh install
-                            this.ui.log(`Next, go to to your admin interface at ${chalk.cyan(adminUrl)} to complete the setup of your publication`, 'white');
+                            this.ui.log('Ghost was installed successfully! To complete setup of your publication, visit', adminUrl, 'green', 'link', true);
                         } else {
-                            this.ui.log(`Your admin interface is located at ${chalk.cyan(adminUrl)}`, 'white');
-                        }
-
-                        if (instance.config.get('mail.transport') === 'Direct') {
-                            this.ui.log('\nGhost uses direct mail by default', 'green');
-                            this.ui.log('To set up an alternative email method read our docs at https://docs.ghost.org/docs/mail-config', 'green');
+                            this.ui.log('Your admin interface is located at', adminUrl, 'green', 'link', true);
                         }
                     }
                 });

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -1,7 +1,6 @@
 'use strict';
 const Command = require('../command');
 const DoctorCommand = require('./doctor');
-const urlUtils = require('../utils/url');
 
 class StartCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -43,7 +43,7 @@ class StopCommand extends Command {
 
         return instance.running().then((isRunning) => {
             if (!isRunning) {
-                this.ui.log('Ghost is already stopped! Nothing to do here.', 'green');
+                this.ui.log('Ghost is already stopped! For more information, run', 'ghost ls', 'green', 'cmd', true);
                 return Promise.resolve();
             }
 

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -28,8 +28,7 @@ class UpdateCommand extends Command {
             this.ui.log(
                 `Ghost was installed with Ghost-CLI v${instance.cliVersion}, which is a pre-release version.\n` +
                 'Your Ghost install is using out-of-date configuration & requires manual changes.\n' +
-                `Please visit ${chalk.blue.underline('https://docs.ghost.org/v1/docs/how-to-upgrade-ghost#section-upgrading-ghost-cli')}\n` +
-                'for instructions on how to upgrade your instance.\n',
+                `For instructions on how to upgrade your instance, visit ${chalk.blue.underline('https://docs.ghost.org/v1/docs/how-to-upgrade-ghost#section-upgrading-ghost-cli')}.\n`,
                 'yellow'
             );
         }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -27,7 +27,7 @@ class CliError extends Error {
         this.options = options;
         this.logMessageOnly = options.logMessageOnly;
 
-        this.help = 'Please refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.';
+        this.help = 'You can always refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.';
 
         if (options.err) {
             if (typeof options.err === 'string') {

--- a/lib/tasks/migrator.js
+++ b/lib/tasks/migrator.js
@@ -33,7 +33,7 @@ const errorHandler = (context) => {
             // We check stdout because knex outputs to stdout on this particular error
             error = new errors.SystemError({
                 message: 'It appears that sqlite3 did not install properly when Ghost-CLI was installed.\n' +
-                'Please either uninstall and reinstall Ghost-CLI, or switch to MySQL',
+                'You can either uninstall and reinstall Ghost-CLI, or switch to MySQL',
                 help: 'https://docs.ghost.org/v1/docs/troubleshooting#section-sqlite3-install-failure'
             });
         } else {

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -278,6 +278,11 @@ class UI {
      * @public
      */
     log(message, color, stderr) {
+        if (arguments.length > 3) {
+            this._logHelp.apply(this, arguments);
+            return;
+        }
+
         if (color) {
             message = chalk[color](message);
         }
@@ -307,6 +312,22 @@ class UI {
         if (this.verbose) {
             return this.log(message, color, stderr);
         }
+    }
+
+    /**
+     * Shorthand helper to output a help message, which displays a hint indented on the next line
+     *
+     * Don't call me directly, call ui.log with 4 args.
+     *
+     * @param {string} message Main message to output
+     * @param {string} hint Hint line to output e.g. a command to fix things
+     * @param {string} msgColor Main color of the message
+     * @param {string} hintType One of link or cmd
+     * @param {boolean} solo Is this message output as the last thing?
+     */
+    _logHelp(message, hint, msgColor, hintType, last) {
+        let hintColor = hintType === 'link' ? 'cyan' : 'yellow';
+        this.log(`\n${message}: \n\n    ${chalk[hintColor](hint)}${last ? '\n' : ''}`, msgColor);
     }
 
     /**

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -131,7 +131,7 @@ class UI {
      */
     prompt(prompts) {
         if (!this.allowPrompt) {
-            throw new errors.SystemError('Prompts have been disabled, please provide options via command line flags');
+            throw new errors.SystemError('Prompts have been disabled, all options must be provided via command line flags');
         }
 
         if (this.auto) {
@@ -416,7 +416,7 @@ class UI {
             }
 
             this.log(`\nTry running ${(chalk.cyan('ghost doctor'))} to check your system for known issues.`);
-            this.log('\nPlease refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
+            this.log('\nYou can always refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
         } else if (error instanceof Error) {
             // System errors or regular old errors go here.
             let output = `An error occurred.\n${chalk.yellow('Message:')} '${error.message}'\n\n`;
@@ -445,7 +445,7 @@ class UI {
             const logLocation = system.writeErrorLog(stripAnsi(`${debugInfo}\n${output}`));
             this.log(`\nAdditional log info available in: ${logLocation}`);
             this.log(`\nTry running ${(chalk.cyan('ghost doctor'))} to check your system for known issues.`);
-            this.log('\nPlease refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
+            this.log('\nYou can always refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
         } else if (isObject(error)) {
             // TODO: find better way to handle object errors?
             this.log(JSON.stringify(error), null, true);

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -215,7 +215,7 @@ class UI {
      */
     sudo(command, options) {
         options = options || {};
-        this.log(`Running sudo command: ${command}`, 'gray');
+        this.log(`+ sudo ${command}`, 'gray');
 
         const prompt = '#node-sudo-passwd#';
         const cmd = command.replace(/^ghost/, process.argv.slice(0, 2).join(' '));

--- a/lib/utils/check-root-user.js
+++ b/lib/utils/check-root-user.js
@@ -24,15 +24,15 @@ function checkRootUser(command) {
         if (!isRootInstall()) {
             // CASE: the user uses either the new DO image, where installations are following our setup guid (aka not-root),
             // or the user followed the fix root user guide already, but the user uses root to run the command
-            console.error(`${chalk.yellow('Can\'t run command as \'root\' user.')}
-Please use the user you set up in the installation process, or create a new user with regular account privileges and use this user to run 'ghost ${command}'.
-See ${chalk.underline.green('https://docs.ghost.org/docs/install#section-create-a-new-user')} for more information\n`);
+            console.error(`${chalk.yellow('You can\'t run commands as the \'root\' user.')}
+Switch to your regular user, or create a new user with regular account privileges and use this user to run 'ghost ${command}'.
+For more information, see ${chalk.underline.green('https://docs.ghost.org/docs/install#section-create-a-new-user')}.\n`);
         } else {
             // CASE: the ghost installation folder is owned by root. The user needs to migrate the installation
             // to a non-root and follow the instructions.
             console.error(`${chalk.yellow('We discovered that you are using the Digitalocean One-Click install.')}
-You need to create a user with regular account privileges and migrate your installation to use this user.
-Please follow the steps here: ${chalk.underline.green('https://docs.ghost.org/docs/troubleshooting#section-fix-root-user')} to fix your setup.\n`);
+You need to create a user with regular account privileges and migrate your installation to this user.
+There is a guide to fixing your setup here: ${chalk.underline.green('https://docs.ghost.org/docs/troubleshooting#section-fix-root-user')}.\n`);
         }
 
         // TODO: remove this 4 versions after 1.5.0
@@ -41,17 +41,17 @@ Please follow the steps here: ${chalk.underline.green('https://docs.ghost.org/do
         }
     } else if (isRootInstall()) {
         console.error(`${chalk.yellow('It seems Ghost was installed using the root user.')}
-You need to create a user with regular account privileges and migrate your installation to use this user.
-Please follow the steps here: ${chalk.underline.green('https://docs.ghost.org/docs/troubleshooting#section-fix-root-user')} to fix your setup.\n`);
+You need to create a user with regular account privileges and migrate your installation to this user.
+There is a guide to fixing your setup here: ${chalk.underline.green('https://docs.ghost.org/docs/troubleshooting#section-fix-root-user')}.\n`);
 
         // TODO: remove this 4 versions after 1.5.0
         if (allowedCommands.includes(command)) {
             return;
         }
     } else {
-        console.error(`${chalk.yellow('Can\'t run command as \'root\' user.')}
-Please use the user you set up in the installation process, or create a new user with regular account privileges and use this user to run 'ghost ${command}'.
-See ${chalk.underline.green('https://docs.ghost.org/docs/install#section-create-a-new-user')} for more information\n`);
+        console.error(`${chalk.yellow('You can\'t run commands as the \'root\' user.')}
+Switch to your regular user, or create a new user with regular account privileges and use this user to run 'ghost ${command}'.
+For more information, see ${chalk.underline.green('https://docs.ghost.org/docs/install#section-create-a-new-user')}.\n`);
     }
 
     process.exit(1);

--- a/lib/utils/check-valid-install.js
+++ b/lib/utils/check-valid-install.js
@@ -18,8 +18,8 @@ function checkValidInstall(name) {
      */
     if (fs.existsSync(path.join(process.cwd(), 'config.js'))) {
         console.error(`${chalk.yellow('Ghost-CLI only works with Ghost versions >= 1.0.0.')}
-If you are trying to upgrade Ghost LTS to 1.0.0 please see ${chalk.blue.underline('https://docs.ghost.org/v1/docs/migrating-to-ghost-1-0-0')}.
-Otherwise, please run \`ghost ${name}\` again within a valid Ghost installation.`);
+If you are trying to upgrade Ghost LTS to 1.0.0, refer to ${chalk.blue.underline('https://docs.ghost.org/v1/docs/migrating-to-ghost-1-0-0')}.
+Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
 
         process.exit(1);
     }
@@ -35,7 +35,7 @@ Otherwise, please run \`ghost ${name}\` again within a valid Ghost installation.
         fs.existsSync(path.join(process.cwd(), 'Gruntfile.js'))) {
         console.error(`${chalk.yellow('Ghost-CLI commands do not work inside of a git clone, zip download or with Ghost <1.0.0.')}
 Perhaps you meant \`grunt ${name}\`?
-Otherwise, please run \`ghost ${name}\` again within a valid Ghost installation.`);
+Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
 
         process.exit(1);
     }
@@ -45,7 +45,7 @@ Otherwise, please run \`ghost ${name}\` again within a valid Ghost installation.
      */
     if (!fs.existsSync(path.join(process.cwd(), '.ghost-cli'))) {
         console.error(`${chalk.yellow('Working directory is not a recognisable Ghost installation.')}
-Please run \`ghost ${name}\` again within a folder where Ghost was installed with Ghost-CLI.`);
+Run \`ghost ${name}\` again within a folder where Ghost was installed with Ghost-CLI.`);
 
         process.exit(1);
     }

--- a/lib/utils/local-process.js
+++ b/lib/utils/local-process.js
@@ -30,7 +30,7 @@ class LocalProcess extends ProcessManager {
         // Check that content folder is owned by the current user
         if (!this._checkContentFolder(cwd)) {
             return Promise.reject(new errors.SystemError(`The content folder is not owned by the current user.
-Please ensure the content folder has correct permissions and try again.`));
+Ensure the content folder has correct permissions and try again.`));
         }
 
         return new Promise((resolve, reject) => {

--- a/lib/utils/resolve-version.js
+++ b/lib/utils/resolve-version.js
@@ -83,7 +83,7 @@ module.exports = function resolveVersion(version, activeVersion, v1 = false, for
                 } else if (majorVersionJump && !force && v1Versions.length) {
                     return Promise.reject(new errors.CliError({
                         message: 'You are about to migrate to Ghost 2.0. Your blog is not on the latest Ghost 1.0 version.',
-                        help: 'Please run "ghost update --v1".'
+                        help: 'Instead run "ghost update --v1".'
                     }));
                 }
             }

--- a/lib/utils/url.js
+++ b/lib/utils/url.js
@@ -3,13 +3,13 @@
 const {isURL} = require('validator');
 const endsWithGhost = /\/ghost\/?$/i;
 
-const validate = function validateURL(url) {
+const validate = function validateURL(url, isAdmin) {
     const isValidURL = isURL(url, {require_protocol: true});
     if (!isValidURL) {
-        return 'Invalid URL. Your URL should include a protocol, E.g. http://my-ghost-blog.com';
+        return 'Invalid domain. Your domain should include a protocol and a TLD, E.g. http://my-ghost-blog.com';
     }
 
-    return (!endsWithGhost.test(url)) || 'Ghost doesn\'t support running in a path that ends with `ghost`';
+    return (!isAdmin && !endsWithGhost.test(url)) || 'Ghost doesn\'t support running in a path that ends with `ghost`';
 };
 
 const isCustomDomain = function isCustomDomain(input) {

--- a/lib/utils/version-from-zip.js
+++ b/lib/utils/version-from-zip.js
@@ -55,7 +55,7 @@ module.exports = function versionFromZip(zipPath, currentVersion, force = false)
                 currentVersion !== latestV1ReleaseVersion) {
                 return Promise.reject(new errors.SystemError({
                     message: 'You are about to migrate to Ghost 2.0. Your blog is not on the latest Ghost 1.0 version.',
-                    help: 'Please run "ghost update --v1".'
+                    help: 'Instead run "ghost update --v1".'
                 }));
             }
 

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -507,8 +507,8 @@ describe('Unit: Command > Config', function () {
 
             // Check validate function
             expect(advancedOptions.adminUrl.validate('http://localhost:2368')).to.be.true;
-            expect(advancedOptions.adminUrl.validate('localhost:2368')).to.match(/Invalid URL/);
-            expect(advancedOptions.adminUrl.validate('not even remotely a URL')).to.match(/Invalid URL/);
+            expect(advancedOptions.adminUrl.validate('localhost:2368')).to.match(/Invalid domain/);
+            expect(advancedOptions.adminUrl.validate('not even remotely a domain')).to.match(/Invalid domain/);
 
             // Check transform function
             expect(advancedOptions.adminUrl.transform('http://MyUpperCaseUrl.com')).to.equal('http://myuppercaseurl.com');

--- a/test/unit/commands/doctor/checks/check-directory-spec.js
+++ b/test/unit/commands/doctor/checks/check-directory-spec.js
@@ -101,7 +101,7 @@ describe('Unit: Doctor Checks > checkDirectoryAndAbove', function () {
             expect(false, 'error should have been thrown').to.be.true;
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.SystemError);
-            expect(error.message).to.match(/path \/root\/ is not readable/);
+            expect(error.message).to.match(/directory \/root\/ is not readable/);
 
             expect(isRootStub.calledTwice).to.be.true;
             expect(lstatStub.calledTwice).to.be.true;

--- a/test/unit/commands/doctor/checks/install-folder-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/install-folder-permissions-spec.js
@@ -21,7 +21,7 @@ describe('Unit: Doctor Checks > installFolderPermissions', function () {
             expect(false, 'error should have been thrown').to.be.true;
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.SystemError);
-            expect(error.message).to.match(/current directory is not writable/);
+            expect(error.message).to.match(/is not writable by your user/);
             expect(accessStub.calledOnce).to.be.true;
             expect(accessStub.calledWith(process.cwd())).to.be.true;
         });

--- a/test/unit/commands/doctor/checks/logged-in-ghost-user-spec.js
+++ b/test/unit/commands/doctor/checks/logged-in-ghost-user-spec.js
@@ -39,7 +39,7 @@ describe('Unit: Doctor Checks > loggedInGhostUser', function () {
             expect(fsStub.calledOnce).to.be.true;
             expect(ghostUserStub.calledOnce).to.be.true;
             expect(error).to.be.an.instanceof(errors.SystemError);
-            expect(error.message).to.match(/You can't use Ghost with the ghost user./);
+            expect(error.message).to.match(/You can't run commands with the "ghost" user./);
         }
     });
 

--- a/test/unit/commands/doctor/checks/logged-in-user-owner-spec.js
+++ b/test/unit/commands/doctor/checks/logged-in-user-owner-spec.js
@@ -40,7 +40,7 @@ describe('Unit: Doctor Checks > loggedInUserOwner', function () {
             expect(uidStub.calledOnce).to.be.true;
             expect(gidStub.calledOnce).to.be.true;
             expect(error).to.be.an.instanceof(errors.SystemError);
-            expect(error.message).to.match(/Your current user is not the owner of the Ghost directory and also not part of the same group./);
+            expect(error.message).to.match(/Your user does not own the directory/);
         }
     });
 
@@ -61,7 +61,7 @@ describe('Unit: Doctor Checks > loggedInUserOwner', function () {
         expect(uidStub.calledOnce).to.be.true;
         expect(gidStub.calledOnce).to.be.true;
         expect(logStub.calledOnce).to.be.true;
-        expect(logStub.args[0][0]).to.match(/The current user is not the owner of the Ghost directory. This might cause problems./);
+        expect(logStub.args[0][0]).to.match(/Your user does not own the directory/);
     });
 
     it('resolves if current user is also the owner', function () {

--- a/test/unit/commands/run-spec.js
+++ b/test/unit/commands/run-spec.js
@@ -99,7 +99,7 @@ describe('Unit: Commands > Run', function () {
         instance.useGhostUser({dir: '/var/www/ghost'});
 
         expect(logStub.calledOnce).to.be.true;
-        expect(logStub.args[0][0]).to.match(/Running sudo command/);
+        expect(logStub.args[0][0]).to.match(/^\+ sudo/);
         expect(spawnStub.calledOnce).to.be.true;
         expect(spawnStub.calledWithExactly('sudo', [
             '-E',

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -593,6 +593,36 @@ describe('Unit: UI', function () {
             expect(stdout.write.args[0][0]).to.equal('test\n');
             expect(stdout.write.args[1][0]).to.equal('best\n');
         });
+
+        it('displays a multi-line help message when called with 4 args', function (done) {
+            const stdout = streamTestUtils.getWritableStream(function (output) {
+                expect(output, 'output exists').to.be.ok;
+                expect(hasAnsi(output), 'output has color').to.be.true;
+                expect(output, 'output value').to.include(chalk.green(`\nmy message: \n\n    ${chalk.cyan('testing')}`));
+
+                done();
+            });
+            stdout.on('error', done);
+
+            const UI = require(modulePath);
+            const ui = new UI({stdout: stdout});
+            ui.log('my message', 'testing', 'green', 'link');
+        });
+
+        it('displays a multi-line help message with exta line when called with 5 args', function (done) {
+            const stdout = streamTestUtils.getWritableStream(function (output) {
+                expect(output, 'output exists').to.be.ok;
+                expect(hasAnsi(output), 'output has color').to.be.true;
+                expect(output, 'output value').to.include(chalk.white(`\nmy message: \n\n    ${chalk.yellow('testing')}\n`));
+
+                done();
+            });
+            stdout.on('error', done);
+
+            const UI = require(modulePath);
+            const ui = new UI({stdout: stdout});
+            ui.log('my message', 'testing', 'white', 'cmd', true);
+        });
     });
 
     describe('logVerbose', function () {

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -464,7 +464,7 @@ describe('Unit: UI', function () {
             const stdin = streamTestUtils.getWritableStream((output) => {
                 expect(output).to.equal('password\n');
                 expect(logStub.calledOnce).to.be.true;
-                expect(logStub.calledWithExactly('Running sudo command: ghost -v', 'gray')).to.be.true;
+                expect(logStub.calledWithExactly('+ sudo ghost -v', 'gray')).to.be.true;
                 expect(shellStub.calledOnce).to.be.true;
                 expect(shellStub.args[0][0]).to.match(eCall);
                 expect(shellStub.args[0][1]).to.deep.equal({cwd: '/var/foo'});

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -777,7 +777,7 @@ describe('Unit: UI', function () {
                 expect(stripAnsi(log.args[4][0])).to.match(/Message: Error 2/);
                 expect(log.args[5][0]).to.equal('cherries');
                 expect(stripAnsi(log.args[6][0])).to.match(/Try running ghost doctor to check your system for known issues./);
-                expect(log.args[7][0]).to.match(/Please refer to https:\/\/docs.ghost.org/);
+                expect(log.args[7][0]).to.match(/You can always refer to https:\/\/docs.ghost.org/);
             });
 
             it('non-verbose with log output', function () {
@@ -808,7 +808,7 @@ describe('Unit: UI', function () {
                 expect(log.args[5][0]).to.equal('cherries');
                 expect(log.args[6][0]).to.match(/Additional log info available in/);
                 expect(stripAnsi(log.args[7][0])).to.match(/Try running ghost doctor to check your system for known issues./);
-                expect(log.args[8][0]).to.match(/Please refer to https:\/\/docs.ghost.org/);
+                expect(log.args[8][0]).to.match(/You can always refer to https:\/\/docs.ghost.org/);
             });
         });
 
@@ -839,7 +839,7 @@ describe('Unit: UI', function () {
                 expectedErrors.forEach(function (err, i) {
                     expect(log.args[i * 5 + 2][0]).to.match(/Additional log info/);
                     expect(stripAnsi(log.args[i * 5 + 3][0])).to.match(/Try running ghost doctor to check your system for known issues./);
-                    expect(log.args[i * 5 + 4][0]).to.match(/Please refer to https:\/\/docs\.ghost\.org/);
+                    expect(log.args[i * 5 + 4][0]).to.match(/You can always refer to https:\/\/docs\.ghost\.org/);
                     expect(stripAnsi(log.args[i * 5][0]).split(/\n/)).to.deep.equal(err);
                 });
             });
@@ -859,7 +859,7 @@ describe('Unit: UI', function () {
                 expect(system.writeErrorLog.calledOnce).to.be.true;
                 expect(log.args[2][0]).to.match(/Additional log info/);
                 expect(stripAnsi(log.args[3][0])).to.match(/Try running ghost doctor to check your system for known issues./);
-                expect(log.args[4][0]).to.match(/Please refer to https:\/\/docs\.ghost\.org/);
+                expect(log.args[4][0]).to.match(/You can always refer to https:\/\/docs\.ghost\.org/);
                 expect(stripAnsi(log.args[0][0]).split(/\n/)).to.deep.equal(expectedError);
             });
         });

--- a/test/unit/utils/check-root-user-spec.js
+++ b/test/unit/utils/check-root-user-spec.js
@@ -96,7 +96,7 @@ describe('Unit: Utils > checkRootUser', function () {
             expect(processStub.calledOnce).to.be.true;
             expect(errorStub.calledOnce).to.be.true;
             expect(exitStub.calledOnce).to.be.true;
-            expect(errorStub.args[0][0]).to.match(/Can't run command as 'root' user/);
+            expect(errorStub.args[0][0]).to.match(/You can't run commands as the 'root' user/);
         }
     });
 
@@ -200,7 +200,7 @@ describe('Unit: Utils > checkRootUser', function () {
             expect(processStub.calledOnce).to.be.true;
             expect(errorStub.calledOnce).to.be.true;
             expect(exitStub.calledOnce).to.be.true;
-            expect(errorStub.args[0][0]).to.match(/Can't run command as 'root' user/);
+            expect(errorStub.args[0][0]).to.match(/You can't run commands as the 'root' user/);
         }
     });
 
@@ -228,7 +228,7 @@ describe('Unit: Utils > checkRootUser', function () {
             expect(processStub.calledOnce).to.be.true;
             expect(errorStub.calledOnce).to.be.true;
             expect(exitStub.calledOnce).to.be.true;
-            expect(errorStub.args[0][0]).to.match(/Can't run command as 'root' user/);
+            expect(errorStub.args[0][0]).to.match(/You can't run commands as the 'root' user/);
         }
     });
 });

--- a/test/unit/utils/url.js
+++ b/test/unit/utils/url.js
@@ -7,8 +7,8 @@ const url = require('../../../lib/utils/url');
 describe('Unit: Utils > URL', function () {
     describe('> Validate', function () {
         it('non-URLs fail', function () {
-            expect(url.validate('totally a url')).to.match(/Invalid URL/);
-            expect(url.validate('notaurl')).to.match(/Invalid URL/);
+            expect(url.validate('totally a url')).to.match(/Invalid domain/);
+            expect(url.validate('notaurl')).to.match(/Invalid domain/);
         });
 
         it('protocol-free URLs fail', function () {


### PR DESCRIPTION
This PR builds on top of #813 & focuses on messaging.

I think I could fiddle with the output from CLI forever, but for now there are 5 changes:

1. reduced the sudo output to just add `+ sudo` before the command, consistent with the output from npm.
2. reworded the email prompt for SSL
3. removed the word URL from as many places as possible, when talking to users we should use "domain"
4. a whole bunch of work to the messages output at the end of a start/install to make this super clear
5. changed many messages to make them clearer

Bottom line with language in the CLI is that it should be direct and clear, and that clarity is way more important that politeness. 