### PR TITLE
chore: ensure docs links point to non-versioned docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/--anything-else.md
+++ b/.github/ISSUE_TEMPLATE/--anything-else.md
@@ -14,5 +14,5 @@ Alternatively, check out these resources below. Thanks! 😁.
 - [Ghost-CLI docs](https://docs.ghost.org/docs/ghost-cli)
 - [Forum Support](https://forum.ghost.org/c/help)
 - [Ideas](https://forum.ghost.org/c/Ideas)
-- [Contributing Guide](https://docs.ghost.org/v1/docs/contributing)
-- [Self-hoster Docs](http://docs.ghost.org/v1/)
+- [Contributing Guide](https://docs.ghost.org/docs/contributing)
+- [Self-hoster Docs](http://docs.ghost.org/docs/)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 ## Documentation
 
-- [Complete Setup Guide](https://docs.ghost.org/v1/docs/install)
-- [Command Reference](https://docs.ghost.org/v1/docs/ghost-cli)
-- [Troubleshooting Guide](https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors)
+- [Complete Setup Guide](https://docs.ghost.org/docs/install)
+- [Command Reference](https://docs.ghost.org/docs/ghost-cli)
+- [Troubleshooting Guide](https://docs.ghost.org/docs/troubleshooting#section-cli-errors)
 - [Forum](https://forum.ghost.org)
 
 ## Project Goals

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -144,7 +144,7 @@ const bootstrap = {
         // Yargs magic
         // TODO: evaluate if `wrap` is actually needed?
         yargs.wrap(Math.min(100, yargs.terminalWidth()))
-            .epilogue('For more information, see our docs at https://docs.ghost.org/v1/docs/ghost-cli')
+            .epilogue('For more information, see our docs at https://docs.ghost.org/docs/ghost-cli')
             .option('d', {
                 alias: 'dir',
                 describe: 'Folder to run command in'

--- a/lib/command.js
+++ b/lib/command.js
@@ -90,7 +90,7 @@ class Command {
             yargs.usage(this.longDescription);
         }
 
-        yargs.epilogue('For more information, see our docs at https://docs.ghost.org/v1/docs/ghost-cli');
+        yargs.epilogue('For more information, see our docs at https://docs.ghost.org/docs/ghost-cli');
 
         return yargs;
     }

--- a/lib/commands/doctor/checks/node-version.js
+++ b/lib/commands/doctor/checks/node-version.js
@@ -14,7 +14,7 @@ function nodeVersion(ctx) {
             message: `${chalk.red('The version of Node.js you are using is not supported.')}
 ${chalk.gray('Supported: ')}${cliPackage.engines.node}
 ${chalk.gray('Installed: ')}${process.versions.node}
-See ${chalk.underline.blue('https://docs.ghost.org/v1/docs/supported-node-versions')} for more information`,
+See ${chalk.underline.blue('https://docs.ghost.org/docs/supported-node-versions')} for more information`,
             task: taskTitle
         }));
     }

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -28,7 +28,7 @@ class UpdateCommand extends Command {
             this.ui.log(
                 `Ghost was installed with Ghost-CLI v${instance.cliVersion}, which is a pre-release version.\n` +
                 'Your Ghost install is using out-of-date configuration & requires manual changes.\n' +
-                `For instructions on how to upgrade your instance, visit ${chalk.blue.underline('https://docs.ghost.org/v1/docs/how-to-upgrade-ghost#section-upgrading-ghost-cli')}.\n`,
+                `For instructions on how to upgrade your instance, visit ${chalk.blue.underline('https://docs.ghost.org/docs/upgrade#section-upgrading-ghost-installs-that-used-ghost-cli-1-0-0')}.\n`,
                 'yellow'
             );
         }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -27,7 +27,7 @@ class CliError extends Error {
         this.options = options;
         this.logMessageOnly = options.logMessageOnly;
 
-        this.help = 'You can always refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.';
+        this.help = 'You can always refer to https://docs.ghost.org/docs/troubleshooting#section-cli-errors for troubleshooting.';
 
         if (options.err) {
             if (typeof options.err === 'string') {

--- a/lib/tasks/migrator.js
+++ b/lib/tasks/migrator.js
@@ -34,7 +34,7 @@ const errorHandler = (context) => {
             error = new errors.SystemError({
                 message: 'It appears that sqlite3 did not install properly when Ghost-CLI was installed.\n' +
                 'You can either uninstall and reinstall Ghost-CLI, or switch to MySQL',
-                help: 'https://docs.ghost.org/v1/docs/troubleshooting#section-sqlite3-install-failure'
+                help: 'https://docs.ghost.org/docs/troubleshooting#section-sqlite3-install-failure'
             });
         } else {
             // only show suggestion on `ghost update`
@@ -42,7 +42,7 @@ const errorHandler = (context) => {
                 message: 'The database migration in Ghost encountered an error.',
                 stderr: error.stderr,
                 environment: context.instance.system.environment,
-                help: 'https://docs.ghost.org/v1/docs/troubleshooting#section-general-update-error',
+                help: 'https://docs.ghost.org/docs/troubleshooting#section-general-update-error',
                 suggestion: process.argv.slice(2, 3).join(' ') === 'update' ? 'ghost update --rollback' : null
             });
         }

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -416,7 +416,7 @@ class UI {
             }
 
             this.log(`\nTry running ${(chalk.cyan('ghost doctor'))} to check your system for known issues.`);
-            this.log('\nYou can always refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
+            this.log('\nYou can always refer to https://docs.ghost.org/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
         } else if (error instanceof Error) {
             // System errors or regular old errors go here.
             let output = `An error occurred.\n${chalk.yellow('Message:')} '${error.message}'\n\n`;
@@ -445,7 +445,7 @@ class UI {
             const logLocation = system.writeErrorLog(stripAnsi(`${debugInfo}\n${output}`));
             this.log(`\nAdditional log info available in: ${logLocation}`);
             this.log(`\nTry running ${(chalk.cyan('ghost doctor'))} to check your system for known issues.`);
-            this.log('\nYou can always refer to https://docs.ghost.org/v1/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
+            this.log('\nYou can always refer to https://docs.ghost.org/docs/troubleshooting#section-cli-errors for troubleshooting.', 'blue');
         } else if (isObject(error)) {
             // TODO: find better way to handle object errors?
             this.log(JSON.stringify(error), null, true);

--- a/lib/utils/check-valid-install.js
+++ b/lib/utils/check-valid-install.js
@@ -18,7 +18,7 @@ function checkValidInstall(name) {
      */
     if (fs.existsSync(path.join(process.cwd(), 'config.js'))) {
         console.error(`${chalk.yellow('Ghost-CLI only works with Ghost versions >= 1.0.0.')}
-If you are trying to upgrade Ghost LTS to 1.0.0, refer to ${chalk.blue.underline('https://docs.ghost.org/v1/docs/migrating-to-ghost-1-0-0')}.
+If you are trying to upgrade Ghost LTS to 1.0.0, refer to ${chalk.blue.underline('https://docs.ghost.org/docs/migrating-to-ghost-1-0-0')}.
 Otherwise, run \`ghost ${name}\` again within a valid Ghost installation.`);
 
         process.exit(1);


### PR DESCRIPTION
closes #828
- replace /v1 docs links with their non-versioned counterparts
- correct links pointing to the wrong section of docs