### PR TITLE
fix(pre-check): don't run config check if folder doesn't exist

### DIFF
--- a/lib/utils/pre-checks.js
+++ b/lib/utils/pre-checks.js
@@ -12,6 +12,8 @@ const pkg = require('../../package.json');
  * @param {System} system System instance
  */
 module.exports = function preChecks(ui, system) {
+    const configstore = path.join(os.homedir(), '.config');
+
     const tasks = [{
         title: 'Checking for Ghost-CLI updates',
         task: () => latestVersion(pkg.name).then((latest) => {
@@ -28,20 +30,16 @@ module.exports = function preChecks(ui, system) {
         })
     }, {
         title: 'Ensuring correct ~/.config folder ownership',
-        task: () => {
-            const configstore = path.join(os.homedir(), '.config');
+        task: () => fs.lstat(configstore).then((stats) => {
+            if (stats.uid === process.getuid() && stats.gid === process.getgid()) {
+                return;
+            }
 
-            return fs.lstat(configstore).then((stats) => {
-                if (stats.uid === process.getuid() && stats.gid === process.getgid()) {
-                    return;
-                }
+            const {USER} = process.env;
 
-                const {USER} = process.env;
-
-                return ui.sudo(`chown -R ${USER}:${USER} ${configstore}`);
-            });
-        },
-        enabled: () => system.platform.linux
+            return ui.sudo(`chown -R ${USER}:${USER} ${configstore}`);
+        }),
+        enabled: () => system.platform.linux && fs.existsSync(configstore)
     }];
 
     return ui.listr(tasks, {}, {clearOnSuccess: true});


### PR DESCRIPTION
closes #834
- add fs.existsSync check to task `enabled` fn