### PR TITLE
[Enhancement] Delete bootstrap-socket once ghost is stopped

### DIFF
--- a/extensions/systemd/systemd.js
+++ b/extensions/systemd/systemd.js
@@ -35,6 +35,10 @@ class SystemdProcessManager extends ProcessManager {
             })
             .then(() => this.ui.sudo(`systemctl start ${this.systemdName}`))
             .then(() => this.ensureStarted({logSuggestion, socketAddress}))
+            .then(() => {
+                this.instance.config.set('bootstrap-socket', null);
+                return this.instance.config.save();
+            })
             .catch((error) => {
                 if (error instanceof CliError) {
                     throw error;
@@ -70,6 +74,10 @@ class SystemdProcessManager extends ProcessManager {
             })
             .then(() => this.ui.sudo(`systemctl restart ${this.systemdName}`))
             .then(() => this.ensureStarted({logSuggestion, socketAddress}))
+            .then(() => {
+                this.instance.config.set('bootstrap-socket', null);
+                return this.instance.config.save();
+            })
             .catch((error) => {
                 if (error instanceof CliError) {
                     throw error;


### PR DESCRIPTION
Expecting to fix #805, @kirrg001 please provide any feedback. I also thought in adding this line inside a `.then()` once the `systemctl stop ${this.systemdName}` had run, what do you think?