### PR TITLE
Bumped Node v10 min version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "engines": {
-    "node": "^6.9.0 || ^8.9.0 || ^10.12.0"
+    "node": "^6.9.0 || ^8.9.0 || ^10.13.0"
   },
   "preferGlobal": true,
   "dependencies": {


### PR DESCRIPTION
no issue

- see https://nodejs.org/en/blog/release/v10.13.0/

@acburdine This needs a new release. If this is released in the CLI, we can release https://github.com/TryGhost/Ghost/pull/10125.

