### PR TITLE
chore(docs): update links to new docs site

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -14,7 +14,7 @@ Please be aware that the team behind the Ghost CLI only supports the recommended
 
 ### Summary
 
-Search GitHub for existing issues & check the docs: https://docs.ghost.org/docs/troubleshooting. If you're still stuck, please provide a quick summary of the problem, steps to reproduce, and full tech details including logs.
+Search GitHub for existing issues & check the docs: https://docs.ghost.org/faq/errors/. If you're still stuck, please provide a quick summary of the problem, steps to reproduce, and full tech details including logs.
 
 ### Steps to Reproduce
 

--- a/.github/ISSUE_TEMPLATE/--anything-else.md
+++ b/.github/ISSUE_TEMPLATE/--anything-else.md
@@ -14,5 +14,5 @@ Alternatively, check out these resources below. Thanks! 😁.
 - [Ghost-CLI docs](https://docs.ghost.org/api/ghost-cli/)
 - [Forum Support](https://forum.ghost.org/c/help)
 - [Ideas](https://forum.ghost.org/c/Ideas)
-- [Contributing Guide](https://docs.ghost.org/docs/contributing)
-- [Self-hoster Docs](http://docs.ghost.org/docs/)
+- [Contributing Guide](https://docs.ghost.org/concepts/contributing)
+- [Self-hoster Docs](https://docs.ghost.org/install/ubuntu/)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Documentation
 
-- [Complete Setup Guide](https://docs.ghost.org/setup/)
+- [Complete Setup Guide](https://docs.ghost.org/install/ubuntu/)
 - [Command Reference](https://docs.ghost.org/api/ghost-cli/)
 - [Knowledgebase](https://docs.ghost.org/api/ghost-cli/knowledgebase/)
 - [Forum](https://forum.ghost.org)

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -66,7 +66,7 @@ class StartCommand extends Command {
 
                         // Show a warning about direct mail - but in grey, it's not the most important message here
                         if (isInstall && instance.config.get('mail.transport') === 'Direct') {
-                            this.ui.log('\nGhost uses direct mail by default. To set up an alternative email method read our docs at https://ghost.org/mail', 'gray');
+                            this.ui.log('\nGhost uses direct mail by default. To set up an alternative email method read our docs at https://docs.ghost.org/concepts/config/#mail', 'gray');
                         }
 
                         this.ui.log('\n------------------------------------------------------------------------------', 'white');

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -28,7 +28,7 @@ class UpdateCommand extends Command {
             this.ui.log(
                 `Ghost was installed with Ghost-CLI v${instance.cliVersion}, which is a pre-release version.\n` +
                 'Your Ghost install is using out-of-date configuration & requires manual changes.\n' +
-                `For instructions on how to upgrade your instance, visit ${chalk.blue.underline('https://docs.ghost.org/docs/upgrade#section-upgrading-ghost-installs-that-used-ghost-cli-1-0-0')}.\n`,
+                `For instructions on how to upgrade your instance, visit ${chalk.blue.underline('https://docs.ghost.org/faq/upgrading-from-deprecated-ghost-cli/')}.\n`,
                 'yellow'
             );
         }

--- a/lib/tasks/major-update/ui.js
+++ b/lib/tasks/major-update/ui.js
@@ -97,7 +97,7 @@ module.exports = function ui(ctx) {
 
         if (results.hasFatalErrors) {
             return Promise.reject(new errors.CliError({
-                message: 'Migration failed. Your theme has fatal errors.\n  For additional theme help visit https://themes.ghost.org/docs/changelog',
+                message: 'Migration failed. Your theme has fatal errors.\n  For additional theme help visit https://docs.ghost.org/api/handlebars-themes/',
                 logMessageOnly: true
             }));
         }

--- a/lib/tasks/migrator.js
+++ b/lib/tasks/migrator.js
@@ -34,7 +34,7 @@ const errorHandler = (context) => {
             error = new errors.SystemError({
                 message: 'It appears that sqlite3 did not install properly when Ghost-CLI was installed.\n' +
                 'You can either uninstall and reinstall Ghost-CLI, or switch to MySQL',
-                help: 'https://docs.ghost.org/docs/troubleshooting#section-sqlite3-install-failure'
+                help: 'https://docs.ghost.org/faq/errors/'
             });
         } else {
             // only show suggestion on `ghost update`
@@ -42,7 +42,7 @@ const errorHandler = (context) => {
                 message: 'The database migration in Ghost encountered an error.',
                 stderr: error.stderr,
                 environment: context.instance.system.environment,
-                help: 'https://docs.ghost.org/docs/troubleshooting#section-general-update-error',
+                help: 'https://docs.ghost.org/faq/upgrade-to-ghost-2-0/#what-to-do-when-an-upgrade-fails',
                 suggestion: process.argv.slice(2, 3).join(' ') === 'update' ? 'ghost update --rollback' : null
             });
         }


### PR DESCRIPTION
no issue
- update old docs links

@ErisDS @kirrg001 I had to guess at some of the link replacements, as the original docs for some of the troubleshooting things weren't available.