### PR TITLE
feat(yarn): use package-json instead of yarn for version resolution

### DIFF
--- a/lib/tasks/yarn-install.js
+++ b/lib/tasks/yarn-install.js
@@ -1,42 +1,30 @@
 'use strict';
 const fs = require('fs-extra');
-const semver = require('semver');
 const shasum = require('shasum');
 const download = require('download');
 const decompress = require('decompress');
 const cliPackage = require('../../package.json');
+const packageInfo = require('package-json');
+const {prerelease, satisfies} = require('semver');
 
 const errors = require('../errors');
 const yarn = require('../utils/yarn');
 
 const subTasks = {
-    dist: ctx => yarn(['info', `ghost@${ctx.version}`, '--json']).then((result) => {
-        let data;
+    dist: ctx => packageInfo('ghost', {version: ctx.version}).then(({dist, engines = {}}) => {
+        const skipNodeVersionCheck = (process.env.GHOST_NODE_VERSION_CHECK === 'false');
+        const isPrerelease = Boolean(prerelease(cliPackage.version));
 
-        try {
-            const parsed = JSON.parse(result.stdout);
-            data = parsed && parsed.data;
-        } catch (e) {
-            // invalid response from yarn command, ignore JSON parse error
-        }
-
-        if (!data || !data.dist) {
-            return Promise.reject(new errors.CliError('Ghost download information could not be read correctly.'));
-        }
-
-        if (
-            process.env.GHOST_NODE_VERSION_CHECK !== 'false' &&
-                data.engines && data.engines.node && !semver.satisfies(process.versions.node, data.engines.node)
-        ) {
+        if (!skipNodeVersionCheck && engines.node && !satisfies(process.versions.node, engines.node)) {
             return Promise.reject(new errors.SystemError(`Ghost v${ctx.version} is not compatible with the current Node version.`));
         }
 
-        if (data.engines && data.engines.cli && !semver.prerelease(cliPackage.version) && !semver.satisfies(cliPackage.version, data.engines.cli)) {
+        if (engines.cli && !isPrerelease && !satisfies(cliPackage.version, engines.cli)) {
             return Promise.reject(new errors.SystemError(`Ghost v${ctx.version} is not compatible with this version of the CLI.`));
         }
 
-        ctx.shasum = data.dist.shasum;
-        ctx.tarball = data.dist.tarball;
+        ctx.shasum = dist.shasum;
+        ctx.tarball = dist.tarball;
     }),
     download: ctx => download(ctx.tarball).then((data) => {
         if (shasum(data) !== ctx.shasum) {

--- a/lib/utils/resolve-version.js
+++ b/lib/utils/resolve-version.js
@@ -1,8 +1,8 @@
 'use strict';
 const semver = require('semver');
 const Promise = require('bluebird');
+const packageInfo = require('package-json');
 
-const yarn = require('./yarn');
 const errors = require('../errors');
 const MIN_RELEASE = '>= 1.0.0';
 
@@ -28,72 +28,64 @@ module.exports = function resolveVersion(version, activeVersion, v1 = false, for
         }));
     }
 
-    return yarn(['info', 'ghost', 'versions', '--json']).then((result) => {
-        let comparator;
+    let comparator;
 
-        if (!force && activeVersion) {
-            comparator = `>${activeVersion}`;
-        } else if (force && activeVersion) {
-            comparator = `>=${activeVersion}`;
-        } else {
-            comparator = MIN_RELEASE;
-        }
+    if (!force && activeVersion) {
+        comparator = `>${activeVersion}`;
+    } else if (force && activeVersion) {
+        comparator = `>=${activeVersion}`;
+    } else {
+        comparator = MIN_RELEASE;
+    }
 
-        if (v1) {
-            comparator += ' <2.0.0';
-        }
+    if (v1) {
+        comparator += ' <2.0.0';
+    }
 
-        try {
-            let versions = JSON.parse(result.stdout).data || [];
-            versions = versions.filter(availableVersion => semver.satisfies(availableVersion, comparator));
+    return packageInfo('ghost', {allVersions: true}).then((result) => {
+        const versions = Object.keys(result.versions).filter(v => semver.satisfies(v, comparator));
 
-            if (!versions.length) {
-                return Promise.reject(new errors.CliError({
-                    message: 'No valid versions found.',
-                    log: false
-                }));
-            }
-
-            if (version && !versions.includes(version)) {
-                return Promise.reject(new errors.CliError({
-                    message: `Invalid version specified: ${version}`,
-                    log: false
-                }));
-            }
-
-            let versionToReturn = version || versions.pop();
-
-            // CASE: you haven't passed `--v1` and you are not about to install a fresh blog
-            if (!v1 && activeVersion) {
-                const majorVersionJump = semver.major(activeVersion) !== semver.major(versionToReturn);
-                const v1Versions = versions.filter(version => semver.satisfies(version, `^${activeVersion}`));
-
-                // CASE 1: you want to force update and you are not on the latest v1 version
-                // CASE 2: you don't use force and you are not on the latest v1 version
-                if (majorVersionJump && force && versions.length > 1) {
-                    const latestV2 = versionToReturn;
-                    while (!semver.satisfies(versionToReturn, '^1.0.0')) {
-                        versionToReturn = versions.pop();
-                    }
-
-                    // super dirty hack @todo: fixme
-                    if (versionToReturn === activeVersion) {
-                        versionToReturn = latestV2;
-                    }
-                } else if (majorVersionJump && !force && v1Versions.length) {
-                    return Promise.reject(new errors.CliError({
-                        message: 'You are about to migrate to Ghost 2.0. Your blog is not on the latest Ghost 1.0 version.',
-                        help: 'Instead run "ghost update --v1".'
-                    }));
-                }
-            }
-
-            return versionToReturn;
-        } catch (e) {
+        if (!versions.length) {
             return Promise.reject(new errors.CliError({
-                message: 'Ghost-CLI was unable to load versions from Yarn.',
+                message: 'No valid versions found.',
                 log: false
             }));
         }
+
+        if (version && !versions.includes(version)) {
+            return Promise.reject(new errors.CliError({
+                message: `Invalid version specified: ${version}`,
+                log: false
+            }));
+        }
+
+        let versionToReturn = version || versions.pop();
+
+        // CASE: you haven't passed `--v1` and you are not about to install a fresh blog
+        if (!v1 && activeVersion) {
+            const majorVersionJump = semver.major(activeVersion) !== semver.major(versionToReturn);
+            const v1Versions = versions.filter(version => semver.satisfies(version, `^${activeVersion}`));
+
+            // CASE 1: you want to force update and you are not on the latest v1 version
+            // CASE 2: you don't use force and you are not on the latest v1 version
+            if (majorVersionJump && force && versions.length > 1) {
+                const latestV2 = versionToReturn;
+                while (!semver.satisfies(versionToReturn, '^1.0.0')) {
+                    versionToReturn = versions.pop();
+                }
+
+                // super dirty hack @todo: fixme
+                if (versionToReturn === activeVersion) {
+                    versionToReturn = latestV2;
+                }
+            } else if (majorVersionJump && !force && v1Versions.length) {
+                return Promise.reject(new errors.CliError({
+                    message: 'You are about to migrate to Ghost 2.0. Your blog is not on the latest Ghost 1.0 version.',
+                    help: 'Instead run "ghost update --v1".'
+                }));
+            }
+        }
+
+        return versionToReturn;
     });
 };

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "moment": "2.23.0",
     "mysql": "2.16.0",
     "ora": "3.0.0",
+    "package-json": "5.0.0",
     "path-is-root": "0.1.0",
     "portfinder": "1.0.20",
     "prettyjson": "1.2.1",

--- a/test/unit/utils/resolve-version-spec.js
+++ b/test/unit/utils/resolve-version-spec.js
@@ -2,19 +2,20 @@
 const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 
-let resolveVersion;
+function stub(versions = []) {
+    const data = versions.reduce((obj, v) => {
+        obj.versions[v] = true;
+        return obj;
+    }, {versions: {}});
 
-function stubYarn(result) {
-    resolveVersion = proxyquire('../../../lib/utils/resolve-version', {
-        './yarn': function () {
-            return Promise.resolve({stdout: result});
-        }
+    return proxyquire('../../../lib/utils/resolve-version', {
+        'package-json': () => Promise.resolve(data)
     });
 }
 
 describe('Unit: resolveVersion', function () {
     it('rejects for versions less than 1.0.0-alpha.1', function () {
-        stubYarn('');
+        const resolveVersion = stub();
 
         return resolveVersion('0.11.0').then(function () {
             throw new Error('Version finder should not have resolved.');
@@ -24,30 +25,8 @@ describe('Unit: resolveVersion', function () {
         });
     });
 
-    it('rejects if result from yarn is invalid JSON', function () {
-        stubYarn('invalid json');
-
-        return resolveVersion().then(function () {
-            throw new Error('Version finder should not have resolved.');
-        }).catch(function (error) {
-            expect(error).to.be.an.instanceOf(Error);
-            expect(error.message).to.equal('Ghost-CLI was unable to load versions from Yarn.');
-        });
-    });
-
-    it('defaults versions to none', function () {
-        stubYarn('{}');
-
-        return resolveVersion().then(function () {
-            throw new Error('Version finder should not have resolved.');
-        }).catch(function (error) {
-            expect(error).to.be.an.instanceOf(Error);
-            expect(error.message).to.equal('No valid versions found.');
-        });
-    });
-
     it('rejects if no versions are found', function () {
-        stubYarn('{"data": []}');
+        const resolveVersion = stub();
 
         return resolveVersion().then(function () {
             throw new Error('Version finder should not have resolved');
@@ -59,7 +38,7 @@ describe('Unit: resolveVersion', function () {
 
     describe('without existing version', function () {
         it('correctly filters out versions less than 1.0.0-alpha.1', function () {
-            stubYarn('{"data": ["0.10.1", "0.11.0"]}');
+            const resolveVersion = stub(['0.10.1', '0.11.0']);
 
             return resolveVersion().then(function () {
                 throw new Error('Version finder should not have resolved');
@@ -70,7 +49,7 @@ describe('Unit: resolveVersion', function () {
         });
 
         it('errors if specified version is not in list of valid versions', function () {
-            stubYarn('{"data": ["1.0.0", "1.0.1"]}');
+            const resolveVersion = stub(['1.0.0', '1.0.1']);
 
             return resolveVersion('1.0.5').then(function () {
                 throw new Error('Version finder should not have resolved');
@@ -81,7 +60,7 @@ describe('Unit: resolveVersion', function () {
         });
 
         it('resolves with specified version if it exists and is valid', function () {
-            stubYarn('{"data": ["1.0.0", "1.0.1"]}');
+            const resolveVersion = stub(['1.0.0', '1.0.1']);
 
             return resolveVersion('1.0.0').then(function (version) {
                 expect(version).to.equal('1.0.0');
@@ -89,7 +68,7 @@ describe('Unit: resolveVersion', function () {
         });
 
         it('allows a v in front of the version number', function () {
-            stubYarn('{"data": ["1.0.0", "1.0.1"]}');
+            const resolveVersion = stub(['1.0.0', '1.0.1']);
 
             return resolveVersion('v1.0.0').then(function (version) {
                 expect(version).to.equal('1.0.0');
@@ -97,7 +76,7 @@ describe('Unit: resolveVersion', function () {
         });
 
         it('resolves with latest version if no version specified', function () {
-            stubYarn('{"data": ["1.0.0", "1.0.1"]}');
+            const resolveVersion = stub(['1.0.0', '1.0.1']);
 
             return resolveVersion().then(function (version) {
                 expect(version).to.equal('1.0.1');
@@ -105,7 +84,7 @@ describe('Unit: resolveVersion', function () {
         });
 
         it('filters out 2.0 version if v1 param is specified', function () {
-            stubYarn('{"data": ["1.0.0", "1.0.1", "1.52.37", "2.0.0", "2.0.1"]}');
+            const resolveVersion = stub(['1.0.0', '1.0.1', '1.52.37', '2.0.0', '2.0.1']);
 
             return resolveVersion(null, null, true).then(function (version) {
                 expect(version).to.equal('1.52.37');
@@ -115,7 +94,7 @@ describe('Unit: resolveVersion', function () {
 
     describe('with existing version', function () {
         it('correctly filters out all versions greater than the specified one', function () {
-            stubYarn('{"data": ["1.0.0", "1.0.1"]}');
+            const resolveVersion = stub(['1.0.0', '1.0.1']);
 
             return resolveVersion(null, '1.0.1').then(function () {
                 throw new Error('Version finder should not have resolved');
@@ -126,7 +105,7 @@ describe('Unit: resolveVersion', function () {
         });
 
         it('filters out 2.0 version if v1 param is specified', function () {
-            stubYarn('{"data": ["1.0.0", "1.0.1", "1.52.37", "2.0.0", "2.0.1"]}');
+            const resolveVersion = stub(['1.0.0', '1.0.1', '1.52.37', '2.0.0', '2.0.1']);
 
             return resolveVersion(null, '1.52.37', true).then(function () {
                 throw new Error('Version finder should not have resolved');
@@ -137,7 +116,7 @@ describe('Unit: resolveVersion', function () {
         });
 
         it('allows upgrading from v2 to next v2', function () {
-            stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0", "2.0.1"]}');
+            const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0', '2.0.1']);
 
             return resolveVersion(null, '2.0.0').then(function (version) {
                 expect(version).to.equal('2.0.1');
@@ -146,7 +125,7 @@ describe('Unit: resolveVersion', function () {
 
         describe('jump to next major', function () {
             it('throws error if you aren\'t on the latest v1', function () {
-                stubYarn('{"data": ["1.23.0", "1.24.0", "1.25.0", "2.0.0", "2.0.1"]}');
+                const resolveVersion = stub(['1.23.0', '1.24.0', '1.25.0', '2.0.0', '2.0.1']);
 
                 return resolveVersion(null, '1.24.0', false).then(function () {
                     throw new Error('Version finder should not have resolved');
@@ -157,7 +136,7 @@ describe('Unit: resolveVersion', function () {
             });
 
             it('resolves if you are on the latest v1', function () {
-                stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0", "2.0.1"]}');
+                const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0', '2.0.1']);
 
                 return resolveVersion(null, '1.25.2', false)
                     .then(function (version) {
@@ -166,7 +145,7 @@ describe('Unit: resolveVersion', function () {
             });
 
             it('resolves using `--v1` and you are\'t on the latest v1', function () {
-                stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0", "2.0.1"]}');
+                const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0', '2.0.1']);
 
                 return resolveVersion(null, '1.25.1', true)
                     .then(function (version) {
@@ -175,7 +154,7 @@ describe('Unit: resolveVersion', function () {
             });
 
             it('updates to latest v2 with many v2 releases', function () {
-                stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0", "2.1.0", "2.2.0"]}');
+                const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0', '2.1.0', '2.2.0']);
 
                 return resolveVersion(null, '1.25.2', false, false)
                     .then(function (version) {
@@ -184,7 +163,7 @@ describe('Unit: resolveVersion', function () {
             });
 
             it('force updating and you are on the latest v1', function () {
-                stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0", "2.0.1"]}');
+                const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0', '2.0.1']);
 
                 return resolveVersion(null, '1.25.2', false, true)
                     .then(function (version) {
@@ -193,7 +172,7 @@ describe('Unit: resolveVersion', function () {
             });
 
             it('force updating with `--v1`', function () {
-                stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0", "2.0.1"]}');
+                const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0', '2.0.1']);
 
                 return resolveVersion(null, '1.25.1', true, true)
                     .then(function (version) {
@@ -202,7 +181,7 @@ describe('Unit: resolveVersion', function () {
             });
 
             it('force updating with many v2 releases', function () {
-                stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0", "2.1.0", "2.2.0"]}');
+                const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0', '2.1.0', '2.2.0']);
 
                 return resolveVersion(null, '1.25.1', false, true)
                     .then(function (version) {
@@ -211,7 +190,7 @@ describe('Unit: resolveVersion', function () {
             });
 
             it('throws error if you want to force updating to a previous major', function () {
-                stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0"]}');
+                const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0']);
 
                 return resolveVersion(null, '2.0.0', true, true)
                     .then(function () {
@@ -224,7 +203,7 @@ describe('Unit: resolveVersion', function () {
             });
 
             it('throws error if you want to update to a previous major', function () {
-                stubYarn('{"data": ["1.23.0", "1.25.1", "1.25.2", "2.0.0"]}');
+                const resolveVersion = stub(['1.23.0', '1.25.1', '1.25.2', '2.0.0']);
 
                 return resolveVersion(null, '2.0.0', true, false)
                     .then(function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,7 +3208,7 @@ package-hash@^2.0.0:
     md5-hex "^2.0.0"
     release-zalgo "^1.0.0"
 
-package-json@^5.0.0:
+package-json@5.0.0, package-json@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-5.0.0.tgz#a7dbe2725edcc7dc9bcee627672275e323882433"
   integrity sha512-EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==


### PR DESCRIPTION
While investigating/testing the update notification stuff for prerelease versions, I realized that the `package-json` package exists and that we already depend on it through the `latest-version` package. 

This PR removes some of the places where we were shelling out to the `yarn` command in favor of simply calling the `package-json` module. Simplifies the code and probably improves perf a bit due to not having to spin up yarn each time.

TODO:
- [x] fix tests