### PR TITLE
fix(install): ignore dotfiles except for .ghost-cli in dir check

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -13,17 +13,15 @@ class InstallCommand extends Command {
     }
 
     run(argv) {
-        const fs = require('fs-extra');
-        const every = require('lodash/every');
         const errors = require('../errors');
         const yarnInstall = require('../tasks/yarn-install');
+        const dirIsEmpty = require('../utils/dir-is-empty');
         const ensureStructure = require('../tasks/ensure-structure');
 
         let version = argv.version;
-        const filesInDir = fs.readdirSync(process.cwd());
 
-        // Check if there are existing files that *aren't* ghost-cli debug log files
-        if (filesInDir.length && !every(filesInDir, file => file.match(/^ghost-cli-debug-.*\.log$/i))) {
+        // Check if the directory is empty
+        if (!dirIsEmpty(process.cwd())) {
             return Promise.reject(new errors.SystemError('Current directory is not empty, Ghost cannot be installed here.'));
         }
 

--- a/lib/utils/dir-is-empty.js
+++ b/lib/utils/dir-is-empty.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+const debugLogRegex = /^ghost-cli-debug-.*\.log$/i;
+const importantDotfiles = ['.ghost-cli'];
+
+module.exports = function dirIsEmpty(dir) {
+    const files = fs.readdirSync(dir);
+
+    if (!files.length) {
+        return true;
+    }
+
+    return files.every(file => file.match(debugLogRegex) || (file.startsWith('.') && !importantDotfiles.includes(file)));
+};

--- a/test/unit/utils/dir-is-empty.js
+++ b/test/unit/utils/dir-is-empty.js
@@ -1,0 +1,33 @@
+const proxyquire = require('proxyquire');
+const {expect} = require('chai');
+
+const proxy = files => proxyquire('../../../lib/utils/dir-is-empty', {
+    fs: {readdirSync: () => files}
+});
+
+describe('Unit: Utils > dirIsEmpty', function () {
+    it('returns true if directory is empty', function () {
+        const fn = proxy([]);
+        expect(fn('dir')).to.be.true;
+    });
+
+    it('returns true if directory contains ghost debug log files', function () {
+        const fn = proxy(['ghost-cli-debug-1234.log']);
+        expect(fn('dir')).to.be.true;
+    });
+
+    it('returns true if directory contains dotfiles other than .ghost-cli', function () {
+        const fn = proxy(['.npmrc', '.gitignore']);
+        expect(fn('dir')).to.be.true;
+    });
+
+    it('returns false if directory contains .ghost-cli file', function () {
+        const fn = proxy(['.ghost-cli']);
+        expect(fn('dir')).to.be.false;
+    });
+
+    it('returns false if directory contains other files', function () {
+        const fn = proxy(['file.txt', 'file2.txt']);
+        expect(fn('dir')).to.be.false;
+    });
+});


### PR DESCRIPTION
closes #868
- add dir-is-empty util that checks empty directories correctly

TODO:
- [x] fix install cmd tests