### PR TITLE
docs(nginx): add note to conf file about acme.sh root

### DIFF
--- a/extensions/nginx/templates/nginx-ssl.conf
+++ b/extensions/nginx/templates/nginx-ssl.conf
@@ -3,7 +3,7 @@ server {
     listen [::]:443 ssl http2;
 
     server_name <%= url %>;
-    root <%= webroot %>;
+    root <%= webroot %>; # Used for acme.sh SSL verification (https://acme.sh)
 
     ssl_certificate <%= fullchain %>;
     ssl_certificate_key <%= privkey %>;

--- a/extensions/nginx/templates/nginx.conf
+++ b/extensions/nginx/templates/nginx.conf
@@ -3,7 +3,7 @@ server {
     listen [::]:80;
 
     server_name <%= url %>;
-    root <%= webroot %>;
+    root <%= webroot %>; # Used for acme.sh SSL verification (https://acme.sh)
 
     location <%= location %> {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
closes #843
- add comment about acme.sh requirement

doesn't really need a migration imo since it's only a documentation update