### PR TITLE
refactor(base): use async/await in base classes

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,4 +1,3 @@
-'use strict';
 const fs = require('fs-extra');
 const each = require('lodash/each');
 const path = require('path');

--- a/lib/command.js
+++ b/lib/command.js
@@ -2,8 +2,6 @@
  * Inspired by the Denali-CLI command class
  * https://github.com/denali-js/denali-cli/blob/master/lib/command.ts
  */
-'use strict';
-
 const each = require('lodash/each');
 const createDebug = require('debug');
 const kebabCase = require('lodash/kebabCase');
@@ -107,7 +105,7 @@ class Command {
      * @method run
      * @private
      */
-    static _run(commandName, argv = {}, extensions) {
+    static async _run(commandName, argv = {}, extensions) {
         debug('running command prep');
         // Set process title
         process.title = `ghost ${commandName}`;
@@ -170,25 +168,22 @@ class Command {
                 .removeAllListeners('SIGTERM').on('SIGTERM', cleanup);
         }
 
-        let precheck = Promise.resolve();
+        try {
+            if (this.runPreChecks) {
+                const preChecks = require('./utils/pre-checks');
+                await preChecks(ui, system);
+            }
 
-        if (this.runPreChecks) {
-            const preChecks = require('./utils/pre-checks');
-            precheck = preChecks(ui, system);
-        }
-
-        return precheck.then(() => {
-            // Run ze command
             debug(`running command ${commandName}`);
-            return Promise.resolve(commandInstance.run(argv));
-        }).catch((error) => {
+            await commandInstance.run(argv);
+        } catch (error) {
             debug(`command ${commandName} failed!`);
 
             // Handle an error
             ui.error(error, system);
 
             process.exit(1);
-        });
+        }
     }
 
     /**
@@ -208,7 +203,7 @@ class Command {
      * @method run
      * @public
      */
-    run() {
+    async run() {
         throw new Error('Command must implement run function');
     }
 
@@ -219,13 +214,13 @@ class Command {
      * @method runCommand
      * @public
      */
-    runCommand(CommandClass, argv) {
+    async runCommand(CommandClass, argv) {
         if (!(CommandClass.prototype instanceof Command)) {
-            return Promise.reject(new Error('Provided command class does not extend the Command class'));
+            throw new Error('Provided command class does not extend the Command class');
         }
 
         const cmdInstance = new CommandClass(this.ui, this.system);
-        return Promise.resolve(cmdInstance.run(argv || {}));
+        return cmdInstance.run(argv || {});
     }
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,4 +1,3 @@
-'use strict';
 const chalk = require('chalk');
 
 /**

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -1,8 +1,6 @@
-'use strict';
 const fs = require('fs-extra');
 const path = require('path');
 const mapValues = require('lodash/mapValues');
-const Promise = require('bluebird');
 
 /**
  * Handles various extension-related behavior
@@ -56,12 +54,12 @@ class Extension {
      * @method template
      * @public
      */
-    template(instance, contents, descriptor, file, dir) {
+    async template(instance, contents, descriptor, file, dir) {
         // If `--no-prompt` is passed to the CLI or the `--verbose` flag was not passed, don't show anything
         if (!this.ui.allowPrompt || !this.ui.verbose) {
             return this._generateTemplate(instance, contents, descriptor, file, dir);
         } else {
-            return this.ui.prompt({
+            const {choice} = await this.ui.prompt({
                 type: 'expand',
                 name: 'choice',
                 message: `Would you like to view or edit the ${descriptor} file?`,
@@ -71,31 +69,28 @@ class Extension {
                     {key: 'v', name: 'View the file', value: 'view'},
                     {key: 'e', name: 'Edit the file before generation', value: 'edit'}
                 ]
-            }).then((answer) => {
-                const choice = answer.choice;
-
-                if (choice === 'continue') {
-                    return this._generateTemplate(instance, contents, descriptor, file, dir);
-                }
-
-                if (choice === 'view') {
-                    this.ui.log(contents);
-                    return this.template(instance, contents, descriptor, file, dir);
-                }
-
-                /* istanbul ignore else */
-                if (choice === 'edit') {
-                    return this.ui.prompt({
-                        type: 'editor',
-                        name: 'contents',
-                        message: 'Edit the generated file',
-                        default: contents
-                    }).then((answer) => {
-                        contents = answer.contents;
-                        return this._generateTemplate(instance, contents, descriptor, file, dir);
-                    });
-                }
             });
+
+            if (choice === 'continue') {
+                return this._generateTemplate(instance, contents, descriptor, file, dir);
+            }
+
+            if (choice === 'view') {
+                this.ui.log(contents);
+                return this.template(instance, contents, descriptor, file, dir);
+            }
+
+            /* istanbul ignore else */
+            if (choice === 'edit') {
+                const answer = await this.ui.prompt({
+                    type: 'editor',
+                    name: 'contents',
+                    message: 'Edit the generated file',
+                    default: contents
+                });
+
+                return this._generateTemplate(instance, answer.contents, descriptor, file, dir);
+            }
         }
     }
 
@@ -109,25 +104,23 @@ class Extension {
      * @param {string} dir Directory to link
      * @return {bool} True if the file was successfully created & linked
      */
-    _generateTemplate(instance, contents, descriptor, file, dir) {
+    async _generateTemplate(instance, contents, descriptor, file, dir) {
         const tmplDir = path.join(instance.dir, 'system', 'files');
         const tmplFile = path.join(tmplDir, file);
-
-        const promises = [
-            () => fs.ensureDir(tmplDir),
-            () => fs.writeFile(tmplFile, contents)
-        ];
 
         // Dir is optional, if a file just needs to be created locally
         // so we log here
         this.ui.success(`Creating ${descriptor} file at ${tmplFile}`);
 
+        await fs.ensureDir(tmplDir);
+        await fs.writeFile(tmplFile, contents);
+
         if (dir) {
             const outputLocation = path.join(dir, file);
-            promises.push(() => this.ui.sudo(`ln -sf ${tmplFile} ${outputLocation}`));
+            await this.ui.sudo(`ln -sf ${tmplFile} ${outputLocation}`);
         }
 
-        return Promise.each(promises, fn => fn()).then(() => Promise.resolve(true));
+        return true;
     }
 
     /**

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -1,4 +1,3 @@
-'use strict';
 const os = require('os');
 const path = require('path');
 const Config = require('./utils/config');
@@ -143,58 +142,52 @@ class Instance {
      * @method running
      * @public
      */
-    running(environment) {
+    async running(environment) {
         if (environment !== undefined) {
             // setter
             this._cliConfig.set('running', environment).save();
-            return Promise.resolve(true);
+            return true;
         }
 
         if (!this._cliConfig.has('running')) {
             const currentEnvironment = this.system.development;
 
-            const envIsRunning = (environment) => {
+            const envIsRunning = async (environment) => {
                 if (!Config.exists(path.join(this.dir, `config.${environment}.json`))) {
-                    return Promise.resolve(false);
+                    return false;
                 }
 
                 this.system.setEnvironment(environment === 'development');
-                return Promise.resolve(this.process.isRunning(this.dir)).then((running) => {
-                    if (running) {
-                        this._cliConfig.set('running', environment).save();
-                    }
-
-                    return running;
-                });
-            };
-
-            // Check production environment first
-            return envIsRunning('production').then((production) => {
-                if (production) {
-                    return true;
+                const running = await this.process.isRunning(this.dir);
+                if (running) {
+                    this._cliConfig.set('running', environment).save();
                 }
 
-                // Check development next
-                return envIsRunning('development').then((development) => {
-                    if (development) {
-                        return true;
-                    }
+                return running;
+            };
 
-                    this.system.setEnvironment(currentEnvironment);
-                    return false;
-                });
-            });
+            const production = await envIsRunning('production');
+            if (production) {
+                return true;
+            }
+
+            const development = await envIsRunning('development');
+            if (development) {
+                return true;
+            }
+
+            this.system.setEnvironment(currentEnvironment);
+            return false;
         }
 
         this.loadRunningEnvironment();
 
-        return Promise.resolve(this.process.isRunning(this.dir)).then((running) => {
-            if (!running) {
-                this._cliConfig.set('running', null).save();
-            }
+        const running = await this.process.isRunning(this.dir);
+        if (!running) {
+            this._cliConfig.set('running', null).save();
+        }
 
-            return running;
-        });
+        return running;
     }
 
     /**

--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -1,17 +1,16 @@
 'use strict';
 
-function ensureSettingsFolder(context) {
+async function ensureSettingsFolder(context) {
     const path = require('path');
     const ghostUser = require('./utils/use-ghost-user');
 
     const contentDir = context.instance.config.get('paths.contentPath');
 
     if (ghostUser.shouldUseGhostUser(contentDir)) {
-        return context.ui.sudo(`mkdir -p ${path.resolve(contentDir, 'settings')}`, {sudoArgs: '-E -u ghost'});
+        await context.ui.sudo(`mkdir -p ${path.resolve(contentDir, 'settings')}`, {sudoArgs: '-E -u ghost'});
     } else {
         const fs = require('fs-extra');
         fs.ensureDirSync(path.resolve(contentDir, 'settings'));
-        return Promise.resolve();
     }
 }
 

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -33,18 +33,12 @@ class ProcessManager {
      * @param {String} environment Environment to start Ghost in
      * @return Promise<void>|null
      */
-    start() {
-        // Base implementation - noop
-        return Promise.resolve();
-    }
+    async start() {}
+    async stop() {}
 
-    stop() {
-        // Base implementation - noop
-        return Promise.resolve();
-    }
-
-    restart(cwd, env) {
-        return this.stop(cwd, env).then(() => this.start(cwd, env));
+    async restart(cwd, env) {
+        await this.stop(cwd, env);
+        await this.start(cwd, env);
     }
 
     /* istanbul ignore next */
@@ -58,9 +52,8 @@ class ProcessManager {
         throw error;
     }
 
-    isRunning() {
-        // Base Implementation - noop
-        return Promise.resolve(false);
+    async isRunning() {
+        return false;
     }
 
     /**
@@ -68,7 +61,7 @@ class ProcessManager {
      *
      * @returns {Promise<any>}
      */
-    ensureStarted(options) {
+    async ensureStarted(options) {
         const portPolling = require('./utils/port-polling');
         const semver = require('semver');
 
@@ -79,13 +72,19 @@ class ProcessManager {
             useNetServer: semver.major(this.instance.version) === 2
         }, options || {});
 
-        return portPolling(options).catch((err) => {
+        try {
+            await portPolling(options);
+        } catch (error) {
             if (options.stopOnError) {
-                return this.stop().catch(() => Promise.reject(err)).then(() => Promise.reject(err));
+                try {
+                    await this.stop();
+                } catch (e) {
+                    // ignore stop error
+                }
             }
 
-            return Promise.reject(err);
-        });
+            throw error;
+        }
     }
 
     /**

--- a/lib/system.js
+++ b/lib/system.js
@@ -224,7 +224,7 @@ class System {
      * @method getAllInstances
      * @public
      */
-    getAllInstances(running) {
+    async getAllInstances(running) {
         const instances = this.globalConfig.get('instances', {});
         const names = Object.keys(instances);
 
@@ -247,7 +247,7 @@ class System {
 
         // If we're not filtering out stopped instances, just return the result
         if (!running) {
-            return Promise.resolve(result);
+            return result;
         }
 
         // Return the result filtered by whether or not the instance is running

--- a/test/unit/command-spec.js
+++ b/test/unit/command-spec.js
@@ -171,7 +171,7 @@ describe('Unit: Command', function () {
     });
 
     describe('_run', function () {
-        it('calls checkValidInstall when global option is not set', function () {
+        it('calls checkValidInstall when global option is not set', async function () {
             const checkValidInstall = sinon.stub();
             const Command = proxyquire(modulePath, {
                 './utils/check-valid-install': checkValidInstall
@@ -181,7 +181,7 @@ describe('Unit: Command', function () {
             checkValidInstall.throws();
 
             try {
-                TestCommand._run('test', {});
+                await TestCommand._run('test', {});
                 throw new Error('checkValidInstall not called');
             } catch (e) {
                 expect(e.message).to.not.equal('checkValidInstall not called');
@@ -190,7 +190,7 @@ describe('Unit: Command', function () {
             }
         });
 
-        it('will not run command when executed as root user', function () {
+        it('will not run command when executed as root user', async function () {
             const checkRootUserStub = sinon.stub();
             const Command = proxyquire(modulePath, {
                 './utils/check-root-user': checkRootUserStub
@@ -202,14 +202,14 @@ describe('Unit: Command', function () {
             checkRootUserStub.throws();
 
             try {
-                TestCommand._run('test');
+                await TestCommand._run('test');
             } catch (e) {
                 expect(e).to.exist;
                 expect(checkRootUserStub.calledOnce).to.be.true;
             }
         });
 
-        it('doesn\'t check for root when command allows root', function () {
+        it('doesn\'t check for root when command allows root', async function () {
             const checkRootUserStub = sinon.stub().throws('let them be freeee');
             class ShortCircuit {
                 constructor() {
@@ -226,7 +226,7 @@ describe('Unit: Command', function () {
             TestCommand.allowRoot = true;
 
             try {
-                TestCommand._run('test', {dir: '.'});
+                await TestCommand._run('test', {dir: '.'});
             } catch (e) {
                 expect(e).to.exist;
                 expect(e.message).to.equal('you shall not pass');
@@ -234,7 +234,7 @@ describe('Unit: Command', function () {
             }
         });
 
-        it('Changes directory if needed', function () {
+        it('Changes directory if needed', async function () {
             sinon.stub(process, 'exit').throws(new Error('exit_stub'));
             const outStub = sinon.stub(process.stderr, 'write');
             const chdirStub = sinon.stub(process, 'chdir').throws(new Error('chdir_stub'));
@@ -242,7 +242,7 @@ describe('Unit: Command', function () {
             class TestCommand extends Command {}
 
             try {
-                TestCommand._run('test', {dir: '/path/to/ghost', verbose: true});
+                await TestCommand._run('test', {dir: '/path/to/ghost', verbose: true});
                 throw new Error('Should have errored');
             } catch (error) {
                 expect(error).to.be.ok;
@@ -254,7 +254,7 @@ describe('Unit: Command', function () {
             }
         });
 
-        it('Creates & changes into directory if needed', function () {
+        it('Creates & changes into directory if needed', async function () {
             sinon.stub(process.stderr, 'write');
             sinon.stub(process, 'exit').throws(new Error('exit_stub'));
             sinon.stub(process, 'chdir').throws(new Error('chdir_stub'));
@@ -265,7 +265,7 @@ describe('Unit: Command', function () {
             TestCommand.ensureDir = true;
 
             try {
-                TestCommand._run('test', {dir: '/path/to/ghost', verbose: true});
+                await TestCommand._run('test', {dir: '/path/to/ghost', verbose: true});
                 throw new Error('Should have errored');
             } catch (error) {
                 expect(error).to.be.ok;
@@ -275,7 +275,7 @@ describe('Unit: Command', function () {
             }
         });
 
-        it('loads system and ui dependencies, calls run method', function () {
+        it('loads system and ui dependencies, calls run method', async function () {
             const uiStub = sinon.stub().returns({ui: true});
             const setEnvironmentStub = sinon.stub();
             const systemStub = sinon.stub().returns({setEnvironment: setEnvironmentStub});
@@ -290,28 +290,27 @@ describe('Unit: Command', function () {
 
             const runStub = sinon.stub(TestCommand.prototype, 'run');
 
-            return TestCommand._run('test', {
+            await TestCommand._run('test', {
                 verbose: true,
                 prompt: true,
                 development: true,
                 auto: false
-            }, [{extensiona: true}]).then(() => {
-                expect(uiStub.calledOnce).to.be.true;
-                expect(uiStub.calledWithExactly({
-                    verbose: true,
-                    allowPrompt: true,
-                    auto: false
-                })).to.be.true;
-                expect(setEnvironmentStub.calledOnce).to.be.true;
-                expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
-                expect(systemStub.calledOnce).to.be.true;
-                expect(systemStub.calledWithExactly({ui: true}, [{extensiona: true}])).to.be.true;
-                expect(runStub.calledOnce).to.be.true;
-                expect(runStub.calledWithExactly({verbose: true, prompt: true, development: true, auto: false})).to.be.true;
-            });
+            }, [{extensiona: true}]);
+            expect(uiStub.calledOnce).to.be.true;
+            expect(uiStub.calledWithExactly({
+                verbose: true,
+                allowPrompt: true,
+                auto: false
+            })).to.be.true;
+            expect(setEnvironmentStub.calledOnce).to.be.true;
+            expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
+            expect(systemStub.calledOnce).to.be.true;
+            expect(systemStub.calledWithExactly({ui: true}, [{extensiona: true}])).to.be.true;
+            expect(runStub.calledOnce).to.be.true;
+            expect(runStub.calledWithExactly({verbose: true, prompt: true, development: true, auto: false})).to.be.true;
         });
 
-        it('binds cleanup handler if cleanup method is defined', function () {
+        it('binds cleanup handler if cleanup method is defined', async function () {
             const uiStub = sinon.stub().returns({ui: true});
             const setEnvironmentStub = sinon.stub();
             const systemStub = sinon.stub().returns({setEnvironment: setEnvironmentStub});
@@ -331,33 +330,32 @@ describe('Unit: Command', function () {
             const oldEnv = process.env.NODE_ENV;
             process.env.NODE_ENV = 'development';
 
-            return TestCommand._run('test', {
+            await TestCommand._run('test', {
                 verbose: false,
                 prompt: false,
                 development: false,
                 auto: true
-            }, [{extensiona: true}]).then(() => {
-                expect(uiStub.calledOnce).to.be.true;
-                expect(uiStub.calledWithExactly({
-                    verbose: false,
-                    allowPrompt: false,
-                    auto: true
-                })).to.be.true;
-                expect(setEnvironmentStub.calledOnce).to.be.true;
-                expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
-                expect(systemStub.calledOnce).to.be.true;
-                expect(systemStub.calledWithExactly({ui: true}, [{extensiona: true}])).to.be.true;
-                expect(runStub.calledOnce).to.be.true;
-                expect(runStub.calledWithExactly({verbose: false, prompt: false, development: false, auto: true})).to.be.true;
-                expect(onStub.calledTwice).to.be.true;
-                expect(onStub.calledWith('SIGINT')).to.be.true;
-                expect(onStub.calledWith('SIGTERM')).to.be.true;
+            }, [{extensiona: true}]);
+            expect(uiStub.calledOnce).to.be.true;
+            expect(uiStub.calledWithExactly({
+                verbose: false,
+                allowPrompt: false,
+                auto: true
+            })).to.be.true;
+            expect(setEnvironmentStub.calledOnce).to.be.true;
+            expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
+            expect(systemStub.calledOnce).to.be.true;
+            expect(systemStub.calledWithExactly({ui: true}, [{extensiona: true}])).to.be.true;
+            expect(runStub.calledOnce).to.be.true;
+            expect(runStub.calledWithExactly({verbose: false, prompt: false, development: false, auto: true})).to.be.true;
+            expect(onStub.calledTwice).to.be.true;
+            expect(onStub.calledWith('SIGINT')).to.be.true;
+            expect(onStub.calledWith('SIGTERM')).to.be.true;
 
-                process.env.NODE_ENV = oldEnv;
-            });
+            process.env.NODE_ENV = oldEnv;
         });
 
-        it('runs updateCheck if checkVersion property is true on command class', function () {
+        it('runs updateCheck if checkVersion property is true on command class', async function () {
             const uiStub = sinon.stub().returns({ui: true});
             const setEnvironmentStub = sinon.stub();
             const systemStub = sinon.stub().returns({setEnvironment: setEnvironmentStub});
@@ -377,32 +375,31 @@ describe('Unit: Command', function () {
             const oldEnv = process.env.NODE_ENV;
             process.env.NODE_ENV = 'development';
 
-            return TestCommand._run('test', {
+            await TestCommand._run('test', {
                 verbose: false,
                 prompt: false,
                 development: false,
                 auto: false
-            }, [{extensiona: true}]).then(() => {
-                expect(uiStub.calledOnce).to.be.true;
-                expect(uiStub.calledWithExactly({
-                    verbose: false,
-                    allowPrompt: false,
-                    auto: false
-                })).to.be.true;
-                expect(setEnvironmentStub.calledOnce).to.be.true;
-                expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
-                expect(systemStub.calledOnce).to.be.true;
-                expect(systemStub.calledWithExactly({ui: true}, [{extensiona: true}])).to.be.true;
-                expect(preChecksStub.calledOnce).to.be.true;
-                expect(preChecksStub.calledWithExactly({ui: true}, {setEnvironment: setEnvironmentStub})).to.be.true;
-                expect(runStub.calledOnce).to.be.true;
-                expect(runStub.calledWithExactly({verbose: false, prompt: false, development: false, auto: false})).to.be.true;
+            }, [{extensiona: true}]);
+            expect(uiStub.calledOnce).to.be.true;
+            expect(uiStub.calledWithExactly({
+                verbose: false,
+                allowPrompt: false,
+                auto: false
+            })).to.be.true;
+            expect(setEnvironmentStub.calledOnce).to.be.true;
+            expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
+            expect(systemStub.calledOnce).to.be.true;
+            expect(systemStub.calledWithExactly({ui: true}, [{extensiona: true}])).to.be.true;
+            expect(preChecksStub.calledOnce).to.be.true;
+            expect(preChecksStub.calledWithExactly({ui: true}, {setEnvironment: setEnvironmentStub})).to.be.true;
+            expect(runStub.calledOnce).to.be.true;
+            expect(runStub.calledWithExactly({verbose: false, prompt: false, development: false, auto: false})).to.be.true;
 
-                process.env.NODE_ENV = oldEnv;
-            });
+            process.env.NODE_ENV = oldEnv;
         });
 
-        it('catches errors, passes them to ui error method, then exits', function () {
+        it('catches errors, passes them to ui error method, then exits', async function () {
             const errorStub = sinon.stub();
             const uiStub = sinon.stub().returns({error: errorStub});
             const setEnvironmentStub = sinon.stub();
@@ -415,7 +412,7 @@ describe('Unit: Command', function () {
 
             class TestCommand extends Command {
                 run() {
-                    return Promise.reject(new Error('an error occurred'));
+                    throw new Error('an error occurred');
                 }
             }
             TestCommand.global = true;
@@ -425,39 +422,38 @@ describe('Unit: Command', function () {
             process.env.NODE_ENV = 'production';
             const exitStub = sinon.stub(process, 'exit');
 
-            return TestCommand._run('test', {
+            await TestCommand._run('test', {
                 verbose: false,
                 prompt: false,
                 development: false,
                 auto: false
-            }, [{extensiona: true}]).then(() => {
-                expect(uiStub.calledOnce).to.be.true;
-                expect(uiStub.calledWithExactly({
-                    verbose: false,
-                    allowPrompt: false,
-                    auto: false
-                })).to.be.true;
-                expect(setEnvironmentStub.calledOnce).to.be.true;
-                expect(setEnvironmentStub.calledWithExactly(false, true)).to.be.true;
-                expect(systemStub.calledOnce).to.be.true;
-                expect(systemStub.calledWithExactly({error: errorStub}, [{extensiona: true}])).to.be.true;
-                expect(runStub.calledOnce).to.be.true;
-                expect(runStub.calledWithExactly({verbose: false, prompt: false, development: false, auto: false})).to.be.true;
-                expect(errorStub.calledOnce).to.be.true;
-                expect(exitStub.calledOnce).to.be.true;
+            }, [{extensiona: true}]);
+            expect(uiStub.calledOnce).to.be.true;
+            expect(uiStub.calledWithExactly({
+                verbose: false,
+                allowPrompt: false,
+                auto: false
+            })).to.be.true;
+            expect(setEnvironmentStub.calledOnce).to.be.true;
+            expect(setEnvironmentStub.calledWithExactly(false, true)).to.be.true;
+            expect(systemStub.calledOnce).to.be.true;
+            expect(systemStub.calledWithExactly({error: errorStub}, [{extensiona: true}])).to.be.true;
+            expect(runStub.calledOnce).to.be.true;
+            expect(runStub.calledWithExactly({verbose: false, prompt: false, development: false, auto: false})).to.be.true;
+            expect(errorStub.calledOnce).to.be.true;
+            expect(exitStub.calledOnce).to.be.true;
 
-                process.env.NODE_ENV = oldEnv;
-            });
+            process.env.NODE_ENV = oldEnv;
         });
     });
 
-    it('base run method throws error', function () {
+    it('base run method throws error', async function () {
         const Command = require(modulePath);
         class TestCommand extends Command {}
         const commandInstance = new TestCommand({}, {});
 
         try {
-            commandInstance.run();
+            await commandInstance.run();
             throw new Error('should not be thrown');
         } catch (e) {
             expect(e.message).to.equal('Command must implement run function');
@@ -467,20 +463,21 @@ describe('Unit: Command', function () {
     describe('runCommand', function () {
         const Command = require(modulePath);
 
-        it('errors if CommandClass does not extend Command', function () {
+        it('errors if CommandClass does not extend Command', async function () {
             class TestCommand extends Command {}
             class BadCommand {}
 
             const newInstance = new TestCommand({}, {});
 
-            return newInstance.runCommand(BadCommand, {}).then(() => {
+            try {
+                await newInstance.runCommand(BadCommand, {});
                 expect(false, 'error should have been thrown').to.be.true;
-            }).catch((error) => {
+            } catch (error) {
                 expect(error.message).to.match(/does not extend the Command class/);
-            });
+            }
         });
 
-        it('instantiates and runs other command class', function () {
+        it('instantiates and runs other command class', async function () {
             class TestCommand extends Command {}
             class Test2Command extends Command {
                 run() {
@@ -491,13 +488,12 @@ describe('Unit: Command', function () {
             const runSpy = sinon.spy(Test2Command.prototype, 'run');
             const testInstance = new TestCommand({}, {});
 
-            return testInstance.runCommand(Test2Command, {argv: true}).then(() => {
-                expect(runSpy.calledOnce).to.be.true;
-                expect(runSpy.calledWithExactly({argv: true})).to.be.true;
-            });
+            await testInstance.runCommand(Test2Command, {argv: true});
+            expect(runSpy.calledOnce).to.be.true;
+            expect(runSpy.calledWithExactly({argv: true})).to.be.true;
         });
 
-        it('defaults to empty object if argv is not passed', function () {
+        it('defaults to empty object if argv is not passed', async function () {
             class TestCommand extends Command {}
             class Test2Command extends Command {
                 run() {
@@ -508,10 +504,9 @@ describe('Unit: Command', function () {
             const runSpy = sinon.spy(Test2Command.prototype, 'run');
             const testInstance = new TestCommand({}, {});
 
-            return testInstance.runCommand(Test2Command).then(() => {
-                expect(runSpy.calledOnce).to.be.true;
-                expect(runSpy.calledWithExactly({})).to.be.true;
-            });
+            await testInstance.runCommand(Test2Command);
+            expect(runSpy.calledOnce).to.be.true;
+            expect(runSpy.calledWithExactly({})).to.be.true;
         });
     });
 });


### PR DESCRIPTION
this PR can only be merged once we're ready to drop support for node 6 in the CLI (it will also fail tests until that point too). It adds async/await usage to the base classes (aka files in the root of `lib/`) and fixes tests (primarily command-spec which was relying on inconsistent promise return values)