### PR TITLE
Improve the CLI help output

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -142,8 +142,7 @@ const bootstrap = {
         }
 
         // Yargs magic
-        // TODO: evaluate if `wrap` is actually needed?
-        yargs.wrap(Math.min(100, yargs.terminalWidth()))
+        yargs.wrap(Math.min(150, yargs.terminalWidth()))
             .epilogue('For more information, see our docs at https://docs.ghost.org/api/ghost-cli/')
             .option('d', {
                 alias: 'dir',

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -144,33 +144,40 @@ const bootstrap = {
         // Yargs magic
         yargs.wrap(Math.min(150, yargs.terminalWidth()))
             .epilogue('For more information, see our docs at https://docs.ghost.org/api/ghost-cli/')
+            .group('help', 'Global Options:')
             .option('d', {
                 alias: 'dir',
-                describe: 'Folder to run command in'
+                describe: 'Folder to run command in',
+                group: 'Global Options:'
             }).option('D', {
                 alias: 'development',
                 describe: 'Run in development mode',
-                type: 'boolean'
+                type: 'boolean',
+                group: 'Global Options:'
             })
             .option('V', {
                 alias: 'verbose',
                 describe: 'Enable verbose output',
-                type: 'boolean'
+                type: 'boolean',
+                group: 'Global Options:'
             })
             .options('prompt', {
                 describe: '[--no-prompt] Allow/Disallow UI prompting',
                 type: 'boolean',
-                default: true
+                default: true,
+                group: 'Global Options:'
             })
             .option('color', {
                 describe: '[--no-color] Allow/Disallow colorful logging',
                 type: 'boolean',
-                default: true
+                default: true,
+                group: 'Global Options:'
             })
             .option('auto', {
                 describe: 'Automatically run as much as possible',
                 type: 'boolean',
-                default: false
+                default: false,
+                group: 'Global Options:'
             })
             .version(false)
             .parse(argv);

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -131,7 +131,8 @@ InstallCommand.options = {
         type: 'boolean',
         default: true
     },
-    v1: {
+    version1: {
+        alias: 'v1',
         describe: 'Limit install to Ghost 1.x releases',
         type: 'boolean',
         default: false

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -8,8 +8,8 @@ const DoctorCommand = require('./doctor');
 class InstallCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {
         yargs = super.configureOptions(commandName, yargs, extensions);
-        yargs = DoctorCommand.configureOptions('doctor', yargs, extensions, true);
         yargs = SetupCommand.configureOptions('setup', yargs, extensions, true);
+        yargs = DoctorCommand.configureOptions('doctor', yargs, extensions, true);
 
         return yargs;
     }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -9,7 +9,6 @@ class InstallCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {
         yargs = super.configureOptions(commandName, yargs, extensions);
         yargs = SetupCommand.configureOptions('setup', yargs, extensions, true);
-        yargs = DoctorCommand.configureOptions('doctor', yargs, extensions, true);
 
         return yargs;
     }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -9,7 +9,9 @@ class InstallCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {
         yargs = super.configureOptions(commandName, yargs, extensions);
         yargs = DoctorCommand.configureOptions('doctor', yargs, extensions, true);
-        return SetupCommand.configureOptions('setup', yargs, extensions, true);
+        yargs = SetupCommand.configureOptions('setup', yargs, extensions, true);
+
+        return yargs;
     }
 
     run(argv) {
@@ -112,6 +114,7 @@ InstallCommand.description = 'Install a brand new instance of Ghost';
 InstallCommand.longDescription = '$0 install [version|local]\n Installs a new version of Ghost. Run `ghost install local` to install for local theme development/testing';
 InstallCommand.params = '[version]';
 InstallCommand.options = {
+    // This overrides the description of the global option for this command
     dir: {
         alias: 'd',
         description: 'Folder to install Ghost in',
@@ -120,6 +123,12 @@ InstallCommand.options = {
     zip: {
         description: 'Path to Ghost release zip to install',
         type: 'string'
+    },
+    version1: {
+        alias: 'v1',
+        describe: 'Limit install to Ghost 1.x releases',
+        type: 'boolean',
+        default: false
     },
     stack: {
         description: '[--no-stack] Enable/Disable system stack checks on install',
@@ -130,12 +139,6 @@ InstallCommand.options = {
         description: '[--no-setup] Enable/Disable auto-running the setup command',
         type: 'boolean',
         default: true
-    },
-    version1: {
-        alias: 'v1',
-        describe: 'Limit install to Ghost 1.x releases',
-        type: 'boolean',
-        default: false
     }
 };
 InstallCommand.runPreChecks = true;

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -20,6 +20,8 @@ class SetupCommand extends Command {
 
         yargs = super.configureOptions(commandName, yargs, extensions, onlyOptions);
         yargs = StartCommand.configureOptions('start', yargs, extensions, true);
+
+        return yargs;
     }
 
     localArgs(argv) {

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -15,7 +15,7 @@ class SetupCommand extends Command {
                 return;
             }
 
-            Object.assign(this.options, omit(options, Object.keys(this.options)));
+            this.options = Object.assign({}, omit(options, Object.keys(this.options)), this.options);
         });
 
         yargs = super.configureOptions(commandName, yargs, extensions, onlyOptions);
@@ -185,20 +185,22 @@ class SetupCommand extends Command {
 SetupCommand.description = 'Setup an installation of Ghost (after it is installed)';
 SetupCommand.longDescription = '$0 setup [stages..]\n stages can be one or more of nginx, ssl, mysql, systemd, migrate, linux-user.';
 SetupCommand.params = '[stages..]';
-SetupCommand.options = Object.assign({
+SetupCommand.options = Object.assign({}, options, {
     start: {
         description: '[--no-start] Enable/disable automatically starting Ghost'
     },
     local: {
         alias: 'l',
         description: 'Quick setup for a local install of Ghost',
-        type: 'boolean'
+        type: 'boolean',
+        hidden: true
     },
     pname: {
         description: 'Ghost instance name',
-        type: 'string'
+        type: 'string',
+        group: 'Service Options:'
     }
-}, options);
+});
 SetupCommand.runPreChecks = true;
 
 module.exports = SetupCommand;

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -17,7 +17,9 @@ class StartCommand extends Command {
         });
 
         yargs = super.configureOptions(commandName, yargs, extensions);
-        return DoctorCommand.configureOptions('doctor', yargs, extensions, true);
+        yargs = DoctorCommand.configureOptions('doctor', yargs, extensions, true);
+
+        return yargs;
     }
 
     run(argv) {

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -89,7 +89,7 @@ class StartCommand extends Command {
 StartCommand.description = 'Start an instance of Ghost';
 StartCommand.options = {
     enable: {
-        description: '[--no-enable] Enable/don\'t enable the instance to restart on server reboot (if the process manager supports it)',
+        description: '[--no-enable] Enable/don\'t enable instance restart on server reboot (if the process manager supports it)',
         type: 'boolean',
         default: true
     }

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -15,7 +15,9 @@ class StopCommand extends Command {
             Object.assign(this.options, omit(options, Object.keys(this.options)));
         });
 
-        return super.configureOptions(commandName, yargs, extensions);
+        yargs = super.configureOptions(commandName, yargs, extensions);
+
+        return yargs;
     }
 
     run(argv) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -280,7 +280,8 @@ UpdateCommand.options = {
         description: '[--no-restart] Enable/Disable restarting Ghost after updating',
         type: 'boolean'
     },
-    v1: {
+    version1: {
+        alias: 'v1',
         describe: 'Limit update to Ghost 1.x releases',
         type: 'boolean',
         default: false

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -10,7 +10,9 @@ const DoctorCommand = require('./doctor');
 class UpdateCommand extends Command {
     static configureOptions(commandName, yargs, extensions) {
         yargs = super.configureOptions(commandName, yargs, extensions);
-        return DoctorCommand.configureOptions('doctor', yargs, extensions, true);
+        yargs = DoctorCommand.configureOptions('doctor', yargs, extensions, true);
+
+        return yargs;
     }
 
     run(argv) {

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -12,7 +12,6 @@ describe('Unit: Commands > Install', function () {
     it('configureOptions adds setup & doctor options', function () {
         const superStub = sinon.stub().returnsArg(1);
         const setupStub = sinon.stub().returnsArg(1);
-        const doctorStub = sinon.stub().returnsArg(1);
 
         // Needed for extension
         class Command {}
@@ -20,7 +19,6 @@ describe('Unit: Commands > Install', function () {
 
         const InstallCommand = proxyquire(modulePath, {
             './setup': {configureOptions: setupStub},
-            './doctor': {configureOptions: doctorStub},
             '../command': Command
         });
 
@@ -30,8 +28,6 @@ describe('Unit: Commands > Install', function () {
         expect(superStub.calledWithExactly('install', {yargs: true}, [{extensiona: true}])).to.be.true;
         expect(setupStub.calledOnce).to.be.true;
         expect(setupStub.calledWithExactly('setup', {yargs: true}, [{extensiona: true}], true)).to.be.true;
-        expect(doctorStub.calledOnce).to.be.true;
-        expect(doctorStub.calledWithExactly('doctor', {yargs: true}, [{extensiona: true}], true)).to.be.true;
     });
 
     describe('run', function () {


### PR DESCRIPTION
Whilst attempting to update our CLI docs, I found lots of places where the CLI output was very hard to read. We have a LOT of flags, so it can become really really tricky to understand what is / isn't possible when reading the help output.

Help should be the source of truth, so I've updated it to be a little clearer. None of these changes should be functional, except the expansion to having `--version1` as the long form of `--v1`.

Everything else should _only_ affect what help outputs.

The main thing is that global options are now shown in a "global options" group. The only options left in `Options:` are the command specific options. I've also tweaked the order, so that the commands are easier to read. 

---

A side note: in Gscan and other cli-based tools we use [@tryghost/pretty-cli](https://www.npmjs.com/package/@tryghost/pretty-cli), which wraps http://sywac.io/ instead of yargs. Sywac 1) is designed for dynamic command and option loading 2) has highly configurable, pretty, coloured help output 3) doesn't support the --no boolean switch and 4) doesn't seem to be actively maintained.

I think switching the CLI over to sywac would be a fairly involved task, It would solve some problems more neatly (dynamic loading, better output) and cause others (duplication of flags to reimplement --no switch) so prob not worth doing right now, just wanted to mention its existence!
