### PR TITLE
feat(nginx): customisable paths & program name

### DIFF
--- a/extensions/nginx/acme.js
+++ b/extensions/nginx/acme.js
@@ -7,6 +7,8 @@ const download = require('download');
 
 const {errors: {CliError, ProcessError, SystemError}} = require('../../lib');
 
+const nginxProgramName = process.env.NGINX_PROGRAM_NAME || 'nginx';
+
 function isInstalled() {
     return fs.existsSync('/etc/letsencrypt/acme.sh');
 }
@@ -67,7 +69,7 @@ function install(ui, task) {
 
 function generateCert(ui, domain, webroot, email, staging) {
     const cmd = `/etc/letsencrypt/acme.sh --issue --home /etc/letsencrypt --domain ${domain} --webroot ${webroot} ` +
-    `--reloadcmd "nginx -s reload" --accountemail ${email}${staging ? ' --staging' : ''}`;
+    `--reloadcmd "${nginxProgramName} -s reload" --accountemail ${email}${staging ? ' --staging' : ''}`;
 
     return ui.sudo(cmd).catch((error) => {
         if (error.code === 2) {

--- a/lib/commands/doctor/checks/system-stack.js
+++ b/lib/commands/doctor/checks/system-stack.js
@@ -6,6 +6,8 @@ const errors = require('../../../errors');
 
 const taskTitle = 'Checking operating system compatibility';
 
+const nginxProgramName = process.env.NGINX_PROGRAM_NAME || 'nginx';
+
 function systemStack(ctx, task) {
     let promise;
 
@@ -25,9 +27,9 @@ function systemStack(ctx, task) {
                 task: () => execa.shell('dpkg -l | grep systemd')
                     .catch(() => Promise.reject({missing: 'systemd'}))
             }, {
-                title: 'Checking nginx is installed',
-                task: () => execa.shell('dpkg -l | grep nginx')
-                    .catch(() => Promise.reject({missing: 'nginx'}))
+                title: `Checking ${nginxProgramName} is installed`,
+                task: () => execa.shell(`dpkg -l | grep ${nginxProgramName}`)
+                    .catch(() => Promise.reject({missing: nginxProgramName}))
             }], ctx, {
                 concurrent: true,
                 exitOnError: false,


### PR DESCRIPTION
no issue

- Respect environment variables that customise where nginx lives and what it is called
- Use env vars, not config, because this will be system-wide
- Allows CLI to work with "flavours" of nginx, like OpenResty

The two env vars are:

NGINX_PROGRAM_NAME
NGINX_CONFIG_PATH

I did wonder as part of this if `dpkg -l | grep xxx` is the best way to find out if something is installed, and whether using which, or a version check, might be more interoperable 🤔 (thinking about the case of symlinking openresty as nginx)