### PR TITLE
fix(system): improve hasInstance check

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -196,7 +196,7 @@ class System {
      */
     hasInstance(instance) {
         const instances = this.globalConfig.get('instances', {});
-        return some(instances, ({cwd}) => cwd === instance.dir);
+        return some(instances, ({cwd}, name) => cwd === instance.dir && name === instance.name);
     }
 
     /**

--- a/test/unit/system-spec.js
+++ b/test/unit/system-spec.js
@@ -289,12 +289,17 @@ describe('Unit: System', function () {
     it('hasInstance works', function () {
         const System = require(modulePath);
         const system = new System({}, []);
-        system.globalConfig.set('instances', {test: {cwd: '/dir/a'}});
+        system.globalConfig.set('instances', {test: {cwd: '/dir/a'}, test2: {cwd: '/dir/c'}});
         const instanceA = new Instance({}, system, '/dir/a');
+        instanceA._cliConfig.set('name', 'test');
+
         const instanceB = new Instance({}, system, '/dir/b');
+        const instanceC = new Instance({}, system, '/dir/c');
+        instanceC._cliConfig.set('name', 'different');
 
         expect(system.hasInstance(instanceA)).to.be.true;
         expect(system.hasInstance(instanceB)).to.be.false;
+        expect(system.hasInstance(instanceC)).to.be.false;
     });
 
     it('cachedInstance loads instance and caches it', function () {


### PR DESCRIPTION
refs #936
- check if name matches global config name as well

The problem (I think) is that if you delete the contents of a ghost install directory without running `ghost uninstall`, the entry in `~/.ghost/config` never gets removed, and thus if you attempt to install Ghost in the _same_ directory again, the hasInstance check would happily report that the instance had already been set up. This expands the check to _also_ check the name field.

Note: upon further thought this may only fix half of the issue - may need a follow-up PR to expand the check in the `isSetup` getter in the instance class.