### PR TITLE
fix(config): allow root user to run config command

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -49,5 +49,6 @@ ConfigCommand.description = 'View or edit Ghost configuration';
 ConfigCommand.longDescription = '$0 config [key] [value]\n View or modify the configuration for a Ghost instance.';
 ConfigCommand.params = '[key] [value]';
 ConfigCommand.options = options;
+ConfigCommand.allowRoot = true;
 
 module.exports = ConfigCommand;


### PR DESCRIPTION
closes #981
- this enables the config command to be run as the root user