### PR TITLE
fix(utils): prerelease should statisfy engine requirements

### DIFF
--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -166,7 +166,7 @@ const utils = {
             return Promise.reject(new SystemError('Zip file contains a Ghost version incompatible with the current Node version.'));
         }
 
-        if (pkg.engines && pkg.engines.cli && !semver.satisfies(cliPackage.version, pkg.engines.cli)) {
+        if (pkg.engines && pkg.engines.cli && !semver.satisfies(cliPackage.version, pkg.engines.cli, {includePrerelease: true})) {
             return Promise.reject(new SystemError({
                 message: 'Zip file contains a Ghost version incompatible with this version of the CLI.',
                 help: `Required: v${pkg.engines.cli}, current: v${cliPackage.version}`,


### PR DESCRIPTION
When testing installs with a prerelease version of the CLI the satisfy check against Ghosts engines field in package.json fails.