### PR TITLE
Use `which` to detect packages rather than `dpkg`

### DIFF
--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -281,7 +281,7 @@ class NginxExtension extends Extension {
 
     isSupported() {
         try {
-            execa.shellSync(`dpkg -l | grep ${nginxProgramName}`, {stdio: 'ignore'});
+            execa.shellSync(`which ${nginxProgramName}`, {stdio: 'ignore'});
             return true;
         } catch (e) {
             return false;

--- a/lib/commands/doctor/checks/system-stack.js
+++ b/lib/commands/doctor/checks/system-stack.js
@@ -24,11 +24,11 @@ function systemStack(ctx, task) {
 
             return ctx.ui.listr([{
                 title: 'Checking systemd is installed',
-                task: () => execa.shell('dpkg -l | grep systemd')
+                task: () => execa.shell('which systemd')
                     .catch(() => Promise.reject({missing: 'systemd'}))
             }, {
                 title: `Checking ${nginxProgramName} is installed`,
-                task: () => execa.shell(`dpkg -l | grep ${nginxProgramName}`)
+                task: () => execa.shell(`which ${nginxProgramName}`)
                     .catch(() => Promise.reject({missing: nginxProgramName}))
             }], ctx, {
                 concurrent: true,

--- a/test/unit/commands/doctor/checks/system-stack-spec.js
+++ b/test/unit/commands/doctor/checks/system-stack-spec.js
@@ -155,8 +155,8 @@ describe('Unit: Doctor Checks > systemStack', function () {
         const confirmStub = sinon.stub().resolves(false);
 
         execaStub.withArgs('lsb_release -a').resolves({stdout: 'Ubuntu 16'});
-        execaStub.withArgs('dpkg -l | grep nginx').rejects();
-        execaStub.withArgs('dpkg -l | grep systemd').rejects();
+        execaStub.withArgs('which nginx').rejects();
+        execaStub.withArgs('which systemd').rejects();
 
         const listrStub = sinon.stub().callsFake(function (tasks, ctx, opts) {
             expect(opts.renderer).to.equal('verbose');


### PR DESCRIPTION
Currently, ghost assumes there is no MySQL or Nginx package installed
on non-Debian based GNU+Linux distributions. We fix this by querying
for packages using `which` instead of `dpkg`.

References #460