### PR TITLE
Added verbose yarn output

### DIFF
--- a/lib/tasks/yarn-install.js
+++ b/lib/tasks/yarn-install.js
@@ -62,7 +62,11 @@ module.exports = function yarnInstall(ui, zipFile) {
     tasks.push({
         title: 'Installing dependencies',
         task: (ctx) => {
-            const observable = yarn(['install', '--no-emoji', '--no-progress'], {
+            const yarnOpts = ['install', '--no-emoji', '--no-progress'];
+            if (ui.verbose) {
+                yarnOpts.push('--verbose');
+            }
+            const observable = yarn(yarnOpts, {
                 cwd: ctx.installPath,
                 env: {NODE_ENV: 'production'},
                 observe: true

--- a/test/unit/tasks/yarn-install-spec.js
+++ b/test/unit/tasks/yarn-install-spec.js
@@ -49,6 +49,39 @@ describe('Unit: Tasks > yarn-install', function () {
         });
     });
 
+    it('verbose option', function () {
+        const yarnStub = sinon.stub().returns(new Observable(o => o.complete()));
+        const yarnInstall = proxyquire(modulePath, {
+            '../utils/yarn': yarnStub
+        });
+        const subTasks = yarnInstall.subTasks;
+        const ctx = {installPath: '/var/www/ghost/versions/1.5.0'};
+        const listrStub = sinon.stub().callsFake((tasks) => {
+            expect(tasks).to.have.length(3);
+
+            return Promise.each(tasks, (task) => {
+                const result = task.task(ctx);
+                return isObservable(result) ? result.toPromise() : result;
+            });
+        });
+
+        const distTaskStub = sinon.stub(subTasks, 'dist').resolves();
+        const downloadTaskStub = sinon.stub(subTasks, 'download');
+
+        return yarnInstall({listr: listrStub, verbose: true}).then(() => {
+            expect(listrStub.calledOnce).to.be.true;
+            expect(distTaskStub.calledOnce).to.be.true;
+            expect(downloadTaskStub.calledOnce).to.be.true;
+            expect(yarnStub.calledOnce).to.be.true;
+            expect(yarnStub.args[0][0]).to.deep.equal(['install', '--no-emoji', '--no-progress', '--verbose']);
+            expect(yarnStub.args[0][1]).to.deep.equal({
+                cwd: '/var/www/ghost/versions/1.5.0',
+                env: {NODE_ENV: 'production'},
+                observe: true
+            });
+        });
+    });
+
     it('base function can take zip file', function () {
         const decompressStub = sinon.stub().resolves();
         const listrStub = sinon.stub().resolves();


### PR DESCRIPTION
@acburdine Can we add a tiny little fix like this and ship it to help with debugging https://github.com/TryGhost/Ghost/issues/11129?

I'm not sure if we also need to fix https://github.com/TryGhost/Ghost-CLI/blob/master/lib/utils/yarn.js to include stderr as mentioned in https://github.com/lovell/sharp/issues/1942#issuecomment-547513885 but that all seems like it needs a bit more time and attention. 

Definitely want to switch to outputting this info to a log file as well, but again, that takes time whereas this could help immediately.