### PR TITLE
fix(migrator): use ProcessError instead of GhostError

### DIFF
--- a/lib/tasks/migrator.js
+++ b/lib/tasks/migrator.js
@@ -38,16 +38,15 @@ const errorHandler = (context) => {
             });
         } else if (error.stdout && error.stdout.match(/irreversible migration/i)) {
             const {activeVersion, version} = context;
-            error = new errors.GhostError({
+            error = new errors.ProcessError({
                 message: `It's not possible to roll back database changes from ${activeVersion} to ${version}. Please restore from a backup instead`,
                 stderr: error.stderr
             });
         } else {
             // only show suggestion on `ghost update`
-            error = new errors.GhostError({
+            error = new errors.ProcessError({
                 message: 'The database migration in Ghost encountered an error.',
                 stderr: error.stderr,
-                environment: context.instance.system.environment,
                 help: 'https://ghost.org/faq/upgrade-to-ghost-2-0/#what-to-do-when-an-upgrade-fails',
                 suggestion: process.argv.slice(2, 3).join(' ') === 'update' ? 'ghost update --rollback' : null
             });

--- a/test/unit/tasks/migrator-spec.js
+++ b/test/unit/tasks/migrator-spec.js
@@ -122,7 +122,7 @@ describe('Unit: Tasks > Migrator', function () {
                 expect(false, 'error should have been thrown').to.be.true;
                 process.argv = originalArgv;
             }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.GhostError);
+                expect(error).to.be.an.instanceof(errors.ProcessError);
                 expect(error.options.stderr).to.match(/YA_GOOFED/);
                 expect(error.options.suggestion).to.eql('ghost update --rollback');
                 expect(error.options.help).to.exist;
@@ -148,7 +148,7 @@ describe('Unit: Tasks > Migrator', function () {
                 expect(false, 'error should have been thrown').to.be.true;
                 process.argv = originalArgv;
             }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.GhostError);
+                expect(error).to.be.an.instanceof(errors.ProcessError);
                 expect(error.options.stderr).to.match(/YA_GOOFED/);
                 expect(error.options.suggestion).to.not.exist;
                 expect(error.options.help).to.exist;
@@ -293,7 +293,7 @@ describe('Unit: Tasks > Migrator', function () {
             }).then(() => {
                 expect(false, 'error should have been thrown').to.be.true;
             }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.GhostError);
+                expect(error).to.be.an.instanceof(errors.ProcessError);
                 expect(error.message).to.match(/not possible to roll back database changes from 3.0.0 to 2.36.0/);
             });
         });
@@ -329,7 +329,7 @@ describe('Unit: Tasks > Migrator', function () {
                 expect(false, 'error should have been thrown').to.be.true;
                 process.argv = originalArgv;
             }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.GhostError);
+                expect(error).to.be.an.instanceof(errors.ProcessError);
                 expect(error.options.stderr).to.match(/YA_GOOFED/);
                 expect(error.options.suggestion).to.eql('ghost update --rollback');
                 expect(error.options.help).to.exist;


### PR DESCRIPTION
refs #978
- ProcessError will correctly respect the stderr property passed to it