### PR TITLE
refactor(instance): move start/stop logic into instance class

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -22,67 +22,40 @@ class StartCommand extends Command {
         return yargs;
     }
 
-    run(argv) {
-        const ProcessManager = require('../process-manager');
-
+    async run(argv) {
         const instance = this.system.getInstance();
         const runOptions = {quiet: argv.quiet};
 
-        return instance.isRunning().then((isRunning) => {
-            if (isRunning) {
-                this.ui.log('Ghost is already running! For more information, run', 'ghost ls', 'green', 'cmd', true);
-                return Promise.resolve();
+        const isRunning = await instance.isRunning();
+        if (isRunning) {
+            this.ui.log('Ghost is already running! For more information, run', 'ghost ls', 'green', 'cmd', true);
+            return;
+        }
+
+        instance.checkEnvironment();
+        await this.runCommand(DoctorCommand, {categories: ['start'], ...argv, quiet: true});
+        await this.ui.run(() => instance.start(argv.enable), `Starting Ghost: ${instance.name}`, runOptions);
+
+        if (!argv.quiet) {
+            const isInstall = process.argv[2] === 'install';
+            let adminUrl = instance.config.get('admin.url') || instance.config.get('url');
+            // Strip the trailing slash and add the admin path
+            adminUrl = `${adminUrl.replace(/\/$/,'')}/ghost/`;
+
+            // Show a warning about direct mail - but in grey, it's not the most important message here
+            if (isInstall && instance.config.get('mail.transport') === 'Direct') {
+                this.ui.log('\nGhost uses direct mail by default. To set up an alternative email method read our docs at https://ghost.org/docs/concepts/config/#mail', 'gray');
             }
 
-            instance.checkEnvironment();
+            this.ui.log('\n------------------------------------------------------------------------------', 'white');
 
-            return this.runCommand(DoctorCommand, Object.assign({
-                categories: ['start'],
-                quiet: true
-            }, argv)).then(() => {
-                const processInstance = instance.process;
-
-                const start = () => Promise.resolve(processInstance.start(process.cwd(), this.system.environment))
-                    .then(() => {
-                        instance.setRunningMode(this.system.environment);
-                    });
-
-                return this.ui.run(start, 'Starting Ghost', runOptions).then(() => {
-                    if (!argv.enable || !ProcessManager.supportsEnableBehavior(processInstance)) {
-                        return Promise.resolve();
-                    }
-
-                    return Promise.resolve(processInstance.isEnabled()).then((isEnabled) => {
-                        if (isEnabled) {
-                            return Promise.resolve();
-                        }
-
-                        return this.ui.run(() => processInstance.enable(), 'Enabling Ghost instance startup on server boot', runOptions);
-                    });
-                }).then(() => {
-                    if (!argv.quiet) {
-                        const isInstall = process.argv[2] === 'install';
-                        let adminUrl = instance.config.get('admin.url') || instance.config.get('url');
-                        // Strip the trailing slash and add the admin path
-                        adminUrl = `${adminUrl.replace(/\/$/,'')}/ghost/`;
-
-                        // Show a warning about direct mail - but in grey, it's not the most important message here
-                        if (isInstall && instance.config.get('mail.transport') === 'Direct') {
-                            this.ui.log('\nGhost uses direct mail by default. To set up an alternative email method read our docs at https://ghost.org/docs/concepts/config/#mail', 'gray');
-                        }
-
-                        this.ui.log('\n------------------------------------------------------------------------------', 'white');
-
-                        if (isInstall) {
-                            // Show a different message after a fresh install
-                            this.ui.log('Ghost was installed successfully! To complete setup of your publication, visit', adminUrl, 'green', 'link', true);
-                        } else {
-                            this.ui.log('Your admin interface is located at', adminUrl, 'green', 'link', true);
-                        }
-                    }
-                });
-            });
-        });
+            if (isInstall) {
+                // Show a different message after a fresh install
+                this.ui.log('Ghost was installed successfully! To complete setup of your publication, visit', adminUrl, 'green', 'link', true);
+            } else {
+                this.ui.log('Your admin interface is located at', adminUrl, 'green', 'link', true);
+            }
+        }
     }
 }
 

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -1,4 +1,3 @@
-'use strict';
 const Command = require('../command');
 
 class StopCommand extends Command {
@@ -20,9 +19,8 @@ class StopCommand extends Command {
         return yargs;
     }
 
-    run(argv) {
-        const errors = require('../errors');
-        const ProcessManager = require('../process-manager');
+    async run(argv) {
+        const {SystemError} = require('../errors');
         const checkValidInstall = require('../utils/check-valid-install');
 
         const runOptions = {quiet: argv.quiet};
@@ -31,59 +29,31 @@ class StopCommand extends Command {
             return this.stopAll();
         }
 
-        const instance = this.system.getInstance(argv.name);
-
-        if (argv.name) {
-            if (!instance) {
-                return Promise.reject(new errors.SystemError(`Ghost instance '${argv.name}' does not exist`));
-            }
-
-            process.chdir(instance.dir);
+        if (!argv.name) {
+            checkValidInstall('stop');
         }
 
-        checkValidInstall('stop');
+        const instance = this.system.getInstance(argv.name);
 
-        return instance.isRunning().then((isRunning) => {
-            if (!isRunning) {
-                this.ui.log('Ghost is already stopped! For more information, run', 'ghost ls', 'green', 'cmd', true);
-                return Promise.resolve();
-            }
+        if (argv.name && !instance) {
+            throw new SystemError(`Ghost instance '${argv.name}' does not exist`);
+        }
 
-            const stop = () => Promise.resolve(instance.process.stop(process.cwd())).then(() => {
-                instance.setRunningMode(null);
-            });
+        const isRunning = await instance.isRunning();
+        if (!isRunning) {
+            this.ui.log('Ghost is already stopped! For more information, run', 'ghost ls', 'green', 'cmd', true);
+            return;
+        }
 
-            return this.ui.run(stop, 'Stopping Ghost', runOptions);
-        }).then(() => {
-            if (!argv.disable || !ProcessManager.supportsEnableBehavior(instance.process)) {
-                return Promise.resolve();
-            }
-
-            return Promise.resolve(instance.process.isEnabled()).then((isEnabled) => {
-                if (!isEnabled) {
-                    return Promise.resolve();
-                }
-
-                return this.ui.run(
-                    () => instance.process.disable(),
-                    'Disabling Ghost instance startup on server boot',
-                    runOptions
-                );
-            });
-        });
+        await this.ui.run(() => instance.stop(argv.disable), `Stopping Ghost: ${instance.name}`, runOptions);
     }
 
-    stopAll() {
+    async stopAll() {
         const Promise = require('bluebird');
 
         const instances = this.system.getAllInstances(true);
-        const cwd = process.cwd();
-
-        return Promise.each(instances, (instance) => {
-            process.chdir(instance.dir);
-            return this.ui.run(() => this.run({quiet: true}), `Stopping Ghost: ${instance.name}`);
-        }).then(() => {
-            process.chdir(cwd);
+        await Promise.each(instances, async ({name}) => {
+            await this.ui.run(() => this.run({quiet: true, name}), `Stopping Ghost: ${name}`);
         });
     }
 }

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -251,6 +251,52 @@ class Instance {
     }
 
     /**
+     * Starts the Ghost instance
+     *
+     * @return {Promise<void>}
+     * @method start
+     * @public
+     */
+    async start(enable = false) {
+        await this.process.start(this.dir, this.system.environment);
+        this.setRunningMode(this.system.environment);
+
+        if (!enable) {
+            return;
+        }
+
+        const isEnabled = await this.process.isEnabled();
+        if (isEnabled) {
+            return;
+        }
+
+        await this.process.enable();
+    }
+
+    /**
+     * Stops the ghost instance
+     *
+     * @return {Promise<void>}
+     * @method stop
+     * @public
+     */
+    async stop(disable = false) {
+        await this.process.stop(this.dir);
+        this.setRunningMode(null);
+
+        if (!disable) {
+            return;
+        }
+
+        const isEnabled = await this.process.isEnabled();
+        if (!isEnabled) {
+            return;
+        }
+
+        await this.process.disable();
+    }
+
+    /**
      * Gets a summary of this instance, comprised of various values from
      * the cliConfig and the ghost config
      *

--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -1,15 +1,9 @@
 'use strict';
 
-const every = require('lodash/every');
 const requiredMethods = [
     'start',
     'stop',
     'isRunning'
-];
-const enableMethods = [
-    'isEnabled',
-    'enable',
-    'disable'
 ];
 
 class ProcessManager {
@@ -87,6 +81,14 @@ class ProcessManager {
         }
     }
 
+    // No-op base methods for enable/disable handling
+    async isEnabled() {
+        return false;
+    }
+
+    async enable() {}
+    async disable() {}
+
     /**
      * This function checks if this process manager can be used on this system
      *
@@ -112,10 +114,5 @@ function isValid(SubClass) {
     return missing;
 }
 
-function supportsEnableBehavior(processInstance) {
-    return every(enableMethods, method => processInstance[method]);
-}
-
 module.exports = ProcessManager;
 module.exports.isValid = isValid;
-module.exports.supportsEnableBehavior = supportsEnableBehavior;

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -3,257 +3,107 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 
-const modulePath = '../../../lib/commands/stop';
-const errors = require('../../../lib/errors');
-const StopCommand = require(modulePath);
+const {SystemError} = require('../../../lib/errors');
 
-function proxiedCommand() {
-    return new (proxyquire(modulePath, {'../utils/check-valid-install': () => true}))();
-}
+const modulePath = '../../../lib/commands/stop';
+const StopCommand = require(modulePath);
 
 describe('Unit: Commands > Stop', function () {
     describe('run', function () {
-        it('stops all if flag is provided', function () {
+        it('stops all if flag is provided', async function () {
             const stop = new StopCommand();
-            const sAstub = sinon.stub();
-            const context = {stopAll: sAstub};
-            stop.run.call(context, {all: true});
-            expect(sAstub.calledOnce).to.be.true;
+            const stopAll = sinon.stub(stop, 'stopAll').resolves();
+
+            await stop.run({all: true});
+            expect(stopAll.calledOnce).to.be.true;
         });
 
-        it('errors when unknown instance is specified', function () {
-            const stop = new StopCommand();
-            const gIstub = sinon.stub().returns(false);
-            const context = {system: {getInstance: gIstub}};
-
-            return stop.run.call(context, {name: 'ghost'}).then(() => {
-                expect(false, 'Promise should have rejected').to.be.true;
-            }).catch((error) => {
-                expect(error).to.be.ok;
-                expect(error instanceof errors.SystemError).to.be.true;
-                expect(error.message).to.match(/does not exist/);
+        it('checks for valid install if name not specified', async function () {
+            const checkStub = sinon.stub().throws(new Error('checkValidInstall'));
+            const Command = proxyquire(modulePath, {
+                '../utils/check-valid-install': checkStub
             });
-        });
-
-        it('chdirs to instance install directory', function () {
-            const originalCommand = process.chdir;
-            process.chdir = sinon.stub().throws(new Error('SHORT_CIRCUIT'));
-            const stop = new StopCommand();
-            const gIstub = sinon.stub().returns({dir: '../ghost'});
-            const context = {system: {getInstance: gIstub}};
+            const stop = new Command();
 
             try {
-                stop.run.call(context, {name: 'ghost'});
-                process.chdir = originalCommand;
+                await stop.run({});
             } catch (error) {
-                const pcss = process.chdir;
-                process.chdir = originalCommand;
-                expect(error).to.be.ok;
-                expect(error.message).to.equal('SHORT_CIRCUIT');
-                expect(pcss.calledOnce).to.be.true;
-                expect(pcss.args[0][0]).to.equal('../ghost');
+                expect(error.message).to.equal('checkValidInstall');
+                expect(checkStub.calledOnce).to.be.true;
+                return;
+            }
+
+            expect.fail('run should have thrown an error');
+        });
+
+        it('throws an error if no instance found for given name', async function () {
+            const getInstance = sinon.stub().returns(null);
+            const stop = new StopCommand({}, {getInstance});
+
+            try {
+                await stop.run({name: 'test'});
+            } catch (error) {
+                expect(error).to.be.an.instanceof(SystemError);
+                expect(error.message).to.include('\'test\' does not exist');
+                expect(getInstance.calledOnce).to.be.true;
+                expect(getInstance.calledWithExactly('test')).to.be.true;
             }
         });
 
-        it('gracefully notifies of already stopped instance', function () {
-            const runningFake = () => Promise.resolve(false);
-            const gIfake = () => ({isRunning: runningFake});
-            const logStub = sinon.stub();
-            const stop = proxiedCommand();
-            const context = {
-                system: {getInstance: gIfake},
-                ui: {log: logStub}
-            };
+        it('logs and exits if instance isn\'t running', async function () {
+            const log = sinon.stub();
+            const isRunning = sinon.stub().resolves(false);
+            const getInstance = sinon.stub().returns({isRunning});
+            const stop = new StopCommand({log}, {getInstance});
 
-            return stop.run.call(context, {}).then(() => {
-                expect(logStub.calledOnce).to.be.true;
-                expect(logStub.args[0][0]).to.match(/Ghost is already stopped!/);
-            });
+            await stop.run({name: 'testing'});
+
+            expect(getInstance.calledOnce).to.be.true;
+            expect(getInstance.calledWithExactly('testing')).to.be.true;
+            expect(isRunning.calledOnce).to.be.true;
+            expect(log.calledOnce).to.be.true;
         });
 
-        it('calls process manger stop', function () {
-            const stop = proxiedCommand();
-            const stopStub = sinon.stub().resolves();
-            const runningStub = sinon.stub().resolves(true);
-            const setRunningStub = sinon.stub();
-            const gIstub = sinon.stub().returns({
-                isRunning: runningStub,
-                setRunningMode: setRunningStub,
-                process: {stop: stopStub},
-                loadRunningEnvironment: () => true
-            });
+        it('stops instance', async function () {
+            const log = sinon.stub();
+            const run = sinon.stub().callsFake(fn => fn());
 
-            const runner = (fn, name) => {
-                expect(fn).to.be.ok;
-                expect(name).to.equal('Stopping Ghost');
-                return fn().then(() => {
-                    expect(stopStub.calledOnce).to.be.true;
-                    expect(stopStub.args[0][0]).to.equal(process.cwd());
-                    expect(runningStub.calledOnce).to.be.true;
-                    expect(setRunningStub.calledOnce).to.be.true;
-                    expect(setRunningStub.args[0][0]).to.equal(null);
-                });
-            };
+            const isRunning = sinon.stub().resolves(true);
+            const stop = sinon.stub().resolves();
 
-            const context = {
-                system: {getInstance: gIstub},
-                ui: {run: runner}
-            };
+            const getInstance = sinon.stub().returns({isRunning, stop});
 
-            return stop.run.call(context, {});
-        });
+            const cmd = new StopCommand({log, run}, {getInstance});
+            await cmd.run({name: 'testing'});
 
-        describe('handles disabling', function () {
-            it('skips disabling if disable flag is not set', function () {
-                const instance = {
-                    isRunning: () => Promise.resolve(true),
-                    process: {
-                        enable: () => Promise.resolve(),
-                        disable: sinon.stub().resolves(),
-                        stop: sinon.stub().resolves(),
-                        isEnabled: sinon.stub().resolves(true)
-                    },
-                    loadRunningEnvironment: () => true
-                };
-                const system = {
-                    getInstance: () => instance
-                };
-                const ui = {
-                    run: sinon.stub().resolves()
-                };
-
-                const StopCommand = proxyquire(modulePath, {
-                    '../utils/check-valid-install': () => true
-                });
-                const stop = new StopCommand(ui, system);
-
-                return stop.run({disable: false}).then(() => {
-                    expect(instance.process.isEnabled.called).to.be.false;
-                    expect(ui.run.calledOnce).to.be.true;
-                });
-            });
-
-            it('skips disabling if process manager doesn\'t support enable behavior', function () {
-                const instance = {
-                    isRunning: () => Promise.resolve(true),
-                    process: {
-                        stop: sinon.stub().resolves(),
-                        isEnabled: sinon.stub().resolves(false)
-                    },
-                    loadRunningEnvironment: () => true
-                };
-                const system = {
-                    getInstance: () => instance
-                };
-                const ui = {
-                    run: sinon.stub().resolves()
-                };
-
-                const StopCommand = proxyquire(modulePath, {
-                    '../utils/check-valid-install': () => true
-                });
-                const stop = new StopCommand(ui, system);
-
-                return stop.run({disable: true}).then(() => {
-                    expect(ui.run.calledOnce).to.be.true;
-                    expect(instance.process.isEnabled.called).to.be.false;
-                });
-            });
-
-            it('skips disabling if isEnabled returns false', function () {
-                const instance = {
-                    isRunning: () => Promise.resolve(true),
-                    process: {
-                        enable: () => Promise.resolve(),
-                        disable: sinon.stub().resolves(),
-                        stop: sinon.stub().resolves(),
-                        isEnabled: sinon.stub().resolves(false)
-                    },
-                    loadRunningEnvironment: () => true
-                };
-                const system = {
-                    getInstance: () => instance
-                };
-                const ui = {
-                    run: sinon.stub().resolves()
-                };
-
-                const StopCommand = proxyquire(modulePath, {
-                    '../utils/check-valid-install': () => true
-                });
-                const stop = new StopCommand(ui, system);
-
-                return stop.run({disable: true}).then(() => {
-                    expect(instance.process.isEnabled.calledOnce).to.be.true;
-                    expect(instance.process.disable.called).to.be.false;
-                    expect(ui.run.calledOnce).to.be.true;
-                });
-            });
-
-            it('disables if necessary', function () {
-                const instance = {
-                    isRunning: () => Promise.resolve(true),
-                    setRunningMode: () => {},
-                    process: {
-                        enable: () => Promise.resolve(),
-                        disable: sinon.stub().resolves(),
-                        stop: sinon.stub().resolves(),
-                        isEnabled: sinon.stub().resolves(true)
-                    },
-                    loadRunningEnvironment: () => true
-                };
-                const system = {
-                    getInstance: () => instance
-                };
-                const ui = {
-                    run: sinon.stub().callsFake(fn => Promise.resolve(fn()))
-                };
-
-                const StopCommand = proxyquire(modulePath, {
-                    '../utils/check-valid-install': () => true
-                });
-                const stop = new StopCommand(ui, system);
-
-                return stop.run({disable: true}).then(() => {
-                    expect(instance.process.isEnabled.calledOnce).to.be.true;
-                    expect(instance.process.disable.calledOnce).to.be.true;
-                    expect(ui.run.calledTwice).to.be.true;
-                });
-            });
+            expect(getInstance.calledOnce).to.be.true;
+            expect(getInstance.calledWithExactly('testing')).to.be.true;
+            expect(isRunning.calledOnce).to.be.true;
+            expect(run.calledOnce).to.be.true;
+            expect(stop.calledOnce).to.be.true;
+            expect(log.called).to.be.false;
         });
     });
 
-    it('stopAll stops all instances', function () {
-        const stop = new StopCommand();
-        const runStub = sinon.stub().callsFake(fn => fn.call(stop));
+    it('stopAll stops all instances', async function () {
         const cases = 'abcdefgh'.split('');
-        const instances = [];
-        cases.forEach((cse) => {
-            instances.push({
-                dir: `./${cse}`,
-                name: cse
-            });
-        });
+        const instances = cases.map(cse => ({
+            dir: `./${cse}`,
+            name: cse
+        }));
 
-        const context = {
-            system: {getAllInstances: () => instances},
-            ui: {run: runStub},
-            run: sinon.stub().resolves()
-        };
-        const originalChdir = process.chdir;
-        process.chdir = sinon.stub();
+        const run = sinon.stub().callsFake(fn => fn());
+        const getAllInstances = sinon.stub().returns(instances);
 
-        return stop.stopAll.call(context).then(() => {
-            const pcss = process.chdir;
-            process.chdir = originalChdir;
+        const stop = new StopCommand({run}, {getAllInstances});
+        const cmdRun = sinon.stub(stop, 'run').resolves();
 
-            expect(runStub.callCount).to.equal(8);
-            expect(context.run.callCount).to.equal(8);
-            expect(context.run.args[0][0].quiet).to.be.true;
-            expect(pcss.callCount).to.equal(9);
-            expect(pcss.args[0][0]).to.equal('./a');
-            expect(pcss.args[8][0]).to.equal(process.cwd());
-        });
+        await stop.stopAll();
+        expect(getAllInstances.calledOnce).to.be.true;
+        expect(run.callCount).to.equal(8);
+        expect(cmdRun.callCount).to.equal(8);
+
+        expect(cmdRun.calledWithExactly({quiet: true, name: 'a'})).to.be.true;
     });
 
     // @todo: Add more tests if necessary

--- a/test/unit/instance-spec.js
+++ b/test/unit/instance-spec.js
@@ -449,6 +449,136 @@ describe('Unit: Instance', function () {
         });
     });
 
+    describe('start', function () {
+        it('skips enable functionality if enable param is false', async function () {
+            const process = {
+                name: 'local',
+                start: sinon.stub().resolves(),
+                isEnabled: sinon.stub().resolves(true),
+                enable: sinon.stub().resolves()
+            };
+
+            const instance = new Instance({}, {environment: 'testing'}, '/var/www/ghost');
+            instance._process = process;
+            const runningStub = sinon.stub(instance, 'setRunningMode');
+
+            await instance.start();
+            expect(process.start.calledOnce).to.be.true;
+            expect(process.start.calledWithExactly('/var/www/ghost', 'testing'));
+            expect(process.isEnabled.called).to.be.false;
+            expect(process.enable.called).to.be.false;
+            expect(runningStub.calledOnce).to.be.true;
+            expect(runningStub.calledWithExactly('testing')).to.be.true;
+        });
+
+        it('skips enabling if process manager already enabled', async function () {
+            const process = {
+                name: 'local',
+                start: sinon.stub().resolves(),
+                isEnabled: sinon.stub().resolves(true),
+                enable: sinon.stub().resolves()
+            };
+
+            const instance = new Instance({}, {environment: 'testing'}, '/var/www/ghost');
+            instance._process = process;
+            const runningStub = sinon.stub(instance, 'setRunningMode');
+
+            await instance.start(true);
+            expect(process.start.calledOnce).to.be.true;
+            expect(process.start.calledWithExactly('/var/www/ghost', 'testing'));
+            expect(process.isEnabled.calledOnce).to.be.true;
+            expect(process.enable.called).to.be.false;
+            expect(runningStub.calledOnce).to.be.true;
+            expect(runningStub.calledWithExactly('testing')).to.be.true;
+        });
+
+        it('runs enable if not already enabled', async function () {
+            const process = {
+                name: 'local',
+                start: sinon.stub().resolves(),
+                isEnabled: sinon.stub().resolves(false),
+                enable: sinon.stub().resolves()
+            };
+
+            const instance = new Instance({}, {environment: 'testing'}, '/var/www/ghost');
+            instance._process = process;
+            const runningStub = sinon.stub(instance, 'setRunningMode');
+
+            await instance.start(true);
+            expect(process.start.calledOnce).to.be.true;
+            expect(process.start.calledWithExactly('/var/www/ghost', 'testing'));
+            expect(process.isEnabled.calledOnce).to.be.true;
+            expect(process.enable.calledOnce).to.be.true;
+            expect(runningStub.calledOnce).to.be.true;
+            expect(runningStub.calledWithExactly('testing')).to.be.true;
+        });
+    });
+
+    describe('stop', function () {
+        it('skips disable functionality if disable param is false', async function () {
+            const process = {
+                name: 'local',
+                stop: sinon.stub().resolves(),
+                isEnabled: sinon.stub().resolves(false),
+                disable: sinon.stub().resolves()
+            };
+
+            const instance = new Instance({}, {environment: 'testing'}, '/var/www/ghost');
+            instance._process = process;
+            const runningStub = sinon.stub(instance, 'setRunningMode');
+
+            await instance.stop();
+            expect(process.stop.calledOnce).to.be.true;
+            expect(process.stop.calledWithExactly('/var/www/ghost'));
+            expect(process.isEnabled.called).to.be.false;
+            expect(process.disable.called).to.be.false;
+            expect(runningStub.calledOnce).to.be.true;
+            expect(runningStub.calledWithExactly(null)).to.be.true;
+        });
+
+        it('skips disabling if process manager not enabled', async function () {
+            const process = {
+                name: 'local',
+                stop: sinon.stub().resolves(),
+                isEnabled: sinon.stub().resolves(false),
+                disable: sinon.stub().resolves()
+            };
+
+            const instance = new Instance({}, {environment: 'testing'}, '/var/www/ghost');
+            instance._process = process;
+            const runningStub = sinon.stub(instance, 'setRunningMode');
+
+            await instance.stop(true);
+            expect(process.stop.calledOnce).to.be.true;
+            expect(process.stop.calledWithExactly('/var/www/ghost'));
+            expect(process.isEnabled.calledOnce).to.be.true;
+            expect(process.disable.called).to.be.false;
+            expect(runningStub.calledOnce).to.be.true;
+            expect(runningStub.calledWithExactly(null)).to.be.true;
+        });
+
+        it('runs disable if already enabled', async function () {
+            const process = {
+                name: 'local',
+                stop: sinon.stub().resolves(),
+                isEnabled: sinon.stub().resolves(true),
+                disable: sinon.stub().resolves()
+            };
+
+            const instance = new Instance({}, {environment: 'testing'}, '/var/www/ghost');
+            instance._process = process;
+            const runningStub = sinon.stub(instance, 'setRunningMode');
+
+            await instance.stop(true);
+            expect(process.stop.calledOnce).to.be.true;
+            expect(process.stop.calledWithExactly('/var/www/ghost'));
+            expect(process.isEnabled.calledOnce).to.be.true;
+            expect(process.disable.calledOnce).to.be.true;
+            expect(runningStub.calledOnce).to.be.true;
+            expect(runningStub.calledWithExactly(null)).to.be.true;
+        });
+    });
+
     describe('summary', function () {
         it('returns shortened object if running is false', async function () {
             const get = sinon.stub();

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -43,25 +43,6 @@ describe('Unit: Process Manager', function () {
         });
     });
 
-    describe('supportsEnableBehavior', function () {
-        const ProcessManager = require(modulePath);
-
-        it('returns false if the class does not implement all of the methods for enable behavior', function () {
-            const instance = new ProcessManager({}, {}, {});
-            expect(ProcessManager.supportsEnableBehavior(instance)).to.be.false;
-        });
-
-        it('returns true if all the methods for enable behavior are implemented', function () {
-            class TestProcess extends ProcessManager {
-                isEnabled() { }
-                enable() { }
-                disable() { }
-            }
-            const instance = new TestProcess({}, {}, {});
-            expect(ProcessManager.supportsEnableBehavior(instance)).to.be.true;
-        });
-    });
-
     describe('ensureStarted', function () {
         const portPollingStub = sinon.stub();
         const ProcessManager = proxyquire(modulePath, {
@@ -212,6 +193,28 @@ describe('Unit: Process Manager', function () {
         return instance.isRunning().then((result) => {
             expect(result).to.be.false;
         });
+    });
+
+    it('base isEnabled returns true', async function () {
+        const ProcessManager = require(modulePath);
+        const instance = new ProcessManager({}, {}, {});
+
+        const result = await instance.isEnabled();
+        expect(result).to.be.false;
+    });
+
+    it('base enable method', async function () {
+        const ProcessManager = require(modulePath);
+        const instance = new ProcessManager({}, {}, {});
+
+        await instance.enable();
+    });
+
+    it('base disable method', async function () {
+        const ProcessManager = require(modulePath);
+        const instance = new ProcessManager({}, {}, {});
+
+        await instance.disable();
     });
 
     it('base willRun method returns true', function () {


### PR DESCRIPTION
refs #783
- move start/stop functionality into instance class
- add base stub methods for ProcessManager
- refactor stop/start commands to use new instance functionality