### PR TITLE
Add "mailfrom" to command line options

### DIFF
--- a/lib/tasks/configure/options.js
+++ b/lib/tasks/configure/options.js
@@ -128,6 +128,13 @@ module.exports = {
         type: 'string',
         group: 'Mail Options:'
     },
+    mailfrom: {
+        description: 'Mail "from:" address (used with SMTP transport)',
+        configPath: 'mail.from',
+        validate: value => /^([^<]*<)?([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})(>)?$/.test(value) || 'Invalid email from address',
+        type: 'string',
+        group: 'Mail Options:'
+    },
     mailuser: {
         description: 'Mail auth user (used with SMTP transport)',
         configPath: 'mail.options.auth.user',


### PR DESCRIPTION
This provides a way to populate the essential `mail.from` field by means of commandline args