### PR TITLE
fix(version): ensure custom version is handled as a string

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -19,7 +19,9 @@ class InstallCommand extends Command {
         const dirIsEmpty = require('../utils/dir-is-empty');
         const ensureStructure = require('../tasks/ensure-structure');
 
-        let version = argv.version;
+        // if version is a single number (i.e. 2) yargs converts it to a number.
+        // We convert it back to a string for consistency
+        let version = argv.version ? `${argv.version}` : null;
 
         // Check if the directory is empty
         if (!dirIsEmpty(process.cwd())) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -34,7 +34,8 @@ class UpdateCommand extends Command {
             );
         }
 
-        const {force, version, zip, v1} = argv;
+        const {force, zip, v1} = argv;
+        const version = argv.version ? `${argv.version}` : null;
 
         const context = {
             instance,

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -160,6 +160,34 @@ describe('Unit: Commands > Install', function () {
             });
         });
 
+        it('normalizes version to a string', function () {
+            const dirEmptyStub = sinon.stub().returns(true);
+            const listrStub = sinon.stub();
+            listrStub.onFirstCall().resolves();
+            listrStub.onSecondCall().rejects();
+            const setEnvironmentStub = sinon.stub();
+
+            const InstallCommand = proxyquire(modulePath, {
+                '../utils/dir-is-empty': dirEmptyStub
+            });
+            const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
+            const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
+
+            return testInstance.run({version: 2, zip: '', v1: false, _: ['install', 'local']}).then(() => {
+                expect(false, 'run should have rejected').to.be.true;
+            }).catch(() => {
+                expect(dirEmptyStub.calledOnce).to.be.true;
+                expect(runCommandStub.calledOnce).to.be.true;
+                expect(listrStub.calledOnce).to.be.true;
+                expect(listrStub.args[0][1]).to.deep.equal({
+                    argv: {version: '2', zip: '', v1: false, _: ['install', 'local']},
+                    cliVersion: '1.0.0'
+                });
+                expect(setEnvironmentStub.calledOnce).to.be.true;
+                expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
+            });
+        });
+
         it('calls all tasks and returns after tasks run if --no-setup is passed', function () {
             const dirEmptyStub = sinon.stub().returns(true);
             const yarnInstallStub = sinon.stub().resolves();


### PR DESCRIPTION
fixes the `ghost install 2` case throwing an error