### PR TITLE
fix(major): allow automatic major upgrades for clean themes

### DIFF
--- a/lib/tasks/major-update/ui.js
+++ b/lib/tasks/major-update/ui.js
@@ -101,7 +101,8 @@ module.exports = async function ui(ctx) {
         });
     }
 
-    const answer = await ctx.ui.confirm(`Are you sure you want to proceed with migrating to Ghost ${ctx.version}?`, null, {prefix: chalk.cyan('?')});
+    const autoUpgradeDefault = (!results.error.all.length && !results.warning.all.length);
+    const answer = await ctx.ui.confirm(`Are you sure you want to proceed with migrating to Ghost ${ctx.version}?`, autoUpgradeDefault, {prefix: chalk.cyan('?')});
     if (!answer) {
         throw new CliError({
             message: `Update aborted. Your blog is still on ${ctx.activeVersion}.`,

--- a/test/unit/tasks/major-update/ui-spec.js
+++ b/test/unit/tasks/major-update/ui-spec.js
@@ -50,6 +50,7 @@ describe('Unit: Tasks > Major Update > UI', function () {
         await ui(ctx);
         expect(ctx.ui.log.callCount).to.eql(4);
         expect(ctx.ui.confirm.calledOnce).to.be.true;
+        expect(ctx.ui.confirm.args[0][1], 'confirm prompt default should be true').to.be.true;
     });
 
     it('theme has warnings', async function () {
@@ -75,6 +76,7 @@ describe('Unit: Tasks > Major Update > UI', function () {
         await ui(ctx);
         expect(ctx.ui.log.callCount).to.eql(6);
         expect(ctx.ui.confirm.calledTwice).to.be.true;
+        expect(ctx.ui.confirm.args[1][1], 'confirm prompt default should be false').to.be.false;
 
         const output = stripAnsi(ctx.ui.log.args.join(' '));
 
@@ -111,6 +113,7 @@ describe('Unit: Tasks > Major Update > UI', function () {
         await ui(ctx);
         expect(ctx.ui.log.callCount).to.eql(7);
         expect(ctx.ui.confirm.calledTwice).to.be.true;
+        expect(ctx.ui.confirm.args[1][1], 'confirm prompt default should be false').to.be.false;
 
         const output = stripAnsi(ctx.ui.log.args.join(' '));
 


### PR DESCRIPTION
allows for automatic major version upgrades, assuming the theme has no warnings or errors.