### PR TITLE
fix(cleanup): ensure cleanup gets run on process.exit calls

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -163,9 +163,10 @@ class Command {
         if (commandInstance.cleanup) {
             debug(`cleanup handler found for ${commandName}`);
             const cleanup = commandInstance.cleanup.bind(commandInstance);
-            // process.on('exit') is unreliable apparently, so we do this
-            process.removeAllListeners('SIGINT').on('SIGINT', cleanup)
-                .removeAllListeners('SIGTERM').on('SIGTERM', cleanup);
+            // bind cleanup handler to SIGINT, SIGTERM, and exit events
+            process.removeAllListeners('SIGINT').on('SIGINT', cleanup) // handle ctrl + c from keyboard
+                .removeAllListeners('SIGTERM').on('SIGTERM', cleanup) // handle kill signal from something like `kill`
+                .removeAllListeners('exit').on('exit', cleanup); // handle process.exit calls from within CLI codebase
         }
 
         try {

--- a/test/unit/command-spec.js
+++ b/test/unit/command-spec.js
@@ -362,9 +362,10 @@ describe('Unit: Command', function () {
             expect(loadOsInfo.calledOnce).to.be.true;
             expect(runStub.calledOnce).to.be.true;
             expect(runStub.calledWithExactly({verbose: false, prompt: false, development: false, auto: true})).to.be.true;
-            expect(onStub.calledTwice).to.be.true;
+            expect(onStub.calledThrice).to.be.true;
             expect(onStub.calledWith('SIGINT')).to.be.true;
             expect(onStub.calledWith('SIGTERM')).to.be.true;
+            expect(onStub.calledWith('exit')).to.be.true;
         });
 
         it('runs updateCheck if checkVersion property is true on command class', async function () {


### PR DESCRIPTION
refs #1140, #793 

when `process.exit()` is called, it doesn't fire a SIGINT or SIGTERM event, it fires an `exit` event. Adding an event listener for process.exit should fix some cases of cleanup not being called