### PR TITLE
Fix for --no-prompt sudo shell execution in Dockerfile of ghost

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -246,7 +246,7 @@ class UI {
             /* istanbul ignore else */
             // If sudo has prompted for a password, then it will be the last line output
             if (lines[lines.length - 1] === prompt) {
-                if(process.env.SUDO_PASSWORD !== undefined){
+                if (process.env.SUDO_PASSWORD !== undefined) {
                     this.prompt({
                         type: 'password',
                         name: 'password',
@@ -254,7 +254,7 @@ class UI {
                     }).then((answers) => {
                         cp.stdin.write(`${answers.password}\n`);
                     });   
-                }else{
+                } else {
                     cp.stdin.write(`${process.env.SUDO_PASSWORD}\n`);  
                 }
             }

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -246,7 +246,7 @@ class UI {
             /* istanbul ignore else */
             // If sudo has prompted for a password, then it will be the last line output
             if (lines[lines.length - 1] === prompt) {
-                if (process.env.SUDO_PASSWORD !== undefined) {
+                if (process.env.SUDO_PASSWORD === undefined) {
                     this.prompt({
                         type: 'password',
                         name: 'password',

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -246,13 +246,17 @@ class UI {
             /* istanbul ignore else */
             // If sudo has prompted for a password, then it will be the last line output
             if (lines[lines.length - 1] === prompt) {
-                this.prompt({
-                    type: 'password',
-                    name: 'password',
-                    message: 'Sudo Password'
-                }).then((answers) => {
-                    cp.stdin.write(`${answers.password}\n`);
-                });
+                if(process.env.SUDO_PASSWORD !== undefined){
+                    this.prompt({
+                        type: 'password',
+                        name: 'password',
+                        message: 'Sudo Password'
+                    }).then((answers) => {
+                        cp.stdin.write(`${answers.password}\n`);
+                    });   
+                }else{
+                    cp.stdin.write(`${process.env.SUDO_PASSWORD}\n`);  
+                }
             }
         });
 


### PR DESCRIPTION
This is a fix if u run 'ghost setup nginx' in Dockerfile of ghost. 

**Problem**
- when 'RUN gosu node ghost setup nginx' is added in Dockerfile to set ghost on docker, following error comes out:-
```
/usr/local/lib/node_modules/ghost-cli/lib/ui/index.js:148
            throw new errors.SystemError('Prompts have been disabled, all options must be provided via command line flags');
```

- Reason for this is because **this.ui.sudo(command)** called in https://github.com/TryGhost/Ghost-CLI/blob/019f4da8ac699cf68d8cc7ef03c836df982cd501/extensions/nginx/index.js#L112

- sudo(command) in **ui** then tries to call **this.prompt()** which results in an error because docker doesn't allow prompt to open

**Solution**
The user can set an environment variable of SUDO_PASSWORD and then this will automatically enter the password in the sudo prompt.