### PR TITLE
feat(sqlite): ensure sqlite db path is absolute

### DIFF
--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -1,7 +1,6 @@
-'use strict';
+const path = require('path');
 
 async function ensureSettingsFolder(context) {
-    const path = require('path');
     const ghostUser = require('./utils/use-ghost-user');
 
     const contentDir = context.instance.config.get('paths.contentPath');
@@ -14,8 +13,25 @@ async function ensureSettingsFolder(context) {
     }
 }
 
+async function makeSqliteAbsolute({instance}) {
+    const configs = await instance.getAvailableConfigs();
+
+    Object.values(configs).forEach((config) => {
+        const currentFilename = config.get('database.connection.filename', null);
+        if (!currentFilename || path.isAbsolute(currentFilename)) {
+            return;
+        }
+
+        config.set('database.connection.filename', path.resolve(instance.dir, currentFilename)).save();
+    });
+}
+
 module.exports = [{
     before: '1.7.0',
     title: 'Create content/settings directory',
     task: ensureSettingsFolder
+}, {
+    before: '1.14.1',
+    title: 'Fix Sqlite DB path',
+    task: makeSqliteAbsolute
 }];

--- a/lib/tasks/configure/options.js
+++ b/lib/tasks/configure/options.js
@@ -1,10 +1,10 @@
-'use strict';
 // Advanced options for the config command
 const portfinder = require('portfinder');
 const toString = require('lodash/toString');
 const validator = require('validator');
 const urlUtils = require('../../utils/url');
 const url = require('url');
+const path = require('path');
 
 const BASE_PORT = 2368;
 const knownMailServices = [
@@ -24,6 +24,7 @@ module.exports = {
         description: 'Site domain E.g. loveghost.com',
         validate: urlUtils.validate,
         transform: urlUtils.ensureProtocol,
+
         type: 'string',
         group: 'Ghost Options:'
     },
@@ -83,8 +84,9 @@ module.exports = {
             }
 
             const dbFile = (environment === 'production') ? 'ghost.db' : 'ghost-dev.db';
-            return `./content/data/${dbFile}`;
-        }
+            return path.resolve(`./content/data/${dbFile}`);
+        },
+        transform: path.resolve
     },
     dbhost: {
         description: 'Database host',

--- a/test/unit/tasks/configure/options-spec.js
+++ b/test/unit/tasks/configure/options-spec.js
@@ -2,6 +2,7 @@ const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const Promise = require('bluebird');
+const path = require('path');
 
 const options = require('../../../../lib/tasks/configure/options');
 const urlUtils = require('../../../../lib/utils/url');
@@ -64,8 +65,8 @@ describe('Unit: Tasks: Configure > options', function () {
     it('dbpath', function () {
         expect(options.dbpath).to.exist;
         expect(options.dbpath.defaultValue({get: () => 'mysql'})).to.be.null;
-        expect(options.dbpath.defaultValue({get: () => 'sqlite3'}, 'development')).to.equal('./content/data/ghost-dev.db');
-        expect(options.dbpath.defaultValue({get: () => 'sqlite3'}, 'production')).to.equal('./content/data/ghost.db');
+        expect(options.dbpath.defaultValue({get: () => 'sqlite3'}, 'development')).to.equal(path.resolve('./content/data/ghost-dev.db'));
+        expect(options.dbpath.defaultValue({get: () => 'sqlite3'}, 'production')).to.equal(path.resolve('./content/data/ghost.db'));
     });
 
     it('mail', function () {


### PR DESCRIPTION
- ensure dbpath argument is absolute by default
- add migration to make relative sqlite paths absolute

NOTE: depends on functionality from #1210 