### PR TITLE
feat(node): updated minimum Node versions to latest security releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 10, 12 ]
+        node: [ '10.21.0', '12.18.0' ]
         os: [ ubuntu-18.04, windows-latest ]
     env:
       FORCE_COLOR: 1

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "engines": {
-    "node": "^10.13.0 || ^12.10.0"
+    "node": "^10.21.0 || ^12.18.0"
   },
   "preferGlobal": true,
   "dependencies": {


### PR DESCRIPTION
no issue

- Node 10.21.0 and 12.18.0 are the latest

to be merged with:
* https://github.com/TryGhost/Ghost/pull/11874
* https://github.com/TryGhost/Ghost-Admin/pull/1587