### PR TITLE
[SSL] Add -dsaparam to speed up the generation of encryption keys

### DIFF
--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -185,7 +185,7 @@ class NginxExtension extends Extension {
         }, {
             title: 'Generating Encryption Key (may take a few minutes)',
             skip: () => fs.existsSync(dhparamFile),
-            task: () => this.ui.sudo(`openssl dhparam -out ${dhparamFile} 2048`)
+            task: () => this.ui.sudo(`openssl dhparam -dsaparam -out ${dhparamFile} 2048`)
                 .catch(error => Promise.reject(new ProcessError(error)))
         }, {
             title: 'Generating SSL security headers',


### PR DESCRIPTION
Hi, the generation key was taking too long for me, so I checked on the Internet and found [this StackOverflow answer](https://security.stackexchange.com/a/95184/8965):

> This is considerably faster because it does not need to nest the primality tests, and thus only thousands, not millions, of candidates will be generated and tested.  
> As far as academics know, DSA-like parameters for DH are equally secure; there is no actual advantage to using "strong primes" (the terminology is traditional and does not actually imply some extra strength).