### PR TITLE
fix(log) prevent error when no transports exist

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -31,7 +31,7 @@ class LogCommand extends Command {
                 // TODO: fallback to process manager log retrieval?
                 return Promise.reject(new errors.ConfigError({
                     config: {
-                        'logging.transports': instance.config.get('logging.transports').join(', ')
+                        'logging.transports': instance.config.get('logging.transports', []).join(', ')
                     },
                     message: 'You have excluded file logging in your ghost config. ' +
                         'You need to add it to your transport config to use this command.',

--- a/test/unit/commands/log-spec.js
+++ b/test/unit/commands/log-spec.js
@@ -132,6 +132,22 @@ describe('Unit: Commands > Log', function () {
             });
         });
 
+        it('Rejects without crashing when logging to file is disabled', function () {
+            const ext = proxyLog();
+            const instance = {
+                isRunning: () => Promise.resolve(true),
+                config: {get: (key, fallback) => fallback}
+            };
+            ext.system = {getInstance: () => instance};
+
+            return ext.run({name: 'ghost_org'}).then(() => {
+                expect(false, 'An error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.ok;
+                expect(error).to.be.instanceOf(Errors.ConfigError);
+            });
+        });
+
         it('Reads error log when requested', function () {
             stubs.es.throws(new Error('SHORT_CIRCUIT'));
             const ext = proxyLog({fs: {existsSync: stubs.es}});


### PR DESCRIPTION
Originally discovered on [the forum](https://forum.ghost.org/t/migration-from-wordpress-to-ghost-hosted-by-digital-ocean-droplet-fails/17434)