### PR TITLE
feat(mysql): support MySQL version 8

### DIFF
--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -1,13 +1,21 @@
-'use strict';
-
 const Promise = require('bluebird');
 const mysql = require('mysql');
 const omit = require('lodash/omit');
 const generator = require('generate-password');
+const semver = require('semver');
+
 const {Extension, errors} = require('../../lib');
 
 const localhostAliases = ['localhost', '127.0.0.1'];
-const {ConfigError, CliError} = errors;
+const {ConfigError, CliError, SystemError} = errors;
+
+function isMySQL8(version) {
+    return version && version.major === 8;
+}
+
+function isUnsupportedMySQL(version) {
+    return version && semver.lt(version, '5.7.0');
+}
 
 class MySQLExtension extends Extension {
     setup() {
@@ -36,6 +44,10 @@ class MySQLExtension extends Extension {
             title: 'Granting new user permissions',
             task: () => this.grantPermissions(ctx, dbconfig)
         }, {
+            title: 'Setting up database (MySQL 8)',
+            task: () => this.createMySQL8Database(dbconfig),
+            enabled: ({mysql: mysqlCtx}) => mysqlCtx && isMySQL8(mysqlCtx.version)
+        }, {
             title: 'Saving new config',
             task: () => {
                 ctx.instance.config.set('database.connection.user', ctx.mysql.username)
@@ -46,12 +58,28 @@ class MySQLExtension extends Extension {
         }], false);
     }
 
-    canConnect(ctx, dbconfig) {
+    async getServerVersion() {
+        try {
+            const result = await this._query('SELECT @@version AS version');
+            if (result && result[0] && result[0].version) {
+                return semver.parse(result[0].version);
+            }
+
+            return null;
+        } catch (error) {
+            this.ui.logVerbose('MySQL: failed to determine server version, assuming 5.x', 'gray');
+            return null;
+        }
+    }
+
+    async canConnect(ctx, dbconfig) {
         this.connection = mysql.createConnection(omit(dbconfig, 'database'));
 
-        return Promise.fromCallback(cb => this.connection.connect(cb)).catch((error) => {
+        try {
+            await Promise.fromCallback(cb => this.connection.connect(cb));
+        } catch (error) {
             if (error.code === 'ECONNREFUSED') {
-                return Promise.reject(new ConfigError({
+                throw new ConfigError({
                     message: error.message,
                     config: {
                         'database.connection.host': dbconfig.host,
@@ -59,9 +87,9 @@ class MySQLExtension extends Extension {
                     },
                     environment: this.system.environment,
                     help: 'Ensure that MySQL is installed and reachable. You can always re-run `ghost setup` to try again.'
-                }));
+                });
             } else if (error.code === 'ER_ACCESS_DENIED_ERROR') {
-                return Promise.reject(new ConfigError({
+                throw new ConfigError({
                     message: error.message,
                     config: {
                         'database.connection.user': dbconfig.user,
@@ -69,18 +97,39 @@ class MySQLExtension extends Extension {
                     },
                     environment: this.system.environment,
                     help: 'You can run `ghost config` to re-enter the correct credentials. Alternatively you can run `ghost setup` again.'
-                }));
+                });
             }
 
-            return Promise.reject(new CliError({
+            throw new CliError({
                 message: 'Error trying to connect to the MySQL database.',
                 help: 'You can run `ghost config` to re-enter the correct credentials. Alternatively you can run `ghost setup` again.',
                 err: error
-            }));
-        });
+            });
+        }
+
+        const version = await this.getServerVersion();
+        if (version) {
+            if (isUnsupportedMySQL(version)) {
+                throw new SystemError({
+                    message: `Error: unsupported MySQL version (${version.raw})`,
+                    help: 'Update your MySQL server to at least MySQL v5.7 in order to run Ghost'
+                });
+            }
+
+            ctx.mysql = {version};
+        }
     }
 
-    createUser(ctx, dbconfig) {
+    randomUsername() {
+        // IMPORTANT: we generate random MySQL usernames
+        // e.g. you delete all your Ghost instances from your droplet and start from scratch, the MySQL users would remain and the CLI has to generate a random user name to work
+        // e.g. if we would rely on the instance name, the instance naming only auto increments if there are existing instances
+        // the most important fact is, that if a MySQL user exists, we have no access to the password, which we need to autofill the Ghost config
+        // disadvantage: the CLI could potentially create lot's of MySQL users (but this should only happen if the user installs Ghost over and over again with root credentials)
+        return `ghost-${Math.floor(Math.random() * 1000)}`;
+    }
+
+    async getMySQL5Password() {
         const randomPassword = generator.generate({
             length: 20,
             numbers: true,
@@ -88,94 +137,134 @@ class MySQLExtension extends Extension {
             strict: true
         });
 
+        await this._query('SET old_passwords = 0;');
+        this.ui.logVerbose('MySQL: successfully disabled old_password', 'green');
+
+        const result = await this._query(`SELECT PASSWORD('${randomPassword}') AS password;`);
+
+        if (!result || !result[0] || !result[0].password) {
+            throw new Error('MySQL password generation failed');
+        }
+
+        this.ui.logVerbose('MySQL: successfully created password hash.', 'green');
+        return {
+            password: randomPassword,
+            hash: result[0].password
+        };
+    }
+
+    async createMySQL5User(host) {
+        const username = this.randomUsername();
+        const {password, hash} = await this.getMySQL5Password();
+        await this._query(`CREATE USER '${username}'@'${host}' IDENTIFIED WITH mysql_native_password AS '${hash}';`);
+        this.ui.logVerbose(`MySQL: successfully created new user ${username}`, 'green');
+        return {username, password};
+    }
+
+    async createMySQL8User(host) {
+        const username = this.randomUsername();
+
+        const result = await this._query(
+            `CREATE USER '${username}'@'${host}' IDENTIFIED WITH mysql_native_password BY RANDOM PASSWORD`
+        );
+
+        if (!result || !result[0] || !result[0]['generated password']) {
+            throw new Error('MySQL user creation did not return a generated password');
+        }
+
+        this.ui.logVerbose(`MySQL: successfully created new user ${username}`, 'green');
+
+        return {
+            username,
+            password: result[0]['generated password']
+        };
+    }
+
+    async createUser(ctx, dbconfig) {
         // This will be the "allowed connections from" host of the mysql user.
         // If the db connection host is something _other_ than localhost (e.g. a remote db connection)
         // we want the host to be `%` rather than the db host.
         const host = !localhostAliases.includes(dbconfig.host) ? '%' : dbconfig.host;
+        const {version} = ctx.mysql || {};
 
-        let username;
+        try {
+            let user = {};
 
-        // Ensure old passwords is set to 0
-        return this._query('SET old_passwords = 0;').then(() => {
-            this.ui.logVerbose('MySQL: successfully disabled old_password', 'green');
-
-            return this._query(`SELECT PASSWORD('${randomPassword}') AS password;`);
-        }).then((result) => {
-            this.ui.logVerbose('MySQL: successfully created password hash.', 'green');
-
-            const tryCreateUser = () => {
-                // IMPORTANT: we generate random MySQL usernames
-                // e.g. you delete all your Ghost instances from your droplet and start from scratch, the MySQL users would remain and the CLI has to generate a random user name to work
-                // e.g. if we would rely on the instance name, the instance naming only auto increments if there are existing instances
-                // the most important fact is, that if a MySQL user exists, we have no access to the password, which we need to autofill the Ghost config
-                // disadvantage: the CLI could potentially create lot's of MySQL users (but this should only happen if the user installs Ghost over and over again with root credentials)
-                username = `ghost-${Math.floor(Math.random() * 1000)}`;
-
-                return this._query(
-                    `CREATE USER '${username}'@'${host}' ` +
-                    `IDENTIFIED WITH mysql_native_password AS '${result[0].password}';`
-                ).catch((error) => {
-                    // User already exists, run this method again
-                    if (error.err && error.err.errno === 1396) {
-                        this.ui.logVerbose('MySQL: user exists, re-trying user creation with new username', 'yellow');
-                        return tryCreateUser();
-                    }
-
-                    error.message = `Creating new MySQL user errored with message: ${error.message}`;
-
-                    return Promise.reject(error);
-                });
-            };
-
-            return tryCreateUser();
-        }).then(() => {
-            this.ui.logVerbose(`MySQL: successfully created new user ${username}`, 'green');
+            if (isMySQL8(version)) {
+                user = await this.createMySQL8User(host);
+            } else {
+                user = await this.createMySQL5User(host);
+            }
 
             ctx.mysql = {
-                host: host,
-                username: username,
-                password: randomPassword
+                ...(ctx.mysql || {}),
+                ...user,
+                host
             };
-        }).catch((error) => {
+        } catch (error) {
+            if (error.err && error.err.errno === 1396) {
+                this.ui.logVerbose('MySQL: user exists, re-trying user creation with new username', 'yellow');
+                return this.createUser(ctx, dbconfig);
+            }
+
             this.ui.logVerbose('MySQL: Unable to create custom Ghost user', 'red');
             this.connection.end(); // Ensure we end the connection
 
             error.message = `Creating new MySQL user errored with message: ${error.message}`;
-
-            return Promise.reject(error);
-        });
+            throw error;
+        }
     }
 
-    grantPermissions(ctx, dbconfig) {
-        return this._query(`GRANT ALL PRIVILEGES ON ${dbconfig.database}.* TO '${ctx.mysql.username}'@'${ctx.mysql.host}';`).then(() => {
+    async grantPermissions(ctx, dbconfig) {
+        try {
+            await this._query(`GRANT ALL PRIVILEGES ON ${dbconfig.database}.* TO '${ctx.mysql.username}'@'${ctx.mysql.host}';`);
             this.ui.logVerbose(`MySQL: Successfully granted privileges for user "${ctx.mysql.username}"`, 'green');
-            return this._query('FLUSH PRIVILEGES;');
-        }).then(() => {
+
+            await this._query('FLUSH PRIVILEGES;');
             this.ui.logVerbose('MySQL: flushed privileges', 'green');
-        }).catch((error) => {
+        } catch (error) {
             this.ui.logVerbose('MySQL: Unable either to grant permissions or flush privileges', 'red');
             this.connection.end();
 
             error.message = `Granting database permissions errored with message: ${error.message}`;
-
-            return Promise.reject(error);
-        });
+            throw error;
+        }
     }
 
-    _query(queryString) {
-        this.ui.logVerbose(`MySQL: running query > ${queryString}`, 'gray');
-        return Promise.fromCallback(cb => this.connection.query(queryString, cb))
-            .catch((error) => {
-                if (error instanceof CliError) {
-                    return Promise.reject(error);
-                }
+    async createMySQL8Database(dbconfig) {
+        const {database} = dbconfig;
+        if (!database) {
+            return;
+        }
 
-                return Promise.reject(new CliError({
-                    message: error.message,
-                    context: queryString,
-                    err: error
-                }));
+        try {
+            await this._query(`CREATE DATABASE IF NOT EXISTS \`${database}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;`);
+            this.ui.logVerbose(`MySQL: created database ${database}`, 'green');
+        } catch (error) {
+            this.ui.logVerbose(`MySQL: failed to create database ${database}`, 'red');
+            this.connection.end();
+
+            error.message = `Creating database ${database} errored with message: ${error.message}`;
+            throw error;
+        }
+    }
+
+    async _query(queryString) {
+        this.ui.logVerbose(`MySQL: running query > ${queryString}`, 'gray');
+        try {
+            const result = await Promise.fromCallback(cb => this.connection.query(queryString, cb));
+            return result;
+        } catch (error) {
+            if (error instanceof CliError) {
+                throw error;
+            }
+
+            throw new CliError({
+                message: error.message,
+                context: queryString,
+                err: error
             });
+        }
     }
 }
 

--- a/extensions/mysql/test/extension-spec.js
+++ b/extensions/mysql/test/extension-spec.js
@@ -3,6 +3,7 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const configStub = require('../../../test/utils/config-stub');
+const semver = require('semver');
 
 const modulePath = '../index';
 const errors = require('../../../lib/errors');
@@ -58,36 +59,37 @@ describe('Unit: Mysql extension', function () {
         const context = {instance: {config}};
         inst.setupMySQL(context);
 
-        expect(config.get.calledOnce).to.be.true;
-        expect(config.get.calledWithExactly('database.connection')).to.be.true;
+        expect(config.get.calledOnceWithExactly('database.connection')).to.be.true;
         expect(listr.calledOnce).to.be.true;
         const [tasks, ctx] = listr.args[0];
-        expect(tasks).to.have.length(4);
+        expect(tasks).to.have.length(5);
         expect(ctx).to.be.false;
 
         const canConnect = sinon.stub(inst, 'canConnect');
         expect(tasks[0].title).to.equal('Connecting to database');
         tasks[0].task();
-        expect(canConnect.calledOnce).to.be.true;
-        expect(canConnect.calledWithExactly(context, dbConfig)).to.be.true;
+        expect(canConnect.calledOnceWithExactly(context, dbConfig)).to.be.true;
 
         const createUser = sinon.stub(inst, 'createUser');
         expect(tasks[1].title).to.equal('Creating new MySQL user');
         tasks[1].task();
-        expect(createUser.calledOnce).to.be.true;
-        expect(createUser.calledWithExactly(context, dbConfig)).to.be.true;
+        expect(createUser.calledOnceWithExactly(context, dbConfig)).to.be.true;
 
         const grantPermissions = sinon.stub(inst, 'grantPermissions');
         expect(tasks[2].title).to.equal('Granting new user permissions');
         tasks[2].task();
-        expect(grantPermissions.calledOnce).to.be.true;
-        expect(grantPermissions.calledWithExactly(context, dbConfig)).to.be.true;
+        expect(grantPermissions.calledOnceWithExactly(context, dbConfig)).to.be.true;
+
+        const setupDatabase = sinon.stub(inst, 'createMySQL8Database');
+        expect(tasks[3].title).to.equal('Setting up database (MySQL 8)');
+        tasks[3].task();
+        expect(setupDatabase.calledOnceWithExactly(dbConfig)).to.be.true;
 
         const end = sinon.stub();
         inst.connection = {end};
         context.mysql = {username: 'new', password: 'new'};
-        expect(tasks[3].title).to.equal('Saving new config');
-        tasks[3].task();
+        expect(tasks[4].title).to.equal('Saving new config');
+        tasks[4].task();
         expect(config.set.calledTwice).to.be.true;
         expect(config.set.calledWithExactly('database.connection.user', 'new')).to.be.true;
         expect(config.set.calledWithExactly('database.connection.password', 'new')).to.be.true;
@@ -96,19 +98,70 @@ describe('Unit: Mysql extension', function () {
     });
 
     describe('canConnect', function () {
-        it('creates connection and connects', function () {
+        it('creates connection and connects', async function () {
             const connectStub = sinon.stub().callsArg(0);
             const createConnectionStub = sinon.stub().returns({connect: connectStub});
             const MysqlExtension = proxyquire(modulePath, {
                 mysql: {createConnection: createConnectionStub}
             });
-            const instance = new MysqlExtension({}, {}, {}, '/some/dir');
+            const instance = new MysqlExtension({logVerbose: () => {}}, {}, {}, '/some/dir');
+            const getServerVersion = sinon.stub(instance, 'getServerVersion').resolves(null);
 
-            return instance.canConnect({}, {user: 'someuser', password: 'somepass', database: 'testing'}).then(() => {
+            const ctx = {};
+
+            await instance.canConnect(ctx, {user: 'someuser', password: 'somepass', database: 'testing'});
+            expect(createConnectionStub.calledOnce).to.be.true;
+            expect(createConnectionStub.calledWithExactly({user: 'someuser', password: 'somepass'})).to.be.true;
+            expect(connectStub.calledOnce).to.be.true;
+            expect(getServerVersion.calledOnce).to.be.true;
+            expect(ctx.mysql).to.not.exist;
+        });
+
+        it('sets version if version found', async function () {
+            const connectStub = sinon.stub().callsArg(0);
+            const createConnectionStub = sinon.stub().returns({connect: connectStub});
+            const MysqlExtension = proxyquire(modulePath, {
+                mysql: {createConnection: createConnectionStub}
+            });
+            const instance = new MysqlExtension({logVerbose: () => {}}, {}, {}, '/some/dir');
+
+            const version = semver.parse('8.0.0');
+            const getServerVersion = sinon.stub(instance, 'getServerVersion').resolves(version);
+
+            const ctx = {};
+
+            await instance.canConnect(ctx, {user: 'someuser', password: 'somepass', database: 'testing'});
+            expect(createConnectionStub.calledOnce).to.be.true;
+            expect(createConnectionStub.calledWithExactly({user: 'someuser', password: 'somepass'})).to.be.true;
+            expect(connectStub.calledOnce).to.be.true;
+            expect(getServerVersion.calledOnce).to.be.true;
+            expect(ctx.mysql.version).to.exist;
+            expect(semver.eq(ctx.mysql.version, version)).to.be.true;
+        });
+
+        it('throws error on MySQL 5.6', async function () {
+            const connectStub = sinon.stub().callsArg(0);
+            const createConnectionStub = sinon.stub().returns({connect: connectStub});
+            const MysqlExtension = proxyquire(modulePath, {
+                mysql: {createConnection: createConnectionStub}
+            });
+            const instance = new MysqlExtension({logVerbose: () => {}}, {}, {}, '/some/dir');
+
+            const version = semver.parse('5.6.47');
+            const getServerVersion = sinon.stub(instance, 'getServerVersion').resolves(version);
+
+            try {
+                await instance.canConnect({}, {user: 'someuser', password: 'somepass', database: 'testing'});
+            } catch (error) {
+                expect(error).to.be.an.instanceof(errors.SystemError);
                 expect(createConnectionStub.calledOnce).to.be.true;
                 expect(createConnectionStub.calledWithExactly({user: 'someuser', password: 'somepass'})).to.be.true;
                 expect(connectStub.calledOnce).to.be.true;
-            });
+                expect(getServerVersion.calledOnce).to.be.true;
+                return;
+            }
+
+            throw new Error('canConnect should have thrown');
         });
 
         it('throws configerror if error is ECONNREFUSED', function () {
@@ -181,75 +234,77 @@ describe('Unit: Mysql extension', function () {
     describe('createUser', function () {
         const MysqlExtension = require(modulePath);
 
-        it('runs correct queries and logs things', function () {
+        it('runs correct queries and logs things', async function () {
             const logStub = sinon.stub();
             const instance = new MysqlExtension({logVerbose: logStub}, {}, {}, '/some/dir');
             const queryStub = sinon.stub(instance, '_query').resolves();
             queryStub.onSecondCall().resolves([{password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'}]);
             const ctx = {};
 
-            return instance.createUser(ctx, {host: 'localhost'}).then(() => {
-                expect(queryStub.calledThrice).to.be.true;
-                expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
-                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
-                expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
-                expect(logStub.calledThrice).to.be.true;
-                expect(logStub.args[0][0]).to.match(/disabled old_password/);
-                expect(logStub.args[1][0]).to.match(/created password hash/);
-                expect(logStub.args[2][0]).to.match(/successfully created new user/);
-                expect(ctx.mysql).to.exist;
-                expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
-                expect(ctx.mysql.password).to.match(/^[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*$/);
-            });
+            await instance.createUser(ctx, {host: 'localhost'});
+            expect(queryStub.calledThrice).to.be.true;
+            expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
+            expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
+            expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
+            expect(logStub.calledThrice).to.be.true;
+            expect(logStub.args[0][0]).to.match(/disabled old_password/);
+            expect(logStub.args[1][0]).to.match(/created password hash/);
+            expect(logStub.args[2][0]).to.match(/successfully created new user/);
+            expect(ctx.mysql).to.exist;
+            expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
+            expect(ctx.mysql.password).to.match(/^[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*$/);
         });
 
-        it('uses % for user host if db host is not localhost or 127.0.0.1', function () {
+        it('uses % for user host if db host is not localhost or 127.0.0.1', async function () {
             const logStub = sinon.stub();
             const instance = new MysqlExtension({logVerbose: logStub}, {}, {}, '/some/dir');
             const queryStub = sinon.stub(instance, '_query').resolves();
             queryStub.onSecondCall().resolves([{password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'}]);
             const ctx = {};
 
-            return instance.createUser(ctx, {host: '117.241.162.107'}).then(() => {
-                expect(queryStub.calledThrice).to.be.true;
-                expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
-                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
-                expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'%' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
-                expect(logStub.calledThrice).to.be.true;
-                expect(logStub.args[0][0]).to.match(/disabled old_password/);
-                expect(logStub.args[1][0]).to.match(/created password hash/);
-                expect(logStub.args[2][0]).to.match(/successfully created new user/);
-                expect(ctx.mysql).to.exist;
-                expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
-                expect(ctx.mysql.password).to.match(/^[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*$/);
-            });
+            await instance.createUser(ctx, {host: '117.241.162.107'});
+            expect(queryStub.calledThrice).to.be.true;
+            expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
+            expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
+            expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'%' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
+            expect(logStub.calledThrice).to.be.true;
+            expect(logStub.args[0][0]).to.match(/disabled old_password/);
+            expect(logStub.args[1][0]).to.match(/created password hash/);
+            expect(logStub.args[2][0]).to.match(/successfully created new user/);
+            expect(ctx.mysql).to.exist;
+            expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
+            expect(ctx.mysql.password).to.match(/^[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*$/);
         });
 
-        it('retries creating user if username already exists', function () {
+        it('retries creating user if username already exists', async function () {
             const logStub = sinon.stub();
             const instance = new MysqlExtension({logVerbose: logStub}, {}, {}, '/some/dir');
             const queryStub = sinon.stub(instance, '_query').resolves();
             queryStub.onSecondCall().resolves([{password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'}]);
+            queryStub.onCall(4).resolves([{password: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'}]);
             const err = new Error();
             err.errno = 1396;
             queryStub.onThirdCall().rejects(new errors.CliError({message: 'User exists already', err: err}));
             const ctx = {};
 
-            return instance.createUser(ctx, {host: 'localhost'}).then(() => {
-                expect(queryStub.callCount).to.equal(4);
-                expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
-                expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
-                expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
-                expect(queryStub.args[3][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
-                expect(logStub.callCount).to.equal(4);
-                expect(logStub.args[0][0]).to.match(/disabled old_password/);
-                expect(logStub.args[1][0]).to.match(/created password hash/);
-                expect(logStub.args[2][0]).to.match(/user exists, re-trying user creation/);
-                expect(logStub.args[3][0]).to.match(/successfully created new user/);
-                expect(ctx.mysql).to.exist;
-                expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
-                expect(ctx.mysql.password).to.match(/^[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*$/);
-            });
+            await instance.createUser(ctx, {host: 'localhost'});
+            expect(queryStub.callCount).to.equal(6);
+            expect(queryStub.args[0][0]).to.equal('SET old_passwords = 0;');
+            expect(queryStub.args[1][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
+            expect(queryStub.args[2][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
+            expect(queryStub.args[3][0]).to.equal('SET old_passwords = 0;');
+            expect(queryStub.args[4][0]).to.match(/^SELECT PASSWORD\('[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*'\) AS password;$/);
+            expect(queryStub.args[5][0]).to.match(/^CREATE USER 'ghost-[0-9]{1,4}'@'localhost' IDENTIFIED WITH mysql_native_password AS '\*[0-9A-F]*';$/);
+            expect(logStub.callCount).to.equal(6);
+            expect(logStub.args[0][0]).to.match(/disabled old_password/);
+            expect(logStub.args[1][0]).to.match(/created password hash/);
+            expect(logStub.args[2][0]).to.match(/user exists, re-trying user creation/);
+            expect(logStub.args[3][0]).to.match(/disabled old_password/);
+            expect(logStub.args[4][0]).to.match(/created password hash/);
+            expect(logStub.args[5][0]).to.match(/successfully created new user/);
+            expect(ctx.mysql).to.exist;
+            expect(ctx.mysql.username).to.match(/^ghost-[0-9]{1,4}$/);
+            expect(ctx.mysql.password).to.match(/^[a-zA-Z0-9!@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]*$/);
         });
 
         it('rejects if error occurs during user creation', function () {
@@ -391,7 +446,7 @@ describe('Unit: Mysql extension', function () {
 
         it('rejects with correct CliError', function () {
             const MysqlExtension = require(modulePath);
-            const queryStub = sinon.stub().throws(new Error('failed executing'));
+            const queryStub = sinon.stub().callsFake((_, cb) => cb(new Error('failed executing')));
             const logStub = sinon.stub();
 
             const instance = new MysqlExtension({logVerbose: logStub}, {}, {}, '/some/dir');


### PR DESCRIPTION
refs #1265
- refactor mysql extension to use async/await
- add separate setup steps for MySQL 8

### TODOS:
- [x] Test w/MySQL 5.6 and 5.7, to ensure old versions aren't broken
- [x] Update unit tests