### PR TITLE
feat(extensions): add `user skipped` task hook

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -141,6 +141,10 @@ class SetupCommand extends Command {
 
                 const confirmed = await this.ui.confirm(`Do you wish to set up ${name}?`, true);
                 if (!confirmed) {
+                    if (step.onUserSkip) {
+                        await step.onUserSkip(ctx);
+                    }
+
                     return task.skip();
                 }
 

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -1,6 +1,13 @@
+// @ts-check
 const fs = require('fs-extra');
 const path = require('path');
 const mapValues = require('lodash/mapValues');
+
+/**
+ * @typedef {import('./instance')} Instance
+ * @typedef {import('./ui')} UI
+ * @typedef {import('./system')} System
+ */
 
 /**
  * Handles various extension-related behavior
@@ -50,7 +57,7 @@ class Extension {
      * @param {string} descriptor Description of the template file (used in the prompt)
      * @param {string} file Filename
      * @param {string} dir Directory to link the config file into
-     * @return {bool} True if the config file was created successfully, otherwise false
+     * @return {Promise<boolean>} True if the config file was created successfully, otherwise false
      * @method template
      * @public
      */
@@ -102,7 +109,7 @@ class Extension {
      * @param {string} descriptor description of file
      * @param {string} file Filename
      * @param {string} dir Directory to link
-     * @return {bool} True if the file was successfully created & linked
+     * @return {Promise<boolean>} True if the file was successfully created & linked
      */
     async _generateTemplate(instance, contents, descriptor, file, dir) {
         const tmplDir = path.join(instance.dir, 'system', 'files');

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -177,7 +177,7 @@ class UI {
      * Shorthand helper to ask a simple yes/no question
      *
      * @param {string} question Question to ask
-     * @param {bool} defaultAnswer Default answer (true or false)
+     * @param {boolean} defaultAnswer Default answer (true or false)
      *
      * @method confirm
      * @public
@@ -200,7 +200,7 @@ class UI {
      * Runs a set of Listr tasks. Uses Listr under the hood
      *
      * @param {Array} tasks Listr Task objects
-     * @param {Object|bool} context Context to run the tasks with
+     * @param {Object|boolean} context Context to run the tasks with
      * @param {Object} options Additional Listr options
      * @return Listr|Promise<void> Listr object if context === false, otherwise
      *                             a promise that resolves once the tasks have
@@ -232,8 +232,7 @@ class UI {
      * @method sudo
      * @public
      */
-    sudo(command, options) {
-        options = options || {};
+    sudo(command, options = {}) {
         this.log(`+ sudo ${command}`, 'gray');
 
         const prompt = '#node-sudo-passwd#';
@@ -290,8 +289,8 @@ class UI {
      * ensures no spinner covers up the message
      *
      * @param {string} message Message to log
-     * @param {string} color Color to log message in
-     * @param {bool} stderr If true, output to stderr rather than stdout
+     * @param {string} [color] Color to log message in
+     * @param {boolean} [stderr] If true, output to stderr rather than stdout
      *
      * @method log
      * @public
@@ -325,7 +324,7 @@ class UI {
      *
      * @param {string} message
      * @param {string} color
-     * @param {bool} stderr
+     * @param {boolean} stderr
      */
     logVerbose(message, color, stderr) {
         if (this.verbose) {
@@ -342,7 +341,6 @@ class UI {
      * @param {string} hint Hint line to output e.g. a command to fix things
      * @param {string} msgColor Main color of the message
      * @param {string} hintType One of link or cmd
-     * @param {boolean} solo Is this message output as the last thing?
      */
     _logHelp(message, hint, msgColor, hintType, last) {
         let hintColor = hintType === 'link' ? 'cyan' : 'yellow';
@@ -378,7 +376,7 @@ class UI {
      * error to the specified out stream.
      *
      * @param {Error|Object} error Error to handle
-     * @param {System} System object
+     * @param {System} system object
      *
      * @method error
      * @public


### PR DESCRIPTION
refs #308, #1115

I'm not sure if this is the best way to do this, but it's the most pluggable thing that came to mind. I haven't fully tested this or ensured that changing the process manager the way I did will actually work 😄 It's best to look at 28a85b8 individually since it's the only logical change.

@acburdine can you please take a cursory look at this?