### PR TITLE
feat(extension): rewrite template method

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -1,5 +1,6 @@
 // @ts-check
 const fs = require('fs-extra');
+const os = require('os');
 const path = require('path');
 const mapValues = require('lodash/mapValues');
 
@@ -56,78 +57,24 @@ class Extension {
      * @param {string} contents Contents of the template file to create
      * @param {string} descriptor Description of the template file (used in the prompt)
      * @param {string} file Filename
-     * @param {string} dir Directory to link the config file into
-     * @return {Promise<boolean>} True if the config file was created successfully, otherwise false
+     * @param {string} dir Directory to move the config file into
+     * @return {Promise<void>}
      * @method template
      * @public
      */
     async template(instance, contents, descriptor, file, dir) {
-        // If `--no-prompt` is passed to the CLI or the `--verbose` flag was not passed, don't show anything
-        if (!this.ui.allowPrompt || !this.ui.verbose) {
-            return this._generateTemplate(instance, contents, descriptor, file, dir);
-        } else {
-            const {choice} = await this.ui.prompt({
-                type: 'expand',
-                name: 'choice',
-                message: `Would you like to view or edit the ${descriptor} file?`,
-                default: 0,
-                choices: [
-                    {key: 'n', name: 'No, continue', value: 'continue'},
-                    {key: 'v', name: 'View the file', value: 'view'},
-                    {key: 'e', name: 'Edit the file before generation', value: 'edit'}
-                ]
-            });
-
-            if (choice === 'continue') {
-                return this._generateTemplate(instance, contents, descriptor, file, dir);
-            }
-
-            if (choice === 'view') {
-                this.ui.log(contents);
-                return this.template(instance, contents, descriptor, file, dir);
-            }
-
-            /* istanbul ignore else */
-            if (choice === 'edit') {
-                const answer = await this.ui.prompt({
-                    type: 'editor',
-                    name: 'contents',
-                    message: 'Edit the generated file',
-                    default: contents
-                });
-
-                return this._generateTemplate(instance, answer.contents, descriptor, file, dir);
-            }
-        }
-    }
-
-    /**
-     * Actually handles saving the file. Used by the template method
-     *
-     * @param {Instance} instance Ghost instance
-     * @param {string} contents Contents of file
-     * @param {string} descriptor description of file
-     * @param {string} file Filename
-     * @param {string} dir Directory to link
-     * @return {Promise<boolean>} True if the file was successfully created & linked
-     */
-    async _generateTemplate(instance, contents, descriptor, file, dir) {
-        const tmplDir = path.join(instance.dir, 'system', 'files');
-        const tmplFile = path.join(tmplDir, file);
-
-        // Dir is optional, if a file just needs to be created locally
-        // so we log here
-        this.ui.success(`Creating ${descriptor} file at ${tmplFile}`);
-
-        await fs.ensureDir(tmplDir);
-        await fs.writeFile(tmplFile, contents);
-
-        if (dir) {
-            const outputLocation = path.join(dir, file);
-            await this.ui.sudo(`ln -sf ${tmplFile} ${outputLocation}`);
+        if (this.ui.verbose && (await this.ui.confirm(`Would you like to view the ${descriptor} file?`, false))) {
+            this.ui.log(contents);
         }
 
-        return true;
+        const tmpDir = path.join(os.tmpdir(), instance.name);
+        await fs.ensureDir(tmpDir);
+
+        const tmpFile = path.join(tmpDir, file);
+        await fs.writeFile(tmpFile, contents || '');
+
+        const outputLocation = path.join(dir, file);
+        await this.ui.sudo(`mv ${tmpFile} ${outputLocation}`);
     }
 
     /**


### PR DESCRIPTION
The idea behind this PR is to rethink how we're handling the generation of configuration files for things like nginx + systemd. Currently, the configuration files are stored inside the Ghost site's installation directory and symlinked into the proper directory on the system, but this has come with a few drawbacks, and does not in hindsight provide that much of a benefit.

If a person wants to modify their configuration files after Ghost-CLI generates them, then they can visit the directories on the system that those files normally reside in (i.e. `/etc/nginx` for nginx) and edit them there.

As a side benefit, this removes the one significant complication that would prevent us from converting our usage of `inquirer` to `enquirer`.