### PR TITLE
feat(install): added `canary` as an install target

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -12,7 +12,13 @@ class InstallCommand extends Command {
         return yargs;
     }
 
-    run(argv) {
+    async run(argv) {
+        const fs = require('fs-extra');
+        const os = require('os');
+        const decompress = require('decompress');
+        const download = require('download');
+        const got = require('got');
+
         const errors = require('../errors');
         const yarnInstall = require('../tasks/yarn-install');
         const dirIsEmpty = require('../utils/dir-is-empty');
@@ -35,6 +41,36 @@ class InstallCommand extends Command {
             local = true;
             version = (version === 'local') ? null : version;
             this.system.setEnvironment(true, true);
+        }
+
+        if (version === 'canary') {
+            const githubAuthToken = process.env.GST_TOKEN;
+
+            if (!githubAuthToken) {
+                throw new errors.SystemError('The GST_TOKEN environment variable must be populated to install canary versions');
+            }
+
+            const response = await got('https://api.github.com/repos/tryghost/ghost/actions/artifacts', {json: true});
+
+            const latestArtifact = response.body.artifacts
+                .filter(artifact => artifact.name === 'ghost-canary')
+                .sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at))[0];
+
+            const zipBuffer = await download(latestArtifact.archive_download_url, {
+                headers: {
+                    Accept: 'application/vnd.github.v3+json',
+                    Authorization: `token ${githubAuthToken}`
+                }
+            });
+
+            const tmpDir = path.join(os.tmpdir(), `ghost-canary-${latestArtifact.id}`);
+            await fs.ensureDir(tmpDir);
+
+            const files = await decompress(zipBuffer, tmpDir, {
+                filter: file => path.extname(file.path) === '.zip'
+            });
+
+            argv.zip = path.join(tmpDir, files[0].path);
         }
 
         return this.runCommand(DoctorCommand, Object.assign({
@@ -97,7 +133,7 @@ class InstallCommand extends Command {
             }
         }
 
-        if (version && zip) {
+        if (version && version !== 'canary' && zip) {
             ctx.ui.log('Warning: you specified both a specific version and a zip file. The version in the zip file will be used.', 'yellow');
         }
 


### PR DESCRIPTION
- We want to allow Ghost-CLI to download canary builds of the latest commits in Ghost & Ghost-Admin to allow people to test new changes
- This commit allows us to do things like `ghost install canary --local`, which will download the latest CI artifact zip from GitHub, and install it like usual.
- Due to a limitation in the GitHub API, the download link requires a GitHub auth token. This has been implemented as reading it from the GST_TOKEN environment variable, but hopefully we have a workaround for that in the future.