### PR TITLE
feat(update): display release notes when updating Ghost

### DIFF
--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -21,6 +21,7 @@ class UpdateCommand extends Command {
         const MigrateCommand = require('./migrate');
         const migrator = require('../tasks/migrator');
         const majorUpdate = require('../tasks/major-update');
+        const releaseNotes = require('../tasks/release-notes');
 
         const instance = this.system.getInstance();
 
@@ -70,6 +71,9 @@ class UpdateCommand extends Command {
 
         // TODO: add meaningful update checks after this task
         const tasks = [{
+            title: 'Fetching release notes',
+            task: releaseNotes
+        }, {
             title: 'Downloading and updating Ghost',
             skip: ({rollback}) => rollback,
             task: this.downloadAndUpdate

--- a/lib/tasks/release-notes.js
+++ b/lib/tasks/release-notes.js
@@ -1,0 +1,21 @@
+module.exports = async (ctx, task) => {
+    const got = require('got');
+    let response;
+
+    try {
+        response = await got('https://api.github.com/repos/TryGhost/Ghost/releases', {json: true});
+    } catch (err) {
+        task.title = 'Unable to fetch release notes';
+        return;
+    }
+
+    const relevantNotes = response.body.filter(note => note.tag_name === ctx.version)[0];
+
+    if (!relevantNotes) {
+        task.title = 'Release notes were not found';
+        return;
+    }
+
+    task.title = 'Fetched release notes';
+    ctx.ui.log(`\n${relevantNotes.body}\n`, 'green');
+};

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -191,11 +191,13 @@ describe('Unit: Commands > Update', function () {
                 rollback: sinon.stub().resolves()
             };
 
+            const releaseNotesStub = sinon.stub().resolves();
             const majorUpdateStub = sinon.stub();
 
             const UpdateCommand = proxyquire(modulePath, {
                 '../tasks/migrator': migratorStub,
-                '../tasks/major-update': majorUpdateStub
+                '../tasks/major-update': majorUpdateStub,
+                '../tasks/release-notes': releaseNotesStub
             });
 
             const ghostConfig = configStub();
@@ -262,11 +264,13 @@ describe('Unit: Commands > Update', function () {
                 rollback: sinon.stub().resolves()
             };
 
+            const releaseNotesStub = sinon.stub().resolves();
             const majorUpdateStub = sinon.stub();
 
             const UpdateCommand = proxyquire(modulePath, {
                 '../tasks/migrator': migratorStub,
-                '../tasks/major-update': majorUpdateStub
+                '../tasks/major-update': majorUpdateStub,
+                '../tasks/release-notes': releaseNotesStub
             });
 
             const ghostConfig = configStub();
@@ -435,11 +439,13 @@ describe('Unit: Commands > Update', function () {
                 rollback: sinon.stub().resolves()
             };
 
+            const releaseNotesStub = sinon.stub().resolves();
             const majorUpdateStub = sinon.stub();
 
             const UpdateCommand = proxyquire(modulePath, {
                 '../tasks/migrator': migratorStub,
-                '../tasks/major-update': majorUpdateStub
+                '../tasks/major-update': majorUpdateStub,
+                '../tasks/release-notes': releaseNotesStub
             });
 
             const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
@@ -490,11 +496,13 @@ describe('Unit: Commands > Update', function () {
                 migrate: sinon.stub().resolves(),
                 rollback: sinon.stub().resolves()
             };
+            const releaseNotesStub = sinon.stub().resolves();
             const majorUpdateStub = sinon.stub();
 
             const UpdateCommand = proxyquire(modulePath, {
                 '../tasks/migrator': migratorStub,
-                '../tasks/major-update': majorUpdateStub
+                '../tasks/major-update': majorUpdateStub,
+                '../tasks/release-notes': releaseNotesStub
             });
 
             const config = configStub();
@@ -561,8 +569,10 @@ describe('Unit: Commands > Update', function () {
                 migrate: sinon.stub().resolves(),
                 rollback: sinon.stub().resolves()
             };
+            const releaseNotesStub = sinon.stub().resolves();
             const UpdateCommand = proxyquire(modulePath, {
-                '../tasks/migrator': migratorStub
+                '../tasks/migrator': migratorStub,
+                '../tasks/release-notes': releaseNotesStub
             });
             const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
             const system = {getInstance: sinon.stub()};


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost-CLI/issues/1338

- we want to be able to display the release notes so we can inform users
  about new features