### PR TITLE
feat(version): add handling for deprecated Ghost versions

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -80,7 +80,7 @@ class InstallCommand extends Command {
         const semver = require('semver');
         const {SystemError} = require('../errors');
         const {resolveVersion, versionFromZip} = require('../utils/version');
-        let {version, zip, v1, fromExport} = ctx.argv;
+        let {version, zip, v1, fromExport, force} = ctx.argv;
         let exportVersion = null;
 
         if (fromExport) {
@@ -105,7 +105,7 @@ class InstallCommand extends Command {
         if (zip) {
             resolvedVersion = await versionFromZip(zip);
         } else {
-            resolvedVersion = await resolveVersion(version, null, {v1});
+            resolvedVersion = await resolveVersion(version, null, {v1, force});
         }
 
         if (exportVersion && semver.lt(resolvedVersion, exportVersion)) {
@@ -174,6 +174,10 @@ InstallCommand.options = {
         description: 'Check for empty directory before installing',
         type: 'boolean',
         default: true
+    },
+    force: {
+        description: 'Force installing a particular version',
+        type: 'boolean'
     }
 };
 InstallCommand.runPreChecks = true;

--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -20,28 +20,39 @@ const utils = {
             .filter(v => semver.satisfies(v, MIN_RELEASE))
             .sort(semver.rcompare);
 
+        const deprecations = Object.keys(result.versions)
+            .reduce((obj, v) => {
+                if (result.versions[v].deprecated) {
+                    obj[v] = result.versions[v].deprecated;
+                }
+
+                return obj;
+            }, {});
+
         if (!versions.length) {
             return {
                 latest: null,
                 latestMajor: {},
-                all: []
+                all: [],
+                deprecations: {}
             };
         }
 
-        const latestMajor = versions.reduce((result, v) => {
+        const latestMajor = versions.reduce((majors, v) => {
             const key = `v${semver.major(v)}`;
 
-            if (!result[key]) {
-                return {...result, [key]: v};
+            if (!majors[key] && !deprecations[v]) {
+                majors[key] = v;
             }
 
-            return result;
+            return majors;
         }, {});
 
         return {
-            latest: versions[0],
+            latest: versions.find(v => !deprecations[v]),
             latestMajor,
-            all: versions
+            all: versions,
+            deprecations
         };
     },
 
@@ -131,6 +142,15 @@ const utils = {
         if (customVersion) {
             const normalizedVersion = versions.latestMajor[customVersion.replace(/^v?/, 'v')] || customVersion;
             version = utils.checkCustomVersion(normalizedVersion, versions.all, activeVersion, opts);
+
+            if (versions.deprecations[version] && !opts.force) {
+                const deprecation = versions.deprecations[version];
+
+                throw new CliError({
+                    message: `You are trying to install Ghost v${version}, which has been deprecated with the following notice: "${deprecation}"`,
+                    help: `Either pick a different version to install, or re-run with --force to install anyways.`
+                });
+            }
         }
         const latest = version || latestVersion;
 

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -275,11 +275,11 @@ describe('Unit: Commands > Install', function () {
             });
 
             const testInstance = new InstallCommand({}, {});
-            const context = {argv: {version: '1.0.0', v1: false}};
+            const context = {argv: {version: '1.0.0', v1: false, force: false}};
 
             await testInstance.version(context);
             expect(resolveVersion.calledOnce).to.be.true;
-            expect(resolveVersion.calledWithExactly('1.0.0', null, {v1: false})).to.be.true;
+            expect(resolveVersion.calledWithExactly('1.0.0', null, {v1: false, force: false})).to.be.true;
             expect(context.version).to.equal('1.5.0');
             expect(context.installPath).to.equal(path.join(process.cwd(), 'versions/1.5.0'));
         });
@@ -337,7 +337,7 @@ describe('Unit: Commands > Install', function () {
             const context = {argv: {version: '2.0.0', fromExport: 'test-export.json'}, ui: {log}};
 
             await testInstance.version(context);
-            expect(resolveVersion.calledOnceWithExactly('v1', null, {v1: undefined})).to.be.true;
+            expect(resolveVersion.calledOnceWithExactly('v1', null, {v1: undefined, force: undefined})).to.be.true;
             expect(parseExport.calledOnceWithExactly('test-export.json')).to.be.true;
             expect(context.version).to.equal('1.5.0');
             expect(context.installPath).to.equal(path.join(process.cwd(), 'versions/1.5.0'));
@@ -357,7 +357,7 @@ describe('Unit: Commands > Install', function () {
             const context = {argv: {fromExport: 'test-export.json'}, ui: {log}};
 
             await testInstance.version(context);
-            expect(resolveVersion.calledOnceWithExactly('2.0.0', null, {v1: undefined})).to.be.true;
+            expect(resolveVersion.calledOnceWithExactly('2.0.0', null, {v1: undefined, force: undefined})).to.be.true;
             expect(parseExport.calledOnceWithExactly('test-export.json')).to.be.true;
             expect(context.version).to.equal('2.0.0');
             expect(context.installPath).to.equal(path.join(process.cwd(), 'versions/2.0.0'));
@@ -381,7 +381,7 @@ describe('Unit: Commands > Install', function () {
             } catch (error) {
                 expect(error).to.be.an.instanceof(errors.SystemError);
                 expect(error.message).to.include('v3.0.0 into v2.0.0');
-                expect(resolveVersion.calledOnceWithExactly('v2', null, {v1: undefined})).to.be.true;
+                expect(resolveVersion.calledOnceWithExactly('v2', null, {v1: undefined, force: undefined})).to.be.true;
                 expect(parseExport.calledOnceWithExactly('test-export.json')).to.be.true;
                 expect(log.called).to.be.false;
                 return;


### PR DESCRIPTION
this will allow Ghost maintainers to "deprecate" a Ghost version if it contains known severe bugs. A deprecated version will not be installable unless someone specifies the version exactly, and provides the `--force` flag.