### PR TITLE
chore(log,stop): enable directory traversal

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -12,7 +12,7 @@ class LogCommand extends Command {
         const PrettyStream = require('../ui/pretty-stream');
 
         if (!argv.name) {
-            findValidInstall('log');
+            findValidInstall('log', true);
         }
 
         const instance = this.system.getInstance(argv.name);

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -30,7 +30,7 @@ class StopCommand extends Command {
         }
 
         if (!argv.name) {
-            findValidInstall('stop');
+            findValidInstall('stop', true);
         }
 
         const instance = this.system.getInstance(argv.name);


### PR DESCRIPTION
In #820 we added support for traversing the directory tree to find a Ghost instance. It turns out both `stop` and `log` haven't supported this, so this PR fixes that.

Note that `doctor` also uses the `findValidInstall` util, but I'd like to get a second set of eyes before enabling directory traversal in it.