### PR TITLE
feat(config): remind user to restart ghost after making changes

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -37,6 +37,19 @@ class ConfigCommand extends Command {
             // setter
             this.instance.config.set(key, value).save();
             this.ui.log(`Successfully set '${key}' to '${value}'`, 'green');
+
+            // If the instance is running, we want to remind the user to restart
+            // it so the new config can take effect. The isRunning check is only
+            // a nicety, so if it fails, swallow the error for better UX.
+            try {
+                if (await this.instance.isRunning()) {
+                    const chalk = require('chalk');
+                    this.ui.log(
+                        `Ghost is running. Don't forget to run ${chalk.cyan('ghost restart')} to reload the config!`
+                    );
+                }
+            } catch (_) {} // eslint-disable-line no-empty
+
             return;
         }
 


### PR DESCRIPTION
I've seen a lot of cases in the forum where users make config changes but don't restart Ghost. This PR reminds the user to restart Ghost (if it's running) after making a configuration change.

Will need a copy review 😄 