### PR TITLE
feat(channel): add ability to specify release channel for local installs

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -12,7 +12,7 @@ class InstallCommand extends Command {
         return yargs;
     }
 
-    run(argv) {
+    async run(argv) {
         const errors = require('../errors');
         const yarnInstall = require('../tasks/yarn-install');
         const dirIsEmpty = require('../utils/dir-is-empty');
@@ -24,7 +24,7 @@ class InstallCommand extends Command {
 
         // Check if the directory is empty
         if (!dirIsEmpty(process.cwd()) && argv['check-empty']) {
-            return Promise.reject(new errors.SystemError('Current directory is not empty, Ghost cannot be installed here.'));
+            throw new errors.SystemError('Current directory is not empty, Ghost cannot be installed here.');
         }
 
         let local = false;
@@ -37,11 +37,19 @@ class InstallCommand extends Command {
             this.system.setEnvironment(true, true);
         }
 
-        return this.runCommand(DoctorCommand, Object.assign({
+        if (argv.channel && argv.channel !== 'stable' && !local) {
+            throw new errors.CliError(`Specifying a channel of '${argv.channel}' is only supported for local installs at this time.`);
+        }
+
+        await this.runCommand(DoctorCommand, {
             categories: ['install'],
             skipInstanceCheck: true,
-            quiet: true
-        }, argv, {local})).then(() => this.ui.listr([{
+            quiet: true,
+            ...argv,
+            local
+        });
+
+        await this.ui.listr([{
             title: 'Checking for latest Ghost version',
             task: this.version
         }, {
@@ -65,22 +73,21 @@ class InstallCommand extends Command {
         }], {
             argv: {...argv, version},
             cliVersion: this.system.cliVersion
-        })).then(() => {
-            if (!argv.setup) {
-                return Promise.resolve();
-            }
-
-            argv.local = local;
-
-            return this.runCommand(SetupCommand, argv);
         });
+
+        if (!argv.setup) {
+            return;
+        }
+
+        argv.local = local;
+        return this.runCommand(SetupCommand, argv);
     }
 
     async version(ctx) {
         const semver = require('semver');
         const {SystemError} = require('../errors');
         const {resolveVersion, versionFromZip} = require('../utils/version');
-        let {version, zip, v1, fromExport, force} = ctx.argv;
+        let {version, zip, v1, fromExport, force, channel} = ctx.argv;
         let exportVersion = null;
 
         if (fromExport) {
@@ -105,7 +112,7 @@ class InstallCommand extends Command {
         if (zip) {
             resolvedVersion = await versionFromZip(zip);
         } else {
-            resolvedVersion = await resolveVersion(version, null, {v1, force});
+            resolvedVersion = await resolveVersion(version, null, {v1, force, channel});
         }
 
         if (exportVersion && semver.lt(resolvedVersion, exportVersion)) {
@@ -131,6 +138,7 @@ class InstallCommand extends Command {
 
         instance.version = ctx.version;
         instance.cliVersion = this.system.cliVersion;
+        instance.channel = ctx.argv.channel || 'stable';
     }
 }
 
@@ -178,6 +186,12 @@ InstallCommand.options = {
     force: {
         description: 'Force installing a particular version',
         type: 'boolean'
+    },
+    channel: {
+        description: 'Specifies a release channel to use when selecting Ghost versions',
+        type: 'string',
+        choices: ['stable', 'next'],
+        default: 'stable'
     }
 };
 InstallCommand.runPreChecks = true;

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -49,7 +49,7 @@ class UpdateCommand extends Command {
 
         if (argv.rollback) {
             if (!instance.previousVersion) {
-                return Promise.reject(new Error('No previous version found'));
+                throw new Error('No previous version found');
             }
 
             context.rollback = true;
@@ -165,7 +165,7 @@ class UpdateCommand extends Command {
 
     async version(context) {
         const {resolveVersion, versionFromZip} = require('../utils/version');
-        const {rollback, zip, v1, version, force, activeVersion} = context;
+        const {rollback, zip, v1, version, force, activeVersion, instance} = context;
 
         if (rollback) {
             return Promise.resolve(true);
@@ -175,7 +175,11 @@ class UpdateCommand extends Command {
         if (zip) {
             resolvedVersion = await versionFromZip(zip, activeVersion, {force});
         } else {
-            resolvedVersion = await resolveVersion(version, activeVersion, {v1, force});
+            resolvedVersion = await resolveVersion(version, activeVersion, {
+                v1,
+                force,
+                channel: instance.channel
+            });
         }
 
         if (resolvedVersion === null) {

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -118,6 +118,20 @@ class Instance {
     }
 
     /**
+     * Release Channel
+     *
+     * @property channel
+     * @type string
+     * @public
+     */
+    get channel() {
+        return this._cliConfig.get('channel', 'stable');
+    }
+    set channel(value) {
+        this._cliConfig.set('channel', value).save();
+    }
+
+    /**
      * Returns whether or not the instance has been setup
      *
      * @property isSetup

--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -11,13 +11,13 @@ const getProxyAgent = require('./get-proxy-agent');
 const MIN_RELEASE = '>= 1.0.0';
 
 const utils = {
-    async loadVersions() {
+    async loadVersions(includePrerelease = false) {
         const result = await packageJson('ghost', {
             allVersions: true,
             agent: getProxyAgent()
         });
         const versions = Object.keys(result.versions)
-            .filter(v => semver.satisfies(v, MIN_RELEASE))
+            .filter(v => semver.satisfies(v, MIN_RELEASE, {includePrerelease}))
             .sort(semver.rcompare);
 
         const deprecations = Object.keys(result.versions)
@@ -127,7 +127,7 @@ const utils = {
     },
 
     async resolveVersion(customVersion = null, activeVersion = null, opts = {}) {
-        const versions = await utils.loadVersions();
+        const versions = await utils.loadVersions(opts.channel === 'next');
 
         if (!versions.all.length) {
             return null;

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -275,11 +275,27 @@ describe('Unit: Commands > Install', function () {
             });
 
             const testInstance = new InstallCommand({}, {});
-            const context = {argv: {version: '1.0.0', v1: false, force: false}};
+            const context = {argv: {version: '1.0.0', v1: false, force: false, channel: 'stable'}};
 
             await testInstance.version(context);
             expect(resolveVersion.calledOnce).to.be.true;
-            expect(resolveVersion.calledWithExactly('1.0.0', null, {v1: false, force: false})).to.be.true;
+            expect(resolveVersion.calledWithExactly('1.0.0', null, {v1: false, force: false, channel: 'stable'})).to.be.true;
+            expect(context.version).to.equal('1.5.0');
+            expect(context.installPath).to.equal(path.join(process.cwd(), 'versions/1.5.0'));
+        });
+
+        it('calls resolveVersion, sets version and install path (prereleases)', async function () {
+            const resolveVersion = sinon.stub().resolves('1.5.0');
+            const InstallCommand = proxyquire(modulePath, {
+                '../utils/version': {resolveVersion}
+            });
+
+            const testInstance = new InstallCommand({}, {});
+            const context = {argv: {version: '1.0.0', v1: false, force: false, channel: 'next'}};
+
+            await testInstance.version(context);
+            expect(resolveVersion.calledOnce).to.be.true;
+            expect(resolveVersion.calledWithExactly('1.0.0', null, {v1: false, force: false, channel: 'next'})).to.be.true;
             expect(context.version).to.equal('1.5.0');
             expect(context.installPath).to.equal(path.join(process.cwd(), 'versions/1.5.0'));
         });
@@ -337,7 +353,7 @@ describe('Unit: Commands > Install', function () {
             const context = {argv: {version: '2.0.0', fromExport: 'test-export.json'}, ui: {log}};
 
             await testInstance.version(context);
-            expect(resolveVersion.calledOnceWithExactly('v1', null, {v1: undefined, force: undefined})).to.be.true;
+            expect(resolveVersion.calledOnceWithExactly('v1', null, {v1: undefined, force: undefined, channel: undefined})).to.be.true;
             expect(parseExport.calledOnceWithExactly('test-export.json')).to.be.true;
             expect(context.version).to.equal('1.5.0');
             expect(context.installPath).to.equal(path.join(process.cwd(), 'versions/1.5.0'));
@@ -357,7 +373,7 @@ describe('Unit: Commands > Install', function () {
             const context = {argv: {fromExport: 'test-export.json'}, ui: {log}};
 
             await testInstance.version(context);
-            expect(resolveVersion.calledOnceWithExactly('2.0.0', null, {v1: undefined, force: undefined})).to.be.true;
+            expect(resolveVersion.calledOnceWithExactly('2.0.0', null, {v1: undefined, force: undefined, channel: undefined})).to.be.true;
             expect(parseExport.calledOnceWithExactly('test-export.json')).to.be.true;
             expect(context.version).to.equal('2.0.0');
             expect(context.installPath).to.equal(path.join(process.cwd(), 'versions/2.0.0'));
@@ -381,7 +397,7 @@ describe('Unit: Commands > Install', function () {
             } catch (error) {
                 expect(error).to.be.an.instanceof(errors.SystemError);
                 expect(error.message).to.include('v3.0.0 into v2.0.0');
-                expect(resolveVersion.calledOnceWithExactly('v2', null, {v1: undefined, force: undefined})).to.be.true;
+                expect(resolveVersion.calledOnceWithExactly('v2', null, {v1: undefined, force: undefined, channel: undefined})).to.be.true;
                 expect(parseExport.calledOnceWithExactly('test-export.json')).to.be.true;
                 expect(log.called).to.be.false;
                 return;
@@ -421,13 +437,36 @@ describe('Unit: Commands > Install', function () {
 
             const testInstance = new InstallCommand({}, {getInstance: getInstanceStub, cliVersion: '1.0.0'});
 
-            testInstance.link({version: '1.5.0', installPath: '/some/dir/1.5.0'});
+            testInstance.link({version: '1.5.0', installPath: '/some/dir/1.5.0', argv: {}});
             expect(symlinkSyncStub.calledOnce).to.be.true;
             expect(symlinkSyncStub.calledWithExactly('/some/dir/1.5.0', path.join(process.cwd(), 'current')));
             expect(getInstanceStub.calledOnce).to.be.true;
             expect(config).to.deep.equal({
                 version: '1.5.0',
-                cliVersion: '1.0.0'
+                cliVersion: '1.0.0',
+                channel: 'stable'
+            });
+        });
+
+        it('creates current link and updates versions (using channel = next)', function () {
+            const symlinkSyncStub = sinon.stub();
+            const config = {};
+            const getInstanceStub = sinon.stub().returns(config);
+
+            const InstallCommand = proxyquire(modulePath, {
+                'symlink-or-copy': {sync: symlinkSyncStub}
+            });
+
+            const testInstance = new InstallCommand({}, {getInstance: getInstanceStub, cliVersion: '1.0.0'});
+
+            testInstance.link({version: '1.5.0', installPath: '/some/dir/1.5.0', argv: {channel: 'next'}});
+            expect(symlinkSyncStub.calledOnce).to.be.true;
+            expect(symlinkSyncStub.calledWithExactly('/some/dir/1.5.0', path.join(process.cwd(), 'current')));
+            expect(getInstanceStub.calledOnce).to.be.true;
+            expect(config).to.deep.equal({
+                version: '1.5.0',
+                cliVersion: '1.0.0',
+                channel: 'next'
             });
         });
     });

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -876,14 +876,15 @@ describe('Unit: Commands > Update', function () {
                 force: false,
                 version: null,
                 activeVersion: '1.0.0',
-                v1: true
+                v1: true,
+                instance: {channel: 'stable'}
             };
             sinon.stub(process, 'cwd').returns('/var/www/ghost');
 
             const result = await instance.version(context);
             expect(result).to.be.true;
             expect(resolveVersion.calledOnce).to.be.true;
-            expect(resolveVersion.calledWithExactly(null, '1.0.0', {v1: true, force: false})).to.be.true;
+            expect(resolveVersion.calledWithExactly(null, '1.0.0', {v1: true, force: false, channel: 'stable'})).to.be.true;
             expect(context.version).to.equal('1.0.1');
             expect(context.installPath).to.equal('/var/www/ghost/versions/1.0.1');
         });
@@ -925,13 +926,14 @@ describe('Unit: Commands > Update', function () {
                 force: true,
                 version: null,
                 activeVersion: '1.0.0',
-                v1: false
+                v1: false,
+                instance: {channel: 'stable'}
             };
 
             const result = await instance.version(context);
             expect(result).to.be.false;
             expect(resolveVersion.calledOnce).to.be.true;
-            expect(resolveVersion.calledWithExactly(null, '1.0.0', {v1: false, force: true})).to.be.true;
+            expect(resolveVersion.calledWithExactly(null, '1.0.0', {v1: false, force: true, channel: 'stable'})).to.be.true;
         });
     });
 

--- a/test/unit/utils/version-spec.js
+++ b/test/unit/utils/version-spec.js
@@ -46,7 +46,7 @@ describe('Unit: Utils: version', function () {
 
         it('returns correct all versions/latest versions, sorted desc', async function () {
             const loadVersions = stub(
-                ['0.11.0', '1.0.0', '1.0.1', '1.0.2', '1.0.3', '1.0.4', '2.0.0', '2.1.0', '2.22.0', '3.0.0', '3.1.0'],
+                ['0.11.0', '1.0.0', '1.0.1', '1.0.2', '1.0.3', '1.0.4', '2.0.0', '2.1.0', '2.22.0', '3.0.0', '3.1.0', '4.0.0-rc.1'],
                 ['1.0.4', '2.22.0', '3.1.0']
             );
             const result = await loadVersions();
@@ -59,6 +59,30 @@ describe('Unit: Utils: version', function () {
                     v3: '3.0.0'
                 },
                 all: ['3.1.0', '3.0.0', '2.22.0', '2.1.0', '2.0.0', '1.0.4', '1.0.3', '1.0.2', '1.0.1', '1.0.0'],
+                deprecations: {
+                    '1.0.4': 'test deprecation notice',
+                    '2.22.0': 'test deprecation notice',
+                    '3.1.0': 'test deprecation notice'
+                }
+            });
+        });
+
+        it('includes prereleases if requested', async function () {
+            const loadVersions = stub(
+                ['0.11.0', '1.0.0', '1.0.1', '1.0.2', '1.0.3', '1.0.4', '2.0.0', '2.1.0', '2.22.0', '3.0.0', '3.1.0', '4.0.0-rc.1'],
+                ['1.0.4', '2.22.0', '3.1.0']
+            );
+            const result = await loadVersions(true);
+
+            expect(result).to.deep.equal({
+                latest: '4.0.0-rc.1',
+                latestMajor: {
+                    v1: '1.0.3',
+                    v2: '2.1.0',
+                    v3: '3.0.0',
+                    v4: '4.0.0-rc.1'
+                },
+                all: ['4.0.0-rc.1', '3.1.0', '3.0.0', '2.22.0', '2.1.0', '2.0.0', '1.0.4', '1.0.3', '1.0.2', '1.0.1', '1.0.0'],
                 deprecations: {
                     '1.0.4': 'test deprecation notice',
                     '2.22.0': 'test deprecation notice',


### PR DESCRIPTION
this adds a new `--channel` flag to the install command that will allow installing prereleases for local installs if desired.