### PR TITLE
ci: ensure nginx service is started

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,8 +16,8 @@ jobs:
         password: [root]
         node: [12.x]
     steps:
-      - name: Installing nginx
-        run: sudo apt-get update && sudo apt-get install -y nginx
+      - name: Start nginx
+        run: sudo service nginx start
       - name: Updating hosts file
         run: 'echo -e "127.0.0.1 cli-testing.ghost.org\n" | sudo tee -a /etc/hosts'
       - uses: actions/checkout@v2


### PR DESCRIPTION
previously, we had to install Nginx on the action runner in order to run e2e tests. Upon installation, apt-get would automatically start the Nginx service.

Since nginx is already installed, no such automatic start occurs and we have to start it in the test scripts