### PR TITLE
feat(version): expand v1 update policy to cover all versions

### DIFF
--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -100,7 +100,7 @@ const utils = {
         return parsed.version;
     },
 
-    checkActiveVersion(activeVersion, versionToUse, latestV1, opts = {}) {
+    checkActiveVersion(activeVersion, versionToUse, latestMajorVersions, opts = {}) {
         const activeMajor = semver.major(activeVersion);
 
         if (opts.v1 && activeMajor > 1) {
@@ -115,11 +115,14 @@ const utils = {
             return null;
         }
 
-        if (activeMajor === 1 && activeVersion !== latestV1 && semver.diff(activeVersion, versionToUse) === 'major') {
+        const latestMajor = latestMajorVersions[`v${activeMajor}`];
+
+        if (activeVersion !== latestMajor && semver.diff(activeVersion, versionToUse) === 'major') {
             const majorToUse = semver.major(versionToUse);
+
             throw new CliError({
-                message: `You are trying to update to Ghost v${majorToUse}, but your blog is not on the latest Ghost 1.0 version`,
-                help: 'Instead run "ghost update v1".'
+                message: `Unable to update Ghost directly to v${versionToUse}. You must be on the latest v${activeMajor}.x to update across major versions.`,
+                help: `Run "ghost update v${activeMajor}" to get the latest v${activeMajor}.x version, then run "ghost update" to get to v${majorToUse}.`
             });
         }
 
@@ -158,7 +161,7 @@ const utils = {
             return latest;
         }
 
-        return utils.checkActiveVersion(activeVersion, latest, versions.latestMajor.v1, opts);
+        return utils.checkActiveVersion(activeVersion, latest, versions.latestMajor, opts);
     },
 
     async versionFromZip(zipPath, activeVersion = null, opts = {}) {

--- a/test/unit/utils/version-spec.js
+++ b/test/unit/utils/version-spec.js
@@ -189,10 +189,22 @@ describe('Unit: Utils: version', function () {
 
         it('throws if upgrading major versions from v1', function () {
             try {
-                checkActiveVersion('1.0.0', '3.0.0');
+                checkActiveVersion('1.0.0', '3.0.0', {v1: '1.5.0'});
             } catch (error) {
                 expect(error).to.be.an.instanceof(CliError);
-                expect(error.message).to.contain('not on the latest Ghost 1.0');
+                expect(error.message).to.contain('You must be on the latest v1.x');
+                return;
+            }
+
+            expect.fail('expected an error to be thrown');
+        });
+
+        it('throws if upgrading major versions from not latest v2', function () {
+            try {
+                checkActiveVersion('2.0.0', '3.0.0', {v2: '2.5.0'});
+            } catch (error) {
+                expect(error).to.be.an.instanceof(CliError);
+                expect(error.message).to.contain('You must be on the latest v2.x');
                 return;
             }
 
@@ -200,17 +212,22 @@ describe('Unit: Utils: version', function () {
         });
 
         it('allows upgrading from v1 if on latest v1', function () {
-            const result = checkActiveVersion('1.0.0', '2.0.0', '1.0.0');
+            const result = checkActiveVersion('1.0.0', '2.0.0', {v1: '1.0.0'});
             expect(result).to.equal('2.0.0');
         });
 
+        it('allows upgrading from v2 if on latest v2', function () {
+            const result = checkActiveVersion('2.0.0', '3.0.0', {v2: '2.0.0'});
+            expect(result).to.equal('3.0.0');
+        });
+
         it('returns version if active === latest and --force is supplied', function () {
-            const result = checkActiveVersion('3.0.0', '3.0.0', '1.0.0', {force: true});
+            const result = checkActiveVersion('3.0.0', '3.0.0', {v3: '1.0.0'}, {force: true});
             expect(result).to.equal('3.0.0');
         });
 
         it('returns latest if checks pass', function () {
-            const result = checkActiveVersion('2.0.0', '3.0.0');
+            const result = checkActiveVersion('2.0.0', '3.0.0', {v2: '2.0.0'});
             expect(result).to.equal('3.0.0');
         });
     });


### PR DESCRIPTION
no issue
- previously, the supported version policy was you could update to any new major if you were on the latest v1
- now, we're expanding that to say you can upgrade to any new major only if you're on the latest version of the current major