### PR TITLE
feat(local): handle v4 boot events in local process manager

### DIFF
--- a/.github/workflows/local-e2e-test.yml
+++ b/.github/workflows/local-e2e-test.yml
@@ -25,6 +25,9 @@ jobs:
         run: yarn --cwd cli install --frozen-lockfile
       - name: Setting up Ghost instance
         run: node ./cli/bin/ghost install local -d ghost
+      - name: Setting up v4 Ghost instance
+        if: matrix.os == 'ubuntu-latest'
+        run: node ./cli/bin/ghost install local --channel=next -d ghost-next
       - name: Verifying Installation
         run: curl http://localhost:2368 | grep ghost
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -1,4 +1,5 @@
 const spawn = require('child_process').spawn;
+const semver = require('semver');
 const Command = require('../command');
 
 class RunCommand extends Command {
@@ -50,14 +51,16 @@ class RunCommand extends Command {
     }
 
     useDirect(instance) {
+        const isV4 = semver.major(instance.version) >= 4;
+
         this.child = spawn(process.execPath, ['current/index.js'], {
             cwd: instance.dir,
             stdio: [0, 1, 'pipe', 'ipc']
         });
 
-        let started = false;
+        let started = false, ready = false;
         this.child.stderr.on('data', (data) => {
-            if (!started || process.stderr.isTTY) {
+            if (!ready || process.stderr.isTTY) {
                 process.stderr.write(data);
             }
         });
@@ -71,13 +74,28 @@ class RunCommand extends Command {
             if (message.started) {
                 started = true;
 
+                if (!isV4) {
+                    ready = true;
+                    instance.process.success();
+                }
+
+                return;
+            }
+
+            if (isV4 && message.ready) {
+                ready = true;
                 instance.process.success();
                 return;
             }
 
             // NOTE: Backwards compatibility of https://github.com/TryGhost/Ghost/pull/9440
             setTimeout(() => {
-                instance.process.error({message: message.error});
+                let errMsg = isV4 ? message.error.message : message.error;
+                if (isV4 && started) {
+                    errMsg = `Ghost was able to start, but errored during boot with: ${errMsg}`;
+                }
+
+                instance.process.error({message: errMsg});
             }, 1000);
         });
     }

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -90,6 +90,8 @@ class RunCommand extends Command {
 
             // NOTE: Backwards compatibility of https://github.com/TryGhost/Ghost/pull/9440
             setTimeout(() => {
+                // TODO: this isV4 check *shouldn't* be required, but am too afraid to try and
+                // rework this at the moment and test with v1/v2/v3, and as such this check exists
                 let errMsg = isV4 ? message.error.message : message.error;
                 if (isV4 && started) {
                     errMsg = `Ghost was able to start, but errored during boot with: ${errMsg}`;


### PR DESCRIPTION
no issue:
- Ghost in v4+ emits two events on successful start: 'started' and 'ready', so we need to handle both
- The error message structure in v4 events also changes, so we need to handle things there as well