### PR TITLE
feat(boot): handle v4 boot events in port-polling util

### DIFF
--- a/lib/process-manager.js
+++ b/lib/process-manager.js
@@ -63,7 +63,8 @@ class ProcessManager {
             stopOnError: true,
             port: this.instance.config.get('server.port'),
             host: this.instance.config.get('server.host', 'localhost'),
-            useNetServer: semver.major(this.instance.version) >= 2
+            useNetServer: semver.major(this.instance.version) >= 2,
+            useV4Boot: semver.major(this.instance.version) >= 4
         }, options || {});
 
         try {

--- a/lib/utils/port-polling.js
+++ b/lib/utils/port-polling.js
@@ -8,8 +8,11 @@ const errors = require('../errors');
  */
 const useNetServer = options => new Promise((resolve, reject) => {
     const net = require('net');
+    const {useV4Boot} = options;
+
     let waitTimeout = null;
     let ghostSocket = null;
+    let started = false;
 
     const server = net.createServer((socket) => {
         ghostSocket = socket;
@@ -20,7 +23,12 @@ const useNetServer = options => new Promise((resolve, reject) => {
             try {
                 message = JSON.parse(data);
             } catch (err) {
-                message = {started: false, error: err};
+                message = {started: false, ready: false, error: err};
+            }
+
+            if (useV4Boot && message.started) {
+                started = true;
+                return;
             }
 
             /* istanbul ignore else */
@@ -32,11 +40,16 @@ const useNetServer = options => new Promise((resolve, reject) => {
             ghostSocket = null;
 
             server.close(() => {
-                if (message.started) {
+                if ((!useV4Boot && message.started) || (useV4Boot && message.ready)) {
                     resolve();
                 } else {
+                    let {message: errMsg} = message.error;
+                    if (useV4Boot && started) {
+                        errMsg = `Ghost was able to start, but errored during boot with: ${errMsg}`;
+                    }
+
                     reject(new errors.GhostError({
-                        message: message.error.message,
+                        message: errMsg,
                         help: message.error.help,
                         suggestion: options.logSuggestion
                     }));
@@ -167,6 +180,7 @@ module.exports = function portPolling(options) {
         logSuggestion: 'ghost log',
         socketTimeoutInMS: 1000 * 60,
         useNetServer: false,
+        useV4Boot: false,
         netServerTimeoutInMS: 5 * 60 * 1000,
         socketAddress: {
             port: 1212,

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -71,7 +71,8 @@ describe('Unit: Process Manager', function () {
                     stopOnError: true,
                     port: 2368,
                     host: '10.0.1.0',
-                    useNetServer: false
+                    useNetServer: false,
+                    useV4Boot: false
                 })).to.be.true;
                 expect(stopStub.called).to.be.false;
             });
@@ -96,7 +97,8 @@ describe('Unit: Process Manager', function () {
                     stopOnError: false,
                     port: 2368,
                     host: 'localhost',
-                    useNetServer: false
+                    useNetServer: false,
+                    useV4Boot: false
                 })).to.be.true;
                 expect(stopStub.called).to.be.false;
             });
@@ -122,7 +124,8 @@ describe('Unit: Process Manager', function () {
                     stopOnError: true,
                     port: 2368,
                     host: 'localhost',
-                    useNetServer: false
+                    useNetServer: false,
+                    useV4Boot: false
                 })).to.be.true;
                 expect(stopStub.calledOnce).to.be.true;
             });
@@ -148,7 +151,8 @@ describe('Unit: Process Manager', function () {
                     stopOnError: true,
                     port: 2368,
                     host: 'localhost',
-                    useNetServer: false
+                    useNetServer: false,
+                    useV4Boot: false
                 })).to.be.true;
                 expect(stopStub.calledOnce).to.be.true;
             });


### PR DESCRIPTION
no issue
- handles separate 'ready' event from Ghost v4+