### PR TITLE
fix(version): add premajor to update version diff check

### DIFF
--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -117,7 +117,7 @@ const utils = {
 
         const latestMajor = latestMajorVersions[`v${activeMajor}`];
 
-        if (activeVersion !== latestMajor && semver.diff(activeVersion, versionToUse) === 'major') {
+        if (activeVersion !== latestMajor && ['major', 'premajor'].includes(semver.diff(activeVersion, versionToUse))) {
             const majorToUse = semver.major(versionToUse);
 
             throw new CliError({

--- a/test/unit/utils/version-spec.js
+++ b/test/unit/utils/version-spec.js
@@ -211,6 +211,18 @@ describe('Unit: Utils: version', function () {
             expect.fail('expected an error to be thrown');
         });
 
+        it('throws if upgrading premajor versions from not latest v2', function () {
+            try {
+                checkActiveVersion('2.0.0', '4.0.0-alpha.3', {v2: '2.5.0'});
+            } catch (error) {
+                expect(error).to.be.an.instanceof(CliError);
+                expect(error.message).to.contain('You must be on the latest v2.x');
+                return;
+            }
+
+            expect.fail('expected an error to be thrown');
+        });
+
         it('allows upgrading from v1 if on latest v1', function () {
             const result = checkActiveVersion('1.0.0', '2.0.0', {v1: '1.0.0'});
             expect(result).to.equal('2.0.0');


### PR DESCRIPTION
no issue
- if one of the versions in a comparison is a prerelease (i.e. comparing
v3.0.0 and v4.0.0-alpha.1), semver.diff returns 'premajor' instead of
'major', so we need to handle both cases.