### PR TITLE
ci: added `@actions/stale` workflow to manage issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 0 * * *'
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: 'Our bot has automatically marked this issue as stale because there has not been any activity here in some time. The issue will be closed soon if there are no further updates, however we ask that you do not post comments to keep the issue open if you are not actively working on a PR. We keep the issue list minimal so we can keep focus on the most pressing issues. Closed issues can always be reopened if a new contributor is found. Thank you for understanding 🙂'
+          stale-pr-message: 'Our bot has automatically marked this PR as stale because there has not been any activity here in some time. If we’ve failed to review your PR & you’re still interested in working on it, please let us know. Otherwise this PR will be closed shortly, but can always be reopened later. Thank you for understanding 🙂'
+          exempt-issue-labels: 'feature,pinned'
+          exempt-pr-labels: 'feature,pinned'
+          days-before-stale: 120


### PR DESCRIPTION
no issue

- we want a workflow to automatically mark old issues and PRs as stale
- this commit does the following:
    * adds comment messages for both stale issues and PRs
    * sets the number of days before we mark as stale to a very generous
      time of 120 days
    * adds the `feature` and `pinned` labels to the exemptions list
- all of this will run at 00:30