### PR TITLE
chore(docs): improve error message when node or cli version is incompatible

### DIFF
--- a/lib/tasks/yarn-install.js
+++ b/lib/tasks/yarn-install.js
@@ -23,12 +23,16 @@ const subTasks = {
         const isPrerelease = Boolean(prerelease(cliPackage.version));
 
         if (!skipNodeVersionCheck && engines.node && !satisfies(process.versions.node, engines.node)) {
-            throw new SystemError(`Ghost v${ctx.version} is not compatible with the current Node version.`);
+            throw new SystemError(
+                `Ghost v${ctx.version} is not compatible with the current Node version.` +
+                ` Your node version is ${process.versions.node}, but Ghost v${ctx.version} requires ${engines.node}`
+            );
         }
 
         if (engines.cli && !isPrerelease && !satisfies(cliPackage.version, engines.cli)) {
             throw new SystemError({
-                message: `Ghost v${ctx.version} is not compatible with this version of the CLI.`,
+                message: `Ghost v${ctx.version} is not compatible with this version of the CLI.` +
+                ` Your CLI version is ${cliPackage.version}, but Ghost v${ctx.version} requires ${engines.cli}`,
                 help: `Run ${chalk.cyan('`npm install -g ghost-cli@latest`')} to upgrade the CLI, then try again.`
             });
         }

--- a/test/unit/tasks/yarn-install-spec.js
+++ b/test/unit/tasks/yarn-install-spec.js
@@ -166,7 +166,7 @@ describe('Unit: Tasks > yarn-install', function () {
                 expect(false, 'error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.an.instanceof(errors.SystemError);
-                expect(error.message).to.equal('Ghost v1.5.0 is not compatible with the current Node version.');
+                expect(error.message).to.equal(`Ghost v1.5.0 is not compatible with the current Node version. Your node version is ${process.versions.node}, but Ghost v1.5.0 requires ^0.10.0`);
                 expect(infoStub.calledOnce).to.be.true;
                 expect(infoStub.calledWithExactly('ghost', {version: '1.5.0', agent: false})).to.be.true;
             });
@@ -216,7 +216,7 @@ describe('Unit: Tasks > yarn-install', function () {
                 expect(false, 'error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.an.instanceof(errors.SystemError);
-                expect(error.message).to.equal('Ghost v1.5.0 is not compatible with this version of the CLI.');
+                expect(error.message).to.equal(`Ghost v1.5.0 is not compatible with this version of the CLI. Your CLI version is 1.0.0, but Ghost v1.5.0 requires ^0.0.1`);
                 expect(infoStub.calledOnce).to.be.true;
                 expect(infoStub.calledWithExactly('ghost', {version: '1.5.0', agent: false})).to.be.true;
             });


### PR DESCRIPTION
backport of https://github.com/TryGhost/Ghost-CLI/commit/1a73e9fd0763362389d0d90b74aa679344ee695a