### PR TITLE
Added 3 new folders to content

### DIFF
--- a/packages/ghost-cli/lib/migrations.js
+++ b/packages/ghost-cli/lib/migrations.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-
 async function ensureFolder(context, folderName) {
     const ghostUser = require('./utils/use-ghost-user');
 
@@ -15,7 +14,7 @@ async function ensureFolder(context, folderName) {
 }
 
 async function ensureSettingsFolder(context) {
-    await ensureFolder(context, 'settings')
+    await ensureFolder(context, 'settings');
 }
 
 async function makeSqliteAbsolute({instance}) {

--- a/packages/ghost-cli/lib/migrations.js
+++ b/packages/ghost-cli/lib/migrations.js
@@ -1,16 +1,21 @@
 const path = require('path');
 
-async function ensureSettingsFolder(context) {
+
+async function ensureFolder(context, folderName) {
     const ghostUser = require('./utils/use-ghost-user');
 
     const contentDir = context.instance.config.get('paths.contentPath');
 
     if (ghostUser.shouldUseGhostUser(contentDir)) {
-        await context.ui.sudo(`mkdir -p ${path.resolve(contentDir, 'settings')}`, {sudoArgs: '-E -u ghost'});
+        await context.ui.sudo(`mkdir -p ${path.resolve(contentDir, folderName)}`, {sudoArgs: '-E -u ghost'});
     } else {
         const fs = require('fs-extra');
-        fs.ensureDirSync(path.resolve(contentDir, 'settings'));
+        fs.ensureDirSync(path.resolve(contentDir, folderName));
     }
+}
+
+async function ensureSettingsFolder(context) {
+    await ensureFolder(context, 'settings')
 }
 
 async function makeSqliteAbsolute({instance}) {
@@ -26,6 +31,12 @@ async function makeSqliteAbsolute({instance}) {
     });
 }
 
+async function ensureMediaFileAndPublicFolders(context) {
+    await ensureFolder(context, 'media');
+    await ensureFolder(context, 'files');
+    await ensureFolder(context, 'public');
+}
+
 module.exports = [{
     before: '1.7.0',
     title: 'Create content/settings directory',
@@ -34,4 +45,8 @@ module.exports = [{
     before: '1.14.1',
     title: 'Fix Sqlite DB path',
     task: makeSqliteAbsolute
+}, {
+    before: '1.17.4',
+    title: 'Create content/media, content/files and content/public directories',
+    task: ensureMediaFileAndPublicFolders
 }];

--- a/packages/ghost-cli/lib/migrations.js
+++ b/packages/ghost-cli/lib/migrations.js
@@ -46,7 +46,7 @@ module.exports = [{
     title: 'Fix Sqlite DB path',
     task: makeSqliteAbsolute
 }, {
-    before: '1.17.4',
+    before: '1.18.1',
     title: 'Create content/media, content/files and content/public directories',
     task: ensureMediaFileAndPublicFolders
 }];

--- a/packages/ghost-cli/lib/tasks/ensure-structure.js
+++ b/packages/ghost-cli/lib/tasks/ensure-structure.js
@@ -17,4 +17,7 @@ module.exports = function ensureStructure() {
     fs.ensureDirSync(path.resolve(cwd, 'content', 'images'));
     fs.ensureDirSync(path.resolve(cwd, 'content', 'logs'));
     fs.ensureDirSync(path.resolve(cwd, 'content', 'settings'));
+    fs.ensureDirSync(path.resolve(cwd, 'content', 'media'));
+    fs.ensureDirSync(path.resolve(cwd, 'content', 'files'));
+    fs.ensureDirSync(path.resolve(cwd, 'content', 'public'));
 };

--- a/packages/ghost-cli/test/unit/migrations-spec.js
+++ b/packages/ghost-cli/test/unit/migrations-spec.js
@@ -130,5 +130,5 @@ describe('Unit: Migrations', function () {
                 expect(fsStub.thirdCall.calledWithExactly('/var/www/ghost/content/public')).to.be.true;
             });
         });
-    })
+    });
 });


### PR DESCRIPTION
- Recently we've added 3 new folders to content in Ghost: media, files and public
- This updates Ghost-CLI to create the folders for both new and existing installs

This is not urgent, but the migration before version will need updating in line with whenever this gets released, I think. Not sure I understood how that works.