### PR TITLE
ci: remove eol ubuntu-16 test runner from matrix

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
         password: [root]
         node: [14.x]
     steps:


### PR DESCRIPTION
- this is no longer supported by GitHub and will no longer run