### PR TITLE
fix(version): handled force flag when specifying versions

### DIFF
--- a/packages/ghost-cli/lib/utils/version.js
+++ b/packages/ghost-cli/lib/utils/version.js
@@ -88,7 +88,7 @@ const utils = {
             });
         }
 
-        if (activeVersion && semver.lt(parsed, activeVersion)) {
+        if (!opts.force && activeVersion && semver.lt(parsed, activeVersion)) {
             const message = opts.zip ? 'Version in zip file' : 'The custom version specified';
 
             throw new CliError({

--- a/packages/ghost-cli/test/unit/utils/version-spec.js
+++ b/packages/ghost-cli/test/unit/utils/version-spec.js
@@ -494,13 +494,21 @@ describe('Unit: Utils: version', function () {
             this.slow(2000);
 
             try {
-                await versionFromZip(path.join(__dirname, '../../fixtures/ghostold.zip'), '1.5.0', {force: true});
+                await versionFromZip(path.join(__dirname, '../../fixtures/ghostold.zip'), '1.5.0');
                 expect(false, 'error should have been thrown').to.be.true;
             } catch (error) {
                 expect(error).to.be.an.instanceof(CliError);
                 expect(error.message)
                     .to.equal('Version in zip file: 1.0.0, is less than the current active version: 1.5.0');
             }
+        });
+
+        it('resolves if update version passed, force is passed, and zip version < update version', async function () {
+            this.timeout(5000);
+            this.slow(2000);
+
+            const version = await versionFromZip(path.join(__dirname, '../../fixtures/ghostold.zip'), '1.5.0', {force: true});
+            expect(version).to.equal('1.0.0');
         });
 
         it('resolves with version of ghost in zip file', async function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/157

- we've had several bugs in Ghost where users would like to go back to a
  previous version, but `ghost update <version>` doesn't let them go
  back to a version smaller than their current version
- `ghost update <version> --rollback` doesn't work for certain users if
  they've freshly installed Ghost
- by handling `--force`, we can let users choose to go back to an
  arbitrary version at their own discretion
- also adds a test to ensure `force` works with the util