### PR TITLE
fix(yarn): use bundled yarn version

### DIFF
--- a/.github/workflows/local-e2e-test.yml
+++ b/.github/workflows/local-e2e-test.yml
@@ -23,6 +23,10 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Prepare CLI
         run: yarn --cwd cli install --frozen-lockfile
+      - name: Use latest global yarn version
+        run: |
+          cd ~
+          yarn set version berry
       - name: Setting up Ghost instance
         run: node ./cli/bin/ghost install local -d ghost
       - name: Verifying Installation

--- a/lib/tasks/yarn-install.js
+++ b/lib/tasks/yarn-install.js
@@ -89,7 +89,7 @@ module.exports = function yarnInstall(ui, zipFile) {
 
             const observable = yarn(args, {
                 cwd: ctx.installPath,
-                env: {NODE_ENV: 'production'},
+                env: {NODE_ENV: 'production', YARN_IGNORE_PATH: 'true'},
                 observe: true,
                 verbose: ui.verbose || false
             });

--- a/test/unit/tasks/yarn-install-spec.js
+++ b/test/unit/tasks/yarn-install-spec.js
@@ -47,7 +47,7 @@ describe('Unit: Tasks > yarn-install', function () {
             expect(yarnStub.args[0][0]).to.deep.equal(['install', '--no-emoji', '--no-progress']);
             expect(yarnStub.args[0][1]).to.deep.equal({
                 cwd: '/var/www/ghost/versions/1.5.0',
-                env: {NODE_ENV: 'production'},
+                env: {NODE_ENV: 'production', YARN_IGNORE_PATH: 'true'},
                 observe: true,
                 verbose: false
             });
@@ -83,7 +83,7 @@ describe('Unit: Tasks > yarn-install', function () {
             expect(yarnStub.args[0][0]).to.deep.equal(['install', '--no-emoji', '--no-progress', '--ignore-engines']);
             expect(yarnStub.args[0][1]).to.deep.equal({
                 cwd: '/var/www/ghost/versions/1.5.0',
-                env: {NODE_ENV: 'production'},
+                env: {NODE_ENV: 'production', YARN_IGNORE_PATH: 'true'},
                 observe: true,
                 verbose: false
             });
@@ -142,7 +142,7 @@ describe('Unit: Tasks > yarn-install', function () {
             expect(yarnStub.args[0][0]).to.deep.equal(['install', '--no-emoji', '--no-progress']);
             expect(yarnStub.args[0][1]).to.deep.equal({
                 cwd: env.dir,
-                env: {NODE_ENV: 'production'},
+                env: {NODE_ENV: 'production', YARN_IGNORE_PATH: 'true'},
                 observe: true,
                 verbose: true
             });


### PR DESCRIPTION
closes #1590, #1591

Yarn 1.x is the launching point for users to get yarn >2. When a user runs `yarn set version berry`, a .yarnrc.yml will be created in their home directory with the path to yarn >2:

```bash
$ cat ~/.yarnrc.yml
yarnPath: .yarn/releases/yarn-3.1.1.cjs
```

The YARN_IGNORE_PATH environment variable prevents the `yarnPath` from being used, but still allows other options in the yarnrc locations to be picked up (e.g. registry).

Here's the bootstrapping logic in yarn:
https://github.com/yarnpkg/yarn/blob/728feb1414cec2d5cb8ecf8c061bc10f03b99def/src/cli/index.js#L625-L627

And here's a search for YARN_IGNORE_PATH in the repo, suggesting this _shouldn't_ have a negative impact
https://github.com/yarnpkg/yarn/search?q=YARN_IGNORE_PATH

/cc @Paladiamors can you try this patch and confirm it fixes the issue?