### PR TITLE
feat(deprecation): added notice when using a deprecated database

### DIFF
--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -58,6 +58,15 @@ class MySQLExtension extends Extension {
         }], false);
     }
 
+    async isDeprecated(dbconfig) {
+        const ctx = {};
+        await this.canConnect(ctx, dbconfig);
+        this.connection.end();
+
+        // Anything that isn't MySQL 8 is deprecated
+        return ctx.mysql && !isMySQL8(ctx.mysql.version);
+    }
+
     async getServerVersion() {
         try {
             const result = await this._query('SELECT @@version AS version');

--- a/extensions/mysql/test/extension-spec.js
+++ b/extensions/mysql/test/extension-spec.js
@@ -231,6 +231,54 @@ describe('Unit: Mysql extension', function () {
         });
     });
 
+    describe.only('isDeprecated', function () {
+        it('returns that 5.7 is deprecated', async function () {
+            const connectStub = sinon.stub().callsArg(0);
+            const endStub = sinon.stub();
+            const createConnectionStub = sinon.stub().returns({connect: connectStub, end: endStub});
+
+            const MysqlExtension = proxyquire(modulePath, {
+                mysql2: {createConnection: createConnectionStub}
+            });
+            const instance = new MysqlExtension({logVerbose: () => {}}, {}, {}, '/some/dir');
+
+            const version = semver.parse('5.7.30');
+            const getServerVersion = sinon.stub(instance, 'getServerVersion').resolves(version);
+
+            const isDeprecated = await instance.isDeprecated({user: 'someuser', password: 'somepass', database: 'testing'});
+
+            expect(createConnectionStub.calledOnce).to.be.true;
+            expect(createConnectionStub.calledWithExactly({user: 'someuser', password: 'somepass'})).to.be.true;
+            expect(connectStub.calledOnce).to.be.true;
+            expect(endStub.calledOnce).to.be.true;
+            expect(getServerVersion.calledOnce).to.be.true;
+            expect(isDeprecated).to.be.true;
+        });
+
+        it('returns that 8.0 is not deprecated', async function () {
+            const connectStub = sinon.stub().callsArg(0);
+            const endStub = sinon.stub();
+            const createConnectionStub = sinon.stub().returns({connect: connectStub, end: endStub});
+
+            const MysqlExtension = proxyquire(modulePath, {
+                mysql2: {createConnection: createConnectionStub}
+            });
+            const instance = new MysqlExtension({logVerbose: () => {}}, {}, {}, '/some/dir');
+
+            const version = semver.parse('8.0.0');
+            const getServerVersion = sinon.stub(instance, 'getServerVersion').resolves(version);
+
+            const isDeprecated = await instance.isDeprecated({user: 'someuser', password: 'somepass', database: 'testing'});
+
+            expect(createConnectionStub.calledOnce).to.be.true;
+            expect(createConnectionStub.calledWithExactly({user: 'someuser', password: 'somepass'})).to.be.true;
+            expect(connectStub.calledOnce).to.be.true;
+            expect(endStub.calledOnce).to.be.true;
+            expect(getServerVersion.calledOnce).to.be.true;
+            expect(isDeprecated).to.be.false;
+        });
+    });
+
     describe('createUser', function () {
         const MysqlExtension = require(modulePath);
 

--- a/lib/utils/deprecation-checks.js
+++ b/lib/utils/deprecation-checks.js
@@ -14,16 +14,53 @@ Ghost-CLI will drop support for unmaintained Ghost versions in an upcoming relea
 See ${chalk.cyan('https://ghost.org/docs/faq/major-versions-lts/')}.
 `.trim()), {borderColor: 'yellow', align: 'center'});
 
+const databaseDeprecated = () => boxen(chalk.yellow(`
+Warning: MySQL 8 will be the required database in the next major release of Ghost.
+Make sure your database is up to date to ensure forwards compatibility.
+`.trim()), {borderColor: 'yellow', align: 'center'});
+
 async function deprecationChecks(ui, system) {
     if (semver.lt(process.versions.node, '12.0.0')) {
         ui.log(nodeDeprecated());
     }
 
-    const showGhostDeprecation = (await system.getAllInstances(false))
+    const allInstances = await system.getAllInstances(false);
+
+    const showGhostDeprecation = allInstances
         .some(instance => instance.version && semver.lt(instance.version, '3.0.0'));
 
     if (showGhostDeprecation) {
         ui.log(ghostDeprecated());
+    }
+
+    const showDatabaseDeprecation = (await Promise.all(allInstances
+        .map(async (instance) => {
+            instance.checkEnvironment();
+
+            const isProduction = instance.system.production;
+            const databaseClient = instance.config.get('database.client');
+
+            if (isProduction && databaseClient === 'sqlite3') { // SQLite is only supported in development
+                return true;
+            } else if (databaseClient === 'mysql') {
+                const mysqlExtension = instance.system._extensions.filter(e => e.pkg.name === 'ghost-cli-mysql');
+
+                // This shouldn't happen, but still
+                if (!mysqlExtension.length) {
+                    return;
+                }
+
+                const dbconfig = instance.config.get('database.connection');
+                const mysqlIsDeprecated = await mysqlExtension[0].isDeprecated(dbconfig);
+                return mysqlIsDeprecated;
+            }
+        })))
+        .flatMap(x => x)
+        .filter(Boolean)
+        .length;
+
+    if (showDatabaseDeprecation) {
+        ui.log(databaseDeprecated());
     }
 }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/176

- we're going to be making some changes to the list of supported databases in
  Ghost 5.0 so we need to start informing self-hosters if their DB is
  due to become unsupported
- specifically, SQLite will only be supported in development mode, and
  MySQL 5.7 will not going to be supported at all
- this commit adds a deprecation check to CLI that adds a warning when
  we encounter a database that is due to be unsupported in coming months