### PR TITLE
trim whitespace from service names

### DIFF
--- a/extensions/nginx/index.js
+++ b/extensions/nginx/index.js
@@ -269,7 +269,7 @@ class NginxExtension extends Extension {
     async isSupported() {
         try {
             const services = await sysinfo.services('*');
-            return services.some(s => s.name === nginxProgramName);
+            return services.some(s => s.name.trim() === nginxProgramName);
         } catch (error) {
             return false;
         }


### PR DESCRIPTION
You have a number of people reporting that nginx is not detected in their environment, and a couple people reporting it's because the service name evaluates to something like'  nginx'. This uses std lib trim() functionality to remove the whitespace. Tested on an Ubuntu system that was not working before this fix and is now working after.