### PR TITLE
mysql2 as a supported database client type #1677

### DIFF
--- a/lib/tasks/configure/options.js
+++ b/lib/tasks/configure/options.js
@@ -66,9 +66,9 @@ module.exports = {
 
     // Database options
     db: {
-        description: 'Type of database to use E.g. mysql or sqlite3',
-        validate: value => ['sqlite3', 'mysql'].includes(value) ||
-            'Invalid database type. Supported types are mysql and sqlite3',
+        description: 'Type of database to use E.g. mysql, mysql2 or sqlite3',
+        validate: value => ['sqlite3', 'mysql', 'mysql2'].includes(value) ||
+            'Invalid database type. Supported types are mysql, mysql2 and sqlite3',
         configPath: 'database.client',
         type: 'string',
         group: 'Database Options:'

--- a/test/unit/tasks/configure/options-spec.js
+++ b/test/unit/tasks/configure/options-spec.js
@@ -58,6 +58,7 @@ describe('Unit: Tasks: Configure > options', function () {
     it('db', function () {
         expect(options.db).to.exist;
         expect(options.db.validate('mysql')).to.be.true;
+        expect(options.db.validate('mysql2')).to.be.true;
         expect(options.db.validate('sqlite3')).to.be.true;
         expect(options.db.validate('pg')).to.match(/Invalid database type/);
     });
@@ -65,6 +66,7 @@ describe('Unit: Tasks: Configure > options', function () {
     it('dbpath', function () {
         expect(options.dbpath).to.exist;
         expect(options.dbpath.defaultValue({get: () => 'mysql'})).to.be.null;
+        expect(options.dbpath.defaultValue({get: () => 'mysql2'})).to.be.null;
         expect(options.dbpath.defaultValue({get: () => 'sqlite3'}, 'development')).to.equal(path.resolve('./content/data/ghost-dev.db'));
         expect(options.dbpath.defaultValue({get: () => 'sqlite3'}, 'production')).to.equal(path.resolve('./content/data/ghost.db'));
     });


### PR DESCRIPTION
In running some Ghost upgrade migrations today I noticed this validation error when upgrading (details in #1677). There was another user in the forums that reported this as well, https://forum.ghost.org/t/invalid-database-type-supported-types-are-mysql-and-sqlite3-current-value-s-mysql2/30740/4.

In debugging why this was happening I found this options validation logic which was returning the error and failing the `ghost start` command. What I wasn't sure about is if this validation should be checking if the ghost version is compatible with the database client for mysql2... since technically mysql2 wouldn't be possible prior to support was added in https://github.com/TryGhost/Ghost/commit/bf6f607f424106c1973b09dd47f62c1b972b2ae6.

The addition of the mysql2 client was done in a backwards compatible way, but the config.production.json change wasn't done in a compatible way with the ghost-cli. Either we should add the change to validation as I have done here, or change back to simply stating mysql as the database type in the config.production.json files upon upgrading.