### PR TITLE
Updated E2E CI testing workflows

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         password: [root]
-        node: [14.x]
+        node: [16.x]
     steps:
       - name: Start nginx
         run: sudo service nginx start
@@ -32,11 +32,6 @@ jobs:
           FORCE_COLOR: 0
       - name: Start MySQL service
         run: sudo systemctl start mysql.service
-      - name: Fix MySQL Password
-        if: matrix.os == 'ubuntu-20.04'
-        run: |
-          echo "ALTER USER root@localhost IDENTIFIED WITH mysql_native_password BY '${{ matrix.password }}';" >> tmp.sql
-          mysql -u root -proot < tmp.sql
       - name: Prepare CLI
         run: |
           cd cli

--- a/.github/workflows/local-e2e-test.yml
+++ b/.github/workflows/local-e2e-test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [14.x]
+        node: ['16.x']
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- removed Ubuntu 18 as it is EOL on GHA
- switched from Node 14 to 16 as this is our recommended version
- removed the MySQL password workaround because Ghost-CLI should support all auth types now