### PR TITLE
fix(errors): Show full Ghost Error message output

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -58,7 +58,7 @@ class RunCommand extends Command {
             stdio: [0, 1, 'pipe', 'ipc']
         });
 
-        let started = false, ready = false;
+        let started = false; let ready = false;
         this.child.stderr.on('data', (data) => {
             if (!ready || process.stderr.isTTY) {
                 process.stderr.write(data);
@@ -88,16 +88,13 @@ class RunCommand extends Command {
                 return;
             }
 
-            // NOTE: Backwards compatibility of https://github.com/TryGhost/Ghost/pull/9440
             setTimeout(() => {
-                // TODO: this isV4 check *shouldn't* be required, but am too afraid to try and
-                // rework this at the moment and test with v1/v2/v3, and as such this check exists
-                let errMsg = isV4 ? message.error.message : message.error;
-                if (isV4 && started) {
-                    errMsg = `Ghost was able to start, but errored during boot with: ${errMsg}`;
+                // This is tested to work with v3, v4 and v5 -Latest Ghost CLI is no longer compatible with v2
+                if (started && message.error && message.error.message) {
+                    message.error.message = `Ghost was able to start, but errored during boot with: ${message.error.message}`;
                 }
 
-                instance.process.error({message: errMsg});
+                instance.process.error({message: message.error});
             }, 1000);
         });
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -72,8 +72,12 @@ class CliError extends Error {
     toStringBasics() {
         let output = `${chalk.yellow('Message:')} ${this.message}\n`;
 
+        if (this.options.context) {
+            output += `${chalk.gray('Context:')} ${this.options.context}\n`;
+        }
+
         if (this.options.help) {
-            output += `${chalk.gray('Help:')} ${this.options.help}\n`;
+            output += `${chalk.cyan('Help:')} ${this.options.help}\n`;
         }
 
         if (this.options.suggestion) {


### PR DESCRIPTION
- Ghost errors contain context messages that were not being output
- These messages often have the most important information in them
- Updated Ghost CLI to show this if present