### PR TITLE
Ensure X-Forwarded-For is correct in default case

### DIFF
--- a/extensions/nginx/templates/nginx-ssl.conf
+++ b/extensions/nginx/templates/nginx-ssl.conf
@@ -10,7 +10,7 @@ server {
     include <%= sslparams %>;
 
     location <%= location %> {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $http_host;

--- a/extensions/nginx/templates/nginx.conf
+++ b/extensions/nginx/templates/nginx.conf
@@ -6,7 +6,7 @@ server {
     root <%= webroot %>; # Used for acme.sh SSL verification (https://acme.sh)
 
     location <%= location %> {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
refs: https://github.com/orgs/TryGhost/projects/57/views/21

X-Forwarded-For is used to determine the client IP address within Ghost, and is used in some rate-limiting scenarios. The original setting for this was to use Nginx's $proxy_add_x_forwarded_for variable, which appends to the list.

Since it's trivial to spoof a client address with this mode, the default case should be to assume this is the most external proxy (i.e. this Nginx server is what clients connect to, with no other proxies in-between).

If someone has a setup which uses a CDN or additional reverse proxies, then this configuration will need changing to use $proxy_add_x_forwarded_for, and additional configuration may be required to ensure that only the next proxy in the chain can access Nginx.