### PR TITLE
fix: install with proxy agent fail

### DIFF
--- a/lib/utils/get-proxy-agent.js
+++ b/lib/utils/get-proxy-agent.js
@@ -8,7 +8,7 @@ module.exports = function getProxyAgent() {
     const proxyAddress = getProxyForUrl(NPM_REGISTRY);
     if (proxyAddress && !proxyAgent) {
         const HttpsProxyAgent = require('https-proxy-agent');
-        proxyAgent = new HttpsProxyAgent(proxyAddress);
+        proxyAgent = {https: new HttpsProxyAgent(proxyAddress)};
     }
 
     return proxyAgent;


### PR DESCRIPTION
packageJson requires library "got" and pass agent option directly to it, but "got" checks the agent option and only allow "http", "https" or "http2" to be its keys. If pass HttpsProxyAgent without wrapping it with a correct key, finally it will throw an error.

The wrong type annotation which was fixed in package-json v8.0.0, but also changes it into an ESM only library. Ghost-Cli cannot upgrade it to fix type annotation.

