### PR TITLE
🐛 Fixed not all members being exported in CLI

### DIFF
--- a/lib/tasks/import/api.js
+++ b/lib/tasks/import/api.js
@@ -150,7 +150,7 @@ async function downloadContentExport(version, url, auth, outputFile) {
 
 async function downloadMembersExport(version, url, auth, outputFile) {
     const authOpts = await getAuthOpts(version, url, auth);
-    let endpoint = '/members/upload/';
+    let endpoint = '/members/upload?limit=all';
 
     if (semver.lt(version, '3.20.0')) {
         endpoint = '/members/csv/';

--- a/lib/tasks/import/api.js
+++ b/lib/tasks/import/api.js
@@ -150,7 +150,7 @@ async function downloadContentExport(version, url, auth, outputFile) {
 
 async function downloadMembersExport(version, url, auth, outputFile) {
     const authOpts = await getAuthOpts(version, url, auth);
-    let endpoint = '/members/upload?limit=all';
+    let endpoint = '/members/upload/?limit=all';
 
     if (semver.lt(version, '3.20.0')) {
         endpoint = '/members/csv/';


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3578

- The export API, by default is limited to 15 members.
- This sets the API endpoint to query all members via the CLI.