### PR TITLE
Fix installation behind corporate proxy

### DIFF
--- a/lib/utils/get-proxy-agent.js
+++ b/lib/utils/get-proxy-agent.js
@@ -11,5 +11,5 @@ module.exports = function getProxyAgent() {
         proxyAgent = new HttpsProxyAgent(proxyAddress);
     }
 
-    return proxyAgent;
+    return {http: proxyAgent, https: proxyAgent};
 };


### PR DESCRIPTION
In the latest version, it is not possible to install ghost using the ghost-cli behind a corporate proxy.
This is caused by packageJson expects an object containing agents for http and https instead of just the http agent object.