### PR TITLE
✨ Added support for multiple built-in themes

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -131,7 +131,6 @@ class InstallCommand extends Command {
 
     defaultThemes() {
         if (fs.existsSync(path.join(process.cwd(), 'current', 'content', 'themes'))) {
-            const symlinkSync = require('symlink-or-copy').sync;
             const defaultThemes = fs.readdirSync(path.join(process.cwd(), 'current', 'content', 'themes'));
             for (const theme of defaultThemes) {
                 if (!fs.existsSync(path.join(process.cwd(), 'content', 'themes', theme))) {

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -69,7 +69,7 @@ class InstallCommand extends Command {
                     title: 'Linking latest Ghost and recording versions',
                     task: this.link.bind(this)
                 }, {
-                    title: 'Installing default themes',
+                    title: 'Linking built-in themes',
                     task: this.defaultThemes
                 }], false)
             }], {

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -130,12 +130,14 @@ class InstallCommand extends Command {
     }
 
     defaultThemes() {
-        const defaultThemes = fs.readdirSync(path.join(process.cwd(), 'current', 'content', 'themes'));
+        const currentThemesDir = path.join(process.cwd(), 'current', 'content', 'themes');
+        const contentThemesDir = path.join(process.cwd(), 'content', 'themes');
+        const defaultThemes = fs.readdirSync(currentThemesDir);
         for (const theme of defaultThemes) {
-            if (!fs.existsSync(path.join(process.cwd(), 'content', 'themes', theme))) {
+            if (!fs.existsSync(path.join(contentThemesDir, theme))) {
                 symlinkSync(
-                    path.join(process.cwd(), 'current', 'content', 'themes', theme),
-                    path.join(process.cwd(), 'content', 'themes', theme)
+                    path.join(currentThemesDir, theme),
+                    path.join(contentThemesDir, theme)
                 );
             }
         }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -130,15 +130,13 @@ class InstallCommand extends Command {
     }
 
     defaultThemes() {
-        if (fs.existsSync(path.join(process.cwd(), 'current', 'content', 'themes'))) {
-            const defaultThemes = fs.readdirSync(path.join(process.cwd(), 'current', 'content', 'themes'));
-            for (const theme of defaultThemes) {
-                if (!fs.existsSync(path.join(process.cwd(), 'content', 'themes', theme))) {
-                    symlinkSync(
-                        path.join(process.cwd(), 'current', 'content', 'themes', theme),
-                        path.join(process.cwd(), 'content', 'themes', theme)
-                    );
-                }
+        const defaultThemes = fs.readdirSync(path.join(process.cwd(), 'current', 'content', 'themes'));
+        for (const theme of defaultThemes) {
+            if (!fs.existsSync(path.join(process.cwd(), 'content', 'themes', theme))) {
+                symlinkSync(
+                    path.join(process.cwd(), 'current', 'content', 'themes', theme),
+                    path.join(process.cwd(), 'content', 'themes', theme)
+                );
             }
         }
     }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -69,8 +69,8 @@ class InstallCommand extends Command {
                     title: 'Linking latest Ghost and recording versions',
                     task: this.link.bind(this)
                 }, {
-                    title: 'Linking latest Casper',
-                    task: this.casper
+                    title: 'Installing default themes',
+                    task: this.defaultThemes
                 }], false)
             }], {
                 argv: {...argv, version},
@@ -129,12 +129,19 @@ class InstallCommand extends Command {
         ctx.installPath = path.join(process.cwd(), 'versions', resolvedVersion); // eslint-disable-line require-atomic-updates
     }
 
-    casper() {
-        // Create a symlink to the theme from the current version
-        return symlinkSync(
-            path.join(process.cwd(), 'current', 'content', 'themes', 'casper'),
-            path.join(process.cwd(), 'content', 'themes', 'casper')
-        );
+    defaultThemes() {
+        if (fs.existsSync(path.join(process.cwd(), 'current', 'content', 'themes'))) {
+            const symlinkSync = require('symlink-or-copy').sync;
+            const defaultThemes = fs.readdirSync(path.join(process.cwd(), 'current', 'content', 'themes'));
+            for (const theme of defaultThemes) {
+                if (!fs.existsSync(path.join(process.cwd(), 'content', 'themes', theme))) {
+                    symlinkSync(
+                        path.join(process.cwd(), 'current', 'content', 'themes', theme),
+                        path.join(process.cwd(), 'content', 'themes', theme)
+                    );
+                }
+            }
+        }
     }
 
     link(ctx) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -235,7 +235,7 @@ class UpdateCommand extends Command {
         const contentThemesDir = path.join(process.cwd(), 'content', 'themes');
         // remove any broken symlinks caused by default themes no longer existing in previous version
         if (rollback) {
-            if (fs.existsSync(currentThemesDir)) {
+            if (fs.existsSync(contentThemesDir)) {
                 const installedThemes = fs.readdirSync(contentThemesDir);
                 for (const theme of installedThemes) {
                     if (!fs.existsSync(path.join(contentThemesDir, theme))) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -230,9 +230,9 @@ class UpdateCommand extends Command {
         instance.nodeVersion = process.versions.node;
     }
 
-    linkDefaultThemes({rollback}) {
+    linkDefaultThemes({instance, rollback}) {
         const currentThemesDir = path.join(process.cwd(), 'current', 'content', 'themes');
-        const contentThemesDir = path.join(process.cwd(), 'content', 'themes');
+        const contentThemesDir = path.join(instance.config.get('paths.contentPath'), 'themes');
         // remove any broken symlinks caused by default themes no longer existing in previous version
         if (rollback) {
             if (fs.existsSync(contentThemesDir)) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
+const symlinkSync = require('symlink-or-copy').sync;
 
 // Utils
 const {GhostError} = require('../errors');
@@ -221,8 +222,6 @@ class UpdateCommand extends Command {
     }
 
     link({instance, installPath, version, rollback}) {
-        const symlinkSync = require('symlink-or-copy').sync;
-
         fs.removeSync(path.join(process.cwd(), 'current'));
         symlinkSync(installPath, path.join(process.cwd(), 'current'));
 
@@ -247,8 +246,7 @@ class UpdateCommand extends Command {
         } 
 
         // ensure all default themes (e.g. themes shipped with Ghost) are symlinked to /content/themes directory
-        if (fs.existsSync(path.join(process.cwd(), 'current', 'content', 'themes'))) {
-            const symlinkSync = require('symlink-or-copy').sync;
+        if (fs.existsSync(currentThemesDir)) {
             const defaultThemes = fs.readdirSync(path.join(process.cwd(), 'current', 'content', 'themes'));
             for (const theme of defaultThemes) {
                 if (!fs.existsSync(path.join(process.cwd(), 'content', 'themes', theme))) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -247,12 +247,12 @@ class UpdateCommand extends Command {
 
         // ensure all default themes (e.g. themes shipped with Ghost) are symlinked to /content/themes directory
         if (fs.existsSync(currentThemesDir)) {
-            const defaultThemes = fs.readdirSync(path.join(process.cwd(), 'current', 'content', 'themes'));
+            const defaultThemes = fs.readdirSync(currentThemesDir);
             for (const theme of defaultThemes) {
-                if (!fs.existsSync(path.join(process.cwd(), 'content', 'themes', theme))) {
+                if (!fs.existsSync(path.join(contentThemesDir, theme))) {
                     symlinkSync(
-                        path.join(process.cwd(), 'current', 'content', 'themes', theme),
-                        path.join(process.cwd(), 'content', 'themes', theme)
+                        path.join(currentThemesDir, theme),
+                        path.join(contentThemesDir, theme)
                     );
                 }
             }

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -93,6 +93,9 @@ class UpdateCommand extends Command {
             title: 'Linking latest Ghost and recording versions',
             task: this.link
         }, {
+            title: 'Installing default themes',
+            task: this.linkDefaultThemes
+        }, {
             title: 'Running database migrations',
             skip: ({rollback}) => rollback,
             task: migrator.migrate,
@@ -226,6 +229,36 @@ class UpdateCommand extends Command {
         instance.previousVersion = rollback ? null : instance.version;
         instance.version = version;
         instance.nodeVersion = process.versions.node;
+    }
+
+    linkDefaultThemes({rollback}) {
+        const currentThemesDir = path.join(process.cwd(), 'current', 'content', 'themes');
+        const contentThemesDir = path.join(process.cwd(), 'content', 'themes');
+        // remove any broken symlinks caused by default themes no longer existing in previous version
+        if (rollback) {
+            if (fs.existsSync(currentThemesDir)) {
+                const installedThemes = fs.readdirSync(contentThemesDir);
+                for (const theme of installedThemes) {
+                    if (!fs.existsSync(path.join(contentThemesDir, theme))) {
+                        fs.rmSync(path.join(contentThemesDir, theme));
+                    }
+                }
+            }
+        } 
+
+        // ensure all default themes (e.g. themes shipped with Ghost) are symlinked to /content/themes directory
+        if (fs.existsSync(path.join(process.cwd(), 'current', 'content', 'themes'))) {
+            const symlinkSync = require('symlink-or-copy').sync;
+            const defaultThemes = fs.readdirSync(path.join(process.cwd(), 'current', 'content', 'themes'));
+            for (const theme of defaultThemes) {
+                if (!fs.existsSync(path.join(process.cwd(), 'content', 'themes', theme))) {
+                    symlinkSync(
+                        path.join(process.cwd(), 'current', 'content', 'themes', theme),
+                        path.join(process.cwd(), 'content', 'themes', theme)
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/lib/tasks/backup.js
+++ b/lib/tasks/backup.js
@@ -74,7 +74,7 @@ module.exports = async function (ui, instance) {
     const zipPath = path.join(process.cwd(), `backup-${backupSuffix}.zip`);
 
     try {
-        await zip.compress(path.join(instance.dir, 'content/'), zipPath, {glob: `{data/${contentExportFile},data/${membersExportFile},files/**,images/**,media/**,settings/**,themes/**}`, ignore: 'themes/casper'});
+        await zip.compress(path.join(instance.dir, 'content/'), zipPath, {glob: `{data/${contentExportFile},data/${membersExportFile},files/**,images/**,media/**,settings/**,themes/**}`, ignore: 'themes/casper,themes/source'});
     } catch (err) {
         throw new ProcessError(err);
     }

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -417,9 +417,7 @@ describe('Unit: Commands > Install', function () {
             const symlinkSyncStub = sinon.stub();
             const readdirSyncStub = sinon.stub().returns(['casper', 'source']);
             const existsSyncStub = sinon.stub();
-            existsSyncStub.onCall(0).returns(true);
-            existsSyncStub.onCall(1).returns(false);
-            existsSyncStub.onCall(2).returns(false);
+            existsSyncStub.returns(false);
             const InstallCommand = proxyquire(modulePath, {
                 'symlink-or-copy': {sync: symlinkSyncStub},
                 'fs-extra': {readdirSync: readdirSyncStub, existsSync: existsSyncStub}

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -229,6 +229,7 @@ describe('Unit: Commands > Update', function () {
             const downloadStub = sinon.stub(cmdInstance, 'downloadAndUpdate').resolves();
             const removeOldVersionsStub = sinon.stub(cmdInstance, 'removeOldVersions').resolves();
             const linkStub = sinon.stub(cmdInstance, 'link').resolves();
+            const linkDefaultThemesStub = sinon.stub(cmdInstance, 'linkDefaultThemes').resolves();
 
             await cmdInstance.run({version: '2.0.1', force: false, zip: '', v1: false, restart: false});
             expect(runCommandStub.calledTwice).to.be.true;
@@ -246,6 +247,7 @@ describe('Unit: Commands > Update', function () {
             expect(ui.listr.calledOnce).to.be.true;
             expect(removeOldVersionsStub.calledOnce).to.be.true;
             expect(linkStub.calledOnce).to.be.true;
+            expect(linkDefaultThemesStub.calledOnce).to.be.true;
             expect(downloadStub.calledOnce).to.be.true;
             expect(fakeInstance.isRunning.calledOnce).to.be.true;
             expect(fakeInstance.stop.calledOnce).to.be.true;
@@ -277,6 +279,7 @@ describe('Unit: Commands > Update', function () {
             ghostConfig.get.withArgs('database').returns({
                 client: 'sqlite3'
             });
+            ghostConfig.get.withArgs('paths.contentPath').returns('/content/themes');
 
             const ui = {log: sinon.stub(), listr: sinon.stub(), run: sinon.stub()};
             const system = {getInstance: sinon.stub()};
@@ -468,6 +471,7 @@ describe('Unit: Commands > Update', function () {
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(true);
             const linkStub = sinon.stub(cmdInstance, 'link').resolves();
+            sinon.stub(cmdInstance, 'linkDefaultThemes').resolves();
             sinon.stub(process, 'cwd').returns(fakeInstance.dir);
             const downloadStub = sinon.stub(cmdInstance, 'downloadAndUpdate');
             const removeOldVersionsStub = sinon.stub(cmdInstance, 'removeOldVersions');
@@ -533,6 +537,7 @@ describe('Unit: Commands > Update', function () {
             const downloadStub = sinon.stub(cmdInstance, 'downloadAndUpdate');
             const removeOldVersionsStub = sinon.stub(cmdInstance, 'removeOldVersions');
             const runCommandStub = sinon.stub(cmdInstance, 'runCommand').resolves();
+            sinon.stub(cmdInstance, 'linkDefaultThemes').resolves();
 
             await cmdInstance.run({rollback: true, force: false, zip: '', restart: true, v1: true});
             const expectedCtx = {
@@ -593,7 +598,9 @@ describe('Unit: Commands > Update', function () {
             fakeInstance.start.resolves();
             const cmdInstance = new UpdateCommand(ui, system);
             const versionStub = sinon.stub(cmdInstance, 'version').resolves(true);
+
             sinon.stub(cmdInstance, 'link').resolves();
+            sinon.stub(cmdInstance, 'linkDefaultThemes').resolves();
             sinon.stub(process, 'cwd').returns(fakeInstance.dir);
             sinon.stub(cmdInstance, 'downloadAndUpdate');
             sinon.stub(cmdInstance, 'removeOldVersions');
@@ -1082,7 +1089,10 @@ describe('Unit: Commands > Update', function () {
             const env = setupTestFolder(envCfg);
             sinon.stub(process, 'cwd').returns(env.dir);
             const instance = {
-                version: '5.62.0'
+                version: '5.62.0',
+                config: {
+                    get: sinon.stub().withArgs('paths.contentPath').returns(path.join(env.dir, 'content'))
+                }
             };
             const context = {
                 installPath: path.join(env.dir, 'versions/5.67.0'),
@@ -1106,7 +1116,10 @@ describe('Unit: Commands > Update', function () {
             const env = setupTestFolder(envCfg);
             sinon.stub(process, 'cwd').returns(env.dir);
             const instance = {
-                version: '5.67.0'
+                version: '5.67.0',
+                config: {
+                    get: sinon.stub().withArgs('paths.contentPath').returns(path.join(env.dir, 'content'))
+                }
             };
             const context = {
                 installPath: path.join(env.dir, 'versions/5.62.0'),


### PR DESCRIPTION
refs TryGhost/Product#3510

- Until now, Ghost has always shipped with a single built-in theme, Casper. This change adds support for Ghost to ship with multiple built-in themes.
- Updated the install and update commands to create symlinks for any theme that is shipped alongside Ghost (e.g. any theme in `ghost/core/content/themes`)
- When rolling back with `ghost update --rollback`, any symlinks that are broken in the process will be removed