### PR TITLE
Fixed sleep command in CI local-e2e test workflow

### DIFF
--- a/.github/workflows/local-e2e-test.yml
+++ b/.github/workflows/local-e2e-test.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Setting up Ghost instance
         run: node ./cli/bin/ghost install local -d ghost
       - name: Verifying Installation
-        run: sleep 2s && curl -f http://localhost:2368 | grep ghost
+        run: sleep 2 && curl -f http://localhost:2368 | grep ghost
 


### PR DESCRIPTION
no issue

- local e2e tests were failing on macos because of improper usage of the `sleep` command
- on macos, the `sleep` command doesn't accept a suffix (e.g. 's', 'm', 'h'), only an integer which by default is in seconds