### PR TITLE
🎨 add warning when `-d` is provided instead of `-D`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -119,6 +119,16 @@ class Command {
 
         // This needs to run before the installation check
         if (argv.dir) {
+            if (argv.dir === true) {
+                // CASE: the short-form dir flag was provided, and a development flag was not provided in any form
+                // --> This is probably a typo
+                const help = process.argv.includes('-d') && !('development' in argv)
+                    ? '. Did you mean -D?'
+                    : '';
+                ui.log('Invalid directory provided' + help, 'red', true);
+                process.exit(1);
+            }
+
             debug('Directory specified, attempting to update');
             const path = require('path');
             const dir = path.resolve(argv.dir);


### PR DESCRIPTION
reported on the [forum](https://forum.ghost.org/t/ghost-run-d-throws-typeerror/42487)
depends on https://github.com/TryGhost/Ghost-CLI/pull/1814