### PR TITLE
Allow `ghost backup` to run with `--no-prompt`, take authData from command line arguments

### DIFF
--- a/lib/commands/backup.js
+++ b/lib/commands/backup.js
@@ -1,7 +1,7 @@
 const Command = require('../command');
 
 class BackupCommand extends Command {
-    async run() {
+    async run(argv) {
         const semver = require('semver');
 
         const backupTask = require('../tasks/backup');
@@ -22,6 +22,11 @@ class BackupCommand extends Command {
             await this.ui.run(() => instance.start(), 'Starting Ghost');
         }
 
+        const { username, password } = argv;
+        const authData = { username, password };
+        if (!argv.prompt && (!username || !password)) {
+            throw new SystemError('You must specify a username and password');
+        }
         // Get the latest version in our current major
         const {latestMajor, latest} = await loadVersions();
         const activeMajor = semver.major(instance.version);
@@ -32,7 +37,7 @@ class BackupCommand extends Command {
         let backupFile;
 
         await this.ui.run(async () => {
-            backupFile = await backupTask(this.ui, instance);
+            backupFile = await backupTask(this.ui, instance, authData);
         }, 'Backing up site');
 
         if (latestMinor && instance.version !== latestMinor && isBehindByMajor) {

--- a/lib/tasks/backup.js
+++ b/lib/tasks/backup.js
@@ -45,7 +45,7 @@ async function copyFiles(ui, instance, files) {
     }
 }
 
-module.exports = async function (ui, instance) {
+module.exports = async function (ui, instance, authData) {
     const datetime = require('moment')().format('YYYY-MM-DD-HH-mm-ss');
     const backupSuffix = `from-v${instance.version}-on-${datetime}`;
 
@@ -57,7 +57,7 @@ module.exports = async function (ui, instance) {
     await ensureBackupFolder(ui, instance);
 
     // Generate backup files
-    await exportTask(ui, instance, path.join(instance.dir, 'backup/', contentExportFile), path.join(instance.dir, 'backup/', membersExportFile));
+    await exportTask(ui, instance, path.join(instance.dir, 'backup/', contentExportFile), path.join(instance.dir, 'backup/', membersExportFile), authData);
 
     // Next we need to copy `redirects.*` files from `data/` to `settings/` because
     // we're not going to backup `data/

--- a/lib/tasks/import/tasks.js
+++ b/lib/tasks/import/tasks.js
@@ -40,7 +40,7 @@ async function importTask(ui, instance, exportFile) {
     }], false);
 }
 
-async function exportTask(ui, instance, contentFile, membersFile) {
+async function exportTask(ui, instance, contentFile, membersFile, authData) {
     const url = instance.config.get('url');
 
     const blogIsSetup = await isSetup(instance.version, url);
@@ -48,7 +48,9 @@ async function exportTask(ui, instance, contentFile, membersFile) {
         throw new SystemError('Cannot export content from a blog that hasn\'t been set up.');
     }
 
-    const authData = await ui.prompt(authPrompts);
+    if (!authData.username || !authData.password) {
+        authData = await ui.prompt(authPrompts);
+    }
 
     await downloadContentExport(instance.version, url, authData, contentFile);
 


### PR DESCRIPTION
`ghost backup --no-prompt` wasn't actually taking the arguments from the command line required to properly call the exportTask (authData).

This commit checks for authData {username, password} from the command line and passes through to the necessary task calls.

The test spec setup for these were a bit odd (I've never looked at this codebase before but this was blocking my work), so here are some screenshots? 😅 

Note: One of the screenshotted "working" calls fails because localhost in Node 18 automagically favors iPv6. We successfully auth for the backup process with `--no-prompt` and some auth arguments. 

Throw SystemError when not username and password passed but in no-prompt mode:
<img width="566" alt="Screenshot 2024-01-27 at 6 33 00 PM" src="https://github.com/TryGhost/Ghost-CLI/assets/17029312/351bdad4-5969-41f6-8612-edccdaca72e1">

Without `--no-prompt`, use AuthData from interactive CLI:
<img width="521" alt="Screenshot 2024-01-27 at 6 32 27 PM" src="https://github.com/TryGhost/Ghost-CLI/assets/17029312/0c2c9b14-0c0f-406b-ad0e-1f0f57e1c330">

With authdata provided and `--no-prompt`, successfully auth (don't worry, test password for my local dev instance):
<img width="706" alt="Screenshot 2024-01-27 at 6 42 24 PM" src="https://github.com/TryGhost/Ghost-CLI/assets/17029312/3a1493c6-ea85-410f-8334-8d9b27ed760a">

Working on my actual Ghost instance:
```
tdoot@util-arm:/var/www/decked$ ../../code/Ghost-CLI/bin/ghost backup --no-prompt --username <redacted> --password <redacted>

Love open source? We’re hiring JavaScript Engineers to work on Ghost full-time.
https://careers.ghost.org


+ sudo systemctl is-active ghost_decked-gg-1
+ sudo mkdir -p /var/www/decked/backup
+ sudo cp /var/www/decked/backup/content-from-v5.76.2-on-2024-01-28-04-48-40.json /var/www/decked/content/data/content-from-v5.76.2-on-2024-01-28-04-48-40.json
+ sudo cp /var/www/decked/backup/members-from-v5.76.2-on-2024-01-28-04-48-40.csv /var/www/decked/content/data/members-from-v5.76.2-on-2024-01-28-04-48-40.csv
+ sudo chown -R ghost:ghost /var/www/decked/content
✔ Backing up site
Backup saved to /var/www/decked/backup-from-v5.76.2-on-2024-01-28-04-48-40.zip
```
