### PR TITLE
fix: change default mysql hostname on new sites from localhost to 127…

### DIFF
--- a/lib/tasks/configure/get-prompts.js
+++ b/lib/tasks/configure/get-prompts.js
@@ -30,7 +30,7 @@ module.exports = function getPrompts(config, argv, environment) {
                 type: 'input',
                 name: 'dbhost',
                 message: 'Enter your MySQL hostname:',
-                default: config.get('database.connection.host', 'localhost')
+                default: config.get('database.connection.host', '127.0.0.1')
             });
         }
 


### PR DESCRIPTION
As described on [this forum post on the Ghost Forum](https://forum.ghost.org/t/upgrade-ghost-5-71-0-with-node-18-encountered-error/42246?ref=blog.arfy.ca), having the database hostname set to the current default of `localhost` in `config.production.json` results in the hostname being resolved to an IPV6 address when connecting to the database in Node 18, as opposed to IPV4 resolution in Node 16.

Since the upgrade to Node 18, this issue causes sites created with `ghost install` to throw `ECONNREFUSED ::1:3306` when trying to start Ghost, as well as to prevent `ghost install` and `ghost setup` from successfully creating the `ghost` MySQL user. Though the current workaround of setting the database hostname in `config.production.json` as `127.0.0.1` to force Node to use IPV4 and re-running `ghost setup` works fine, I believe it would be better for this to be the new default behavior.

I really hope I this little change will be helpful, and thank you for keeping up the great work on Ghost!😌