### PR TITLE
Updated nosniff header to apply to non-204 responses only

### DIFF
--- a/extensions/nginx/templates/nginx-ssl.conf
+++ b/extensions/nginx/templates/nginx-ssl.conf
@@ -1,3 +1,8 @@
+map $status $header_content_type_options {
+    204 "";
+    default "nosniff";
+}
+
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
@@ -16,6 +21,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_pass http://127.0.0.1:<%= port %>;
         <% if (location !== '/') { %>proxy_redirect off;<% } %>
+        add_header X-Content-Type-Options $header_content_type_options;
     }
 
     location ~ /.well-known {

--- a/extensions/nginx/templates/nginx.conf
+++ b/extensions/nginx/templates/nginx.conf
@@ -1,3 +1,8 @@
+map $status $header_content_type_options {
+    204 "";
+    default "nosniff";
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -12,6 +17,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_pass http://127.0.0.1:<%= port %>;
         <% if (location !== '/') { %>proxy_redirect off;<% } %>
+        add_header X-Content-Type-Options $header_content_type_options;
     }
 
     location ~ /.well-known {

--- a/extensions/nginx/templates/ssl-params.conf
+++ b/extensions/nginx/templates/ssl-params.conf
@@ -10,6 +10,4 @@ resolver 8.8.8.8 8.8.4.4 valid=300s;
 resolver_timeout 5s;
 add_header Strict-Transport-Security 'max-age=63072000; includeSubDomains; preload';
 add_header X-Frame-Options SAMEORIGIN;
-add_header X-Content-Type-Options nosniff;
-
 ssl_dhparam <%= dhparam %>;


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ONC-179

- self-hosters reported seing a prompt to download "auth-frame" when visiting a post with comments enabled on iOS
- recently, we've worked on an optimisation for comments UI to return a empty 204 for `/ghost/auth-frame/` when no staff admin is authenticated (more context: https://github.com/TryGhost/Ghost/pull/19840)
- setting `X-Content-Type-Options` to `nosniff` helps to prevent browsers from interpreting files as a different MIME type than what is specified in the `Content-Type` header
- however, when returning an empty 204 response (`No Content`, therefore no `Content-Type` to check), iOS safari interprets the header as a file to download for some reason
- with this change, we add the `nosniff` header to only non-empty responses (i.e. not HTTP 204)