### PR TITLE
fix(yarn): passthrough NODE_OPTIONS env var to yarn install

### DIFF
--- a/lib/tasks/yarn-install.js
+++ b/lib/tasks/yarn-install.js
@@ -95,9 +95,16 @@ module.exports = function yarnInstall(ui, archiveFile) {
                 args.push('--ignore-engines');
             }
 
+            const env = {NODE_ENV: 'production', YARN_IGNORE_PATH: 'true'};
+            // #1898: pass through NODE_OPTIONS so max_old_space_size can be configured
+            // in memory-constrained environments
+            if (process.env.NODE_OPTIONS) {
+                env.NODE_OPTIONS = process.env.NODE_OPTIONS;
+            }
+
             const observable = yarn(args, {
                 cwd: ctx.installPath,
-                env: {NODE_ENV: 'production', YARN_IGNORE_PATH: 'true'},
+                env,
                 observe: true,
                 verbose: ui.verbose || false
             });


### PR DESCRIPTION
closes #1898
- passthrough NODE_OPTIONS env var to yarn install if set