### PR TITLE
fix(install): pass agent correctly to packageJson function

### DIFF
--- a/lib/tasks/yarn-install.js
+++ b/lib/tasks/yarn-install.js
@@ -15,9 +15,10 @@ const getProxyAgent = require('../utils/get-proxy-agent');
 
 const subTasks = {
     async dist(ctx) {
+        const proxyAgent = getProxyAgent();
         const {dist, engines = {}} = await packageInfo('ghost', {
             version: ctx.version,
-            agent: getProxyAgent()
+            agent: proxyAgent ? {https: proxyAgent} : false
         });
 
         const skipNodeVersionCheck = (process.env.GHOST_NODE_VERSION_CHECK === 'false');

--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -12,9 +12,10 @@ const MIN_RELEASE = '>= 1.0.0';
 
 const utils = {
     async loadVersions(includePrerelease = false) {
+        const proxyAgent = getProxyAgent();
         const result = await packageJson('ghost', {
             allVersions: true,
-            agent: getProxyAgent()
+            agent: proxyAgent ? {https: proxyAgent} : null
         });
         const versions = Object.keys(result.versions)
             .filter(v => semver.satisfies(v, MIN_RELEASE, {includePrerelease}))


### PR DESCRIPTION
closes #1899
- at some point the syntax changed, so we need to pass the agent differently