### PR TITLE
nginx: remove ocsp support, its EOL at letsencrypt

### DIFF
--- a/extensions/nginx/templates/ssl-params.conf
+++ b/extensions/nginx/templates/ssl-params.conf
@@ -4,10 +4,6 @@ ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECD
 ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
 ssl_session_cache shared:SSL:10m;
 ssl_session_tickets off; # Requires nginx >= 1.5.9
-ssl_stapling on; # Requires nginx >= 1.3.7
-ssl_stapling_verify on; # Requires nginx => 1.3.7
-resolver 8.8.8.8 8.8.4.4 valid=300s;
-resolver_timeout 5s;
 add_header Strict-Transport-Security 'max-age=63072000; includeSubDomains; preload';
 add_header X-Frame-Options SAMEORIGIN;
 ssl_dhparam <%= dhparam %>;


### PR DESCRIPTION
Letsencrypt will turn off OCSP responders in August 2025, so lets remove already now.

For more details see https://letsencrypt.org/2024/12/05/ending-ocsp/