### PR TITLE
🐛 Update progress icon for improved terminal compatibility 

### DIFF
--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -91,7 +91,7 @@ class UI {
     run(promiseOrFunction, name, options = {}) {
         const {
             text = name,
-            spinner = 'hamburger',
+            spinner = 'dots',
             stream = this.stdout,
             clear = false,
             quiet = false

--- a/lib/ui/renderer.js
+++ b/lib/ui/renderer.js
@@ -38,7 +38,7 @@ class Renderer {
 
         this.spinner = this.ui.spinner = ora({
             stream: this.ui.stdout,
-            spinner: this.options.spinner || 'hamburger'
+            spinner: this.options.spinner || 'dots'
         });
 
         this.subscribeToEvents();

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -130,7 +130,7 @@ describe('Unit: UI', function () {
                 expect(oraStub.calledOnce).to.be.true;
                 expect(oraStub.calledWithExactly({
                     text: 'do a thing',
-                    spinner: 'hamburger',
+                    spinner: 'dots',
                     stream: {stdout: true}
                 })).to.be.true;
                 expect(startStub.calledOnce).to.be.true;
@@ -191,7 +191,7 @@ describe('Unit: UI', function () {
                 expect(oraStub.calledOnce).to.be.true;
                 expect(oraStub.calledWithExactly({
                     text: 'test',
-                    spinner: 'hamburger',
+                    spinner: 'dots',
                     stream: {stdout: true}
                 })).to.be.true;
                 expect(startStub.calledOnce).to.be.true;


### PR DESCRIPTION
A minor UI issue I discovered while using Ghost CLI within `tmux` - a popular terminal multiplexer.  
It seems that the byte-width of `hamburger` spinner icon used as the progress indicator is not well defined between terminals and locales, which in my example is causing it to unintentionally delete preceding characters.

Switching to the more common `dots` fixes the issue, but any other icon with a known and fixed width will do the trick too.

### Before

https://github.com/user-attachments/assets/552244fb-9921-4cdb-ae8c-97e6a6750edd

### After


https://github.com/user-attachments/assets/f79c8430-e132-4ea2-b546-2896746ba9e1