### PR TITLE
Added check for Python (+ setuptools), required for Node 22+

### DIFF
--- a/lib/commands/doctor/checks/index.js
+++ b/lib/commands/doctor/checks/index.js
@@ -13,6 +13,7 @@ const contentFolder = require('./content-folder');
 const checkMemory = require('./check-memory');
 const binaryDeps = require('./binary-deps');
 const freeSpace = require('./free-space');
+const pythonSetuptools = require('./python-setuptools');
 
 module.exports = [
     nodeVersion,
@@ -28,5 +29,6 @@ module.exports = [
     contentFolder,
     checkMemory,
     binaryDeps,
-    freeSpace
+    freeSpace,
+    pythonSetuptools
 ];

--- a/lib/commands/doctor/checks/python-setuptools.js
+++ b/lib/commands/doctor/checks/python-setuptools.js
@@ -1,0 +1,80 @@
+const execa = require('execa');
+const semver = require('semver');
+
+const {SystemError} = require('../../../errors');
+
+const taskTitle = 'Checking SQLite build dependencies';
+
+async function checkPython3() {
+    try {
+        const {stdout} = await execa('python3', ['--version'], {timeout: 5000});
+        const version = stdout.trim().replace('Python ', '');
+        return {available: true, version};
+    } catch (error) {
+        return {available: false};
+    }
+}
+
+async function checkSetuptools() {
+    try {
+        await execa('python3', ['-c', 'import setuptools'], {timeout: 5000});
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+async function pythonSetuptoolsCheck(ctx, task) {
+    const python = await checkPython3();
+
+    if (!python.available) {
+        throw new SystemError({
+            message: 'Python is required for SQLite3',
+            task: taskTitle
+        });
+    }
+
+    task.title = `${taskTitle} - found Python v${python.version}`;
+
+    // Only check setuptools for Python 3.12+ since distutils was removed from the standard library
+    const needsSetuptools = semver.gte(python.version, '3.12.0');
+
+    if (needsSetuptools) {
+        const hasSetuptools = await checkSetuptools();
+        if (!hasSetuptools) {
+            throw new SystemError({
+                message: 'Python setuptools is required for SQLite3 when using Python 3.12+',
+                task: taskTitle
+            });
+        }
+
+        task.title = `${taskTitle} - found Python v${python.version} with setuptools`;
+    } else {
+        task.title = `${taskTitle} - found Python v${python.version}`;
+    }
+}
+
+function pythonSetuptoolsIsRequired(ctx) {
+    const nodeVersion = process.versions.node;
+    const isNode22Plus = semver.gte(nodeVersion, '22.0.0');
+
+    // SQLite3 provides binaries for node versions < 22
+    if (!isNode22Plus) {
+        return false;
+    }
+
+    // If already setup, then check if sqlite is being used
+    if (ctx.instance.isSetup) {
+        return ctx.instance.config.values.database.client === 'sqlite3';
+    }
+
+    // Otherwise, check if local or sqlite3 explicitly specified
+    return ctx.local || ctx.argv.db === 'sqlite3';
+}
+
+module.exports = {
+    title: taskTitle,
+    task: pythonSetuptoolsCheck,
+    enabled: pythonSetuptoolsIsRequired,
+    category: ['install']
+};

--- a/test/unit/commands/doctor/checks/python-setuptools-spec.js
+++ b/test/unit/commands/doctor/checks/python-setuptools-spec.js
@@ -1,0 +1,218 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const execa = require('execa');
+
+const errors = require('../../../../../lib/errors');
+const pythonSetuptools = require('../../../../../lib/commands/doctor/checks/python-setuptools');
+
+describe('Unit: Doctor Checks > pythonSetuptools', function () {
+    let originalNodeVersion;
+
+    beforeEach(function () {
+        originalNodeVersion = process.versions.node;
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        Object.defineProperty(process.versions, 'node', {
+            value: originalNodeVersion,
+            writable: true
+        });
+    });
+
+    describe('enabled', function () {
+        beforeEach(function () {
+            // Mock Node 22+ for all tests in this suite
+            Object.defineProperty(process.versions, 'node', {
+                value: '22.0.0',
+                writable: true
+            });
+        });
+
+        it('returns false for Node version < 22', function () {
+            Object.defineProperty(process.versions, 'node', {
+                value: '20.0.0',
+                writable: true
+            });
+
+            const ctx = {};
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.false;
+        });
+
+        it('returns true for local installs on Node 22+', function () {
+            const ctx = {local: true, instance: {}};
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.true;
+        });
+
+        it('returns true when instance uses sqlite3', function () {
+            const ctx = {
+                instance: {
+                    isSetup: true,
+                    config: {
+                        values: {
+                            database: {
+                                client: 'sqlite3'
+                            }
+                        }
+                    }
+                }
+            };
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.true;
+        });
+
+        it('returns false when instance uses mysql', function () {
+            const ctx = {
+                instance: {
+                    isSetup: true,
+                    config: {
+                        values: {
+                            database: {
+                                client: 'mysql'
+                            }
+                        }
+                    }
+                }
+            };
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.false;
+        });
+
+        it('returns true when --db sqlite3 is specified', function () {
+            const ctx = {argv: {db: 'sqlite3'}, instance: {}};
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.true;
+        });
+
+        it('returns false when --db mysql is specified', function () {
+            const ctx = {argv: {db: 'mysql'}, instance: {}};
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.false;
+        });
+
+        it('returns false when no db specified and no local flag', function () {
+            const ctx = {argv: {}, instance: {}};
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.false;
+        });
+    });
+
+    describe('task', function () {
+        let ctx, task;
+
+        beforeEach(function () {
+            ctx = {};
+            task = {
+                title: 'initial title'
+            };
+        });
+
+        describe('when Python3 is not available', function () {
+            beforeEach(function () {
+                sinon.stub(execa).withArgs('python3', ['--version']).rejects(new Error('Command not found'));
+            });
+
+            it('throws SystemError', async function () {
+                try {
+                    await pythonSetuptools.task(ctx, task);
+                    expect.fail('Should have thrown an error');
+                } catch (error) {
+                    expect(error).to.be.instanceof(errors.SystemError);
+                    expect(error.message).to.equal('Python is required for SQLite3');
+                }
+            });
+        });
+
+        describe('when Python3 is available', function () {
+            beforeEach(function () {
+                sinon.stub(execa).withArgs('python3', ['--version']).resolves({stdout: 'Python 3.9.0'});
+            });
+
+            it('updates task title with Python version for Python 3.12+', async function () {
+                execa.withArgs('python3', ['--version']).resolves({stdout: 'Python 3.12.0'});
+                execa.withArgs('python3', ['-c', 'import setuptools']).resolves();
+
+                await pythonSetuptools.task(ctx, task);
+
+                expect(task.title).to.include('found Python v3.12.0 with setuptools');
+            });
+
+            it('updates task title for Python < 3.12 (no setuptools check)', async function () {
+                execa.withArgs('python3', ['--version']).resolves({stdout: 'Python 3.11.0'});
+
+                await pythonSetuptools.task(ctx, task);
+
+                expect(task.title).to.include('found Python v3.11.0');
+            });
+
+            describe('when setuptools is not available (Python 3.12+)', function () {
+                beforeEach(function () {
+                    execa.withArgs('python3', ['--version']).resolves({stdout: 'Python 3.12.0'});
+                    execa.withArgs('python3', ['-c', 'import setuptools']).rejects(new Error('Module not found'));
+                });
+
+                it('throws SystemError', async function () {
+                    try {
+                        await pythonSetuptools.task(ctx, task);
+                        expect.fail('Should have thrown an error');
+                    } catch (error) {
+                        expect(error).to.be.instanceof(errors.SystemError);
+                        expect(error.message).to.equal('Python setuptools is required for SQLite3 when using Python 3.12+');
+                    }
+                });
+            });
+
+            describe('when setuptools is available (Python 3.12+)', function () {
+                beforeEach(function () {
+                    execa.withArgs('python3', ['--version']).resolves({stdout: 'Python 3.12.0'});
+                    execa.withArgs('python3', ['-c', 'import setuptools']).resolves();
+                });
+
+                it('completes successfully', async function () {
+                    await pythonSetuptools.task(ctx, task);
+
+                    expect(task.title).to.include('found Python v3.12.0 with setuptools');
+                });
+            });
+        });
+
+        describe('timeout handling', function () {
+            it('handles timeout for python3 --version', async function () {
+                sinon.stub(execa).withArgs('python3', ['--version'], {timeout: 5000}).rejects(new Error('Timeout'));
+
+                try {
+                    await pythonSetuptools.task(ctx, task);
+                    expect.fail('Should have thrown an error');
+                } catch (error) {
+                    expect(error).to.be.instanceof(errors.SystemError);
+                    expect(execa.calledWith('python3', ['--version'], {timeout: 5000})).to.be.true;
+                }
+            });
+
+            it('handles timeout for setuptools import', async function () {
+                const execaStub = sinon.stub(execa);
+                execaStub.withArgs('python3', ['--version']).resolves({stdout: 'Python 3.12.0'});
+                execaStub.withArgs('python3', ['-c', 'import setuptools'], {timeout: 5000}).rejects(new Error('Timeout'));
+
+                try {
+                    await pythonSetuptools.task(ctx, task);
+                    expect.fail('Should have thrown an error');
+                } catch (error) {
+                    expect(error).to.be.instanceof(errors.SystemError);
+                    expect(execaStub.calledWith('python3', ['-c', 'import setuptools'], {timeout: 5000})).to.be.true;
+                }
+            });
+        });
+    });
+
+    describe('module exports', function () {
+        it('has correct properties', function () {
+            expect(pythonSetuptools.title).to.equal('Checking SQLite build dependencies');
+            expect(pythonSetuptools.task).to.be.a('function');
+            expect(pythonSetuptools.enabled).to.be.a('function');
+            expect(pythonSetuptools.category).to.deep.equal(['install']);
+        });
+    });
+});


### PR DESCRIPTION
Sqlite3 doesn't ship binaries for Node 22+, so it needs to be compiled instead. That relies on Python's setuptools. For Python versions <3.12 this works out-of-the-box, but for Python 3.12+ this requires the package be installed.

This PR adds a new check enabled for Node 22+, only when using SQLite (either explicitly or through a local install). The check validates that either: 
* Python <3.12 is installed
* Python 3.12+ _and_ `setuptools` are installed