### PR TITLE
feat(backup): support specifying backup staff token via env var

### DIFF
--- a/lib/tasks/import/tasks.js
+++ b/lib/tasks/import/tasks.js
@@ -17,12 +17,40 @@ const sessionAuthPrompts = [{
     validate: val => validator.isLength(`${val}`, {min: 10}) || 'Password must be at least 10 characters long'
 }];
 
+const staffTokenRegex = /^[0-9a-f]{24}:[0-9a-f]{64}$/;
+
 const staffTokenAuthPrompts = [{
     type: 'string',
     name: 'token',
     message: 'Enter your Ghost Staff access token',
-    validate: val => /[0-9a-f]{24}:[0-9a-f]{64}/.test(val) || 'Token must follow the "{A}:{B}" format, where A is 24 hex characters and B is 64 hex characters'
+    validate: val => staffTokenRegex.test(val) || 'Token must follow the "{A}:{B}" format, where A is 24 hex characters and B is 64 hex characters'
 }];
+
+/**
+ * Gets authentication data for the export tasks
+ * @param{ import('../../ui/index.js')} ui
+ * @param {string} version
+ */
+async function getAuthData(ui, version) {
+    const isSessionAuth = semver.lt(version, TOKEN_AUTH_MIN_VERSION);
+    if (isSessionAuth) {
+        return await ui.prompt(sessionAuthPrompts);
+    }
+
+    // Case: GHOST_CLI_STAFF_AUTH_TOKEN is defined, use it for the token
+    const envToken = process.env.GHOST_CLI_STAFF_AUTH_TOKEN;
+    if (envToken) {
+        const valid = staffTokenRegex.test(envToken);
+        if (!valid) {
+            throw new SystemError('GHOST_CLI_STAFF_AUTH_TOKEN is not a valid token. It must follow the "{A}:{B}" format, where A is 24 hex characters and B is 64 hex characters');
+        }
+
+        return {token: envToken};
+    }
+
+    // Case: GHOST_CLI_STAFF_AUTH_TOKEN is not defined, prompt for it
+    return await ui.prompt(staffTokenAuthPrompts);
+}
 
 /**
  * @param {import('../../ui/index.js')} ui
@@ -81,8 +109,7 @@ async function exportTask(ui, instance, contentFile, membersFile) {
         });
     }
 
-    const authPrompts = semver.gte(version, TOKEN_AUTH_MIN_VERSION) ? staffTokenAuthPrompts : sessionAuthPrompts;
-    const authData = await ui.prompt(authPrompts);
+    const authData = await getAuthData(ui, version);
 
     await downloadContentExport(version, url, authData, contentFile);
 


### PR DESCRIPTION
refs #1952
- add support for GHOST_CLI_STAFF_AUTH_TOKEN env var to remove the need for prompting in automated backup scenarios