### PR TITLE
fix(config): allow mailgun as valid transport

### DIFF
--- a/lib/tasks/configure/options.js
+++ b/lib/tasks/configure/options.js
@@ -12,6 +12,7 @@ const knownMailServices = [
     'mail.ee', 'mail.ru', 'mailgun', 'mailjet', 'mandrill', 'postmark', 'qq', 'qqex', 'sendgrid',
     'sendcloud', 'ses', 'yahoo', 'yandex', 'zoho'
 ];
+const knownMailTransports = ['smtp', 'sendmail', 'direct', 'ses', 'mailgun'];
 
 /*
     Note: these options are handled serially, i.e. one after the other.
@@ -123,7 +124,7 @@ module.exports = {
     // Designed to support the most common mail configs, more advanced configs will require editing the config file
     mail: {
         description: 'Mail transport, E.g SMTP, Sendmail or Direct',
-        validate: value => ['smtp', 'sendmail', 'direct', 'ses'].includes(value.toLowerCase()) || 'Invalid mail transport',
+        validate: value => knownMailTransports.includes(value.toLowerCase()) || 'Invalid mail transport',
         configPath: 'mail.transport',
         type: 'string',
         default: 'Direct',

--- a/test/unit/tasks/configure/options-spec.js
+++ b/test/unit/tasks/configure/options-spec.js
@@ -72,6 +72,7 @@ describe('Unit: Tasks: Configure > options', function () {
     it('mail', function () {
         expect(options.mail).to.exist;
         expect(options.mail.validate('Sendmail')).to.be.true;
+        expect(options.mail.validate('Mailgun')).to.be.true;
         expect(options.mail.validate('SMS')).to.match(/Invalid mail transport/);
     });
 


### PR DESCRIPTION
closes #1968
- add mailgun to list of allowed mail transports

While not officially documented, it does appear to be supported here: https://github.com/TryGhost/framework/blob/main/packages/nodemailer/lib/nodemailer.js#L40-L49 so we're adding it to avoid unnecessary errors when running `ghost doctor`.