### PR TITLE
Fixed nginx config to pass .well-known to Ghost by default

### DIFF
--- a/extensions/nginx/templates/nginx-ssl.conf
+++ b/extensions/nginx/templates/nginx-ssl.conf
@@ -44,9 +44,5 @@ server {
         add_header X-Content-Type-Options $header_content_type_options;
     }
 
-    location ~ /.well-known {
-        allow all;
-    }
-
     client_max_body_size 1g;
 }

--- a/extensions/nginx/templates/nginx.conf
+++ b/extensions/nginx/templates/nginx.conf
@@ -40,7 +40,7 @@ server {
         add_header X-Content-Type-Options $header_content_type_options;
     }
 
-    location ~ /.well-known {
+    location ~ ^/.well-known/acme-challenge {
         allow all;
     }
 


### PR DESCRIPTION
ref [PROD-2362](https://linear.app/ghost/issue/PROD-2362/ghost-clis-nginx-config-doesnt-work-properly-with-apghostorg)

We were passing anything matching /.well-known to Nginx, causing 404s for /ghost/.well-known/jwks.json and /.well-known/recommendations.json

I believe the only use for this was /.well-known/acme-challenge, so I've increased the specificity and only left this block in-tact for the HTTP(80) config file.