### PR TITLE
Disable 2FA for local installs

### DIFF
--- a/lib/tasks/configure/options.js
+++ b/lib/tasks/configure/options.js
@@ -182,5 +182,16 @@ module.exports = {
         },
         type: 'string',
         group: 'Service Options:'
+    },
+
+    // Security options
+    staffDeviceVerification: {
+        description: 'Enable/disable staff device verification (2FA)',
+        configPath: 'security.staffDeviceVerification',
+        defaultValue: (c, env) => {
+            return env === 'production' ? true : false;
+        },
+        type: 'boolean',
+        group: 'Security Options:'
     }
 };


### PR DESCRIPTION
Shouldn't be used, since it just causes failures for logins, as mail isn't a hard requirement for local installs