### PR TITLE
🐛 Fix Python version check and setuptools validation on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Session.vim
 
 # Temp folder - useful for manual testing!
 tmp
+.DS_Store

--- a/lib/commands/doctor/checks/python-setuptools.js
+++ b/lib/commands/doctor/checks/python-setuptools.js
@@ -6,18 +6,28 @@ const {SystemError} = require('../../../errors');
 const taskTitle = 'Checking SQLite build dependencies';
 
 async function checkPython3() {
-    try {
-        const {stdout} = await execa('python3', ['--version'], {timeout: 5000});
-        const version = stdout.trim().replace('Python ', '');
-        return {available: true, version};
-    } catch (error) {
-        return {available: false};
+    const executables = ['python3', 'python'];
+    for (const executable of executables) {
+        try {
+            const {stdout} = await execa(executable, ['--version'], {timeout: 5000});
+            const version = stdout.trim().replace('Python ', '');
+
+            if (semver.major(version) < 3) {
+                continue;
+            }
+
+            return {available: true, version, executable};
+        } catch (error) {
+            // Command not found, try next
+        }
     }
+
+    return {available: false};
 }
 
-async function checkSetuptools() {
+async function checkSetuptools(python) {
     try {
-        await execa('python3', ['-c', 'import setuptools'], {timeout: 5000});
+        await execa(python.executable, ['-c', 'import setuptools'], {timeout: 5000});
         return true;
     } catch (error) {
         return false;
@@ -40,7 +50,7 @@ async function pythonSetuptoolsCheck(ctx, task) {
     const needsSetuptools = semver.gte(python.version, '3.12.0');
 
     if (needsSetuptools) {
-        const hasSetuptools = await checkSetuptools();
+        const hasSetuptools = await checkSetuptools(python);
         if (!hasSetuptools) {
             throw new SystemError({
                 message: 'Python setuptools is required for SQLite3 when using Python 3.12+',


### PR DESCRIPTION
fixes #1982 

- `python3` command is not available on Windows.
Modified the checkPython function to check both `python` and `python3` commands before returning the result

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects Python 3 using either `python` or `python3` and runs the setuptools check against that executable; adds `.DS_Store` to `.gitignore`.
> 
> - **Doctor checks (`lib/commands/doctor/checks/python-setuptools.js`)**:
>   - Detect Python 3 from either `python3` or `python`, ensuring major version >= 3, and return the chosen executable.
>   - Run `setuptools` import check using the detected `python` executable.
>   - Preserve task titles and conditional setuptools requirement for Python >= `3.12`.
> - **Repo**:
>   - Add `.DS_Store` to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e47180bf8669a832284231ed6a38e673315d1750. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->