### PR TITLE
Added --ignore-scripts flag to yarn install

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
           cp -r ./cli /opt/cli
           chmod 755 /opt/cli
           cd /opt/cli
-          yarn install --frozen-lockfile
+          yarn install --ignore-scripts --frozen-lockfile
           sudo ln -s /opt/cli/bin/ghost /usr/local/bin/ghost
       - name: Setting up install directory
         run: |


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1540/

- there have been multiple recent npm incidents with compromised packages using pre/post-install scripts to run malicious scripts
- we want to default to not running these scripts as a security precaution, this matches behaviour of pnpm which is touted as a modern, more secure, npm package manager