### PR TITLE
🐛 Fix dependency installation in newer Ghost versions with pnpm

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -239,17 +239,18 @@ class Command {
     /**
      * @param {Command} CommandClass Class of command to run
      * @param {Object} argv Parsed arguments
+     * @param {Object?} ctx Additional context to pass to the command
      * @return Promise<void>
      * @method runCommand
      * @public
      */
-    async runCommand(CommandClass, argv) {
+    async runCommand(CommandClass, argv, ctx) {
         if (!(CommandClass.prototype instanceof Command)) {
             throw new Error('Provided command class does not extend the Command class');
         }
 
         const cmdInstance = new CommandClass(this.ui, this.system);
-        return cmdInstance.run(argv || {});
+        return cmdInstance.run(argv || {}, ctx);
     }
 }
 

--- a/lib/commands/doctor/checks/index.js
+++ b/lib/commands/doctor/checks/index.js
@@ -14,6 +14,7 @@ const checkMemory = require('./check-memory');
 const binaryDeps = require('./binary-deps');
 const freeSpace = require('./free-space');
 const pythonSetuptools = require('./python-setuptools');
+const pnpm = require('./pnpm');
 
 module.exports = [
     nodeVersion,
@@ -30,5 +31,6 @@ module.exports = [
     checkMemory,
     binaryDeps,
     freeSpace,
-    pythonSetuptools
+    pythonSetuptools,
+    pnpm
 ];

--- a/lib/commands/doctor/checks/node-version.js
+++ b/lib/commands/doctor/checks/node-version.js
@@ -16,7 +16,7 @@ async function nodeVersion(ctx, task) {
             message: `${chalk.red('The version of Node.js you are using is not supported.')}
 ${chalk.gray('Supported: ')}${cliPackage.engines.node}
 ${chalk.gray('Installed: ')}${process.versions.node}
-See ${chalk.underline.blue('https://ghost.org/docs/faq/node-versions/')} for more information`,
+See ${chalk.underline.blue('https://docs.ghost.org/faq/node-versions/')} for more information`,
             task: taskTitle
         });
     }

--- a/lib/commands/doctor/checks/pnpm.js
+++ b/lib/commands/doctor/checks/pnpm.js
@@ -1,0 +1,64 @@
+const chalk = require('chalk');
+const execa = require('execa');
+const semver = require('semver');
+
+const {SystemError} = require('../../../errors');
+
+const taskTitle = 'Checking pnpm installation';
+
+const GHOST_VERSION_WITH_PNPM = '6.30.0';
+
+async function checkPnpm() {
+    try {
+        const {stdout} = await execa('pnpm', ['--version'], {timeout: 5000});
+        const version = stdout.trim();
+        return {available: true, version};
+    } catch (error) {
+        return {available: false};
+    }
+}
+
+async function checkCorepack() {
+    try {
+        const {stdout} = await execa('corepack', ['--version'], {timeout: 5000});
+        const version = stdout.trim();
+        return {available: true, version};
+    } catch (error) {
+        return {available: false};
+    }
+}
+
+async function pnpmCheck(_, task) {
+    const pnpm = await checkPnpm();
+    if (pnpm.available) {
+        task.title = `${taskTitle} - found pnpm v${pnpm.version}`;
+        return;
+    }
+
+    const corepack = await checkCorepack();
+    if (!corepack.available) {
+        throw new SystemError({
+            message: `${chalk.red('pnpm is not installed and corepack is not available to provide it.')}`,
+            help: `Please install pnpm manually from ${chalk.underline.blue('https://pnpm.io/installation')} before continuing.`,
+            task: taskTitle
+        });
+    }
+
+    task.title = `${taskTitle} - found corepack v${corepack.version}`;
+}
+
+function enabled(ctx) {
+    // only enabled if version if specified in context from install/update commands
+    if (!ctx.version) {
+        return false;
+    }
+
+    return semver.gte(ctx.version, GHOST_VERSION_WITH_PNPM);
+}
+
+module.exports = {
+    title: taskTitle,
+    task: pnpmCheck,
+    enabled,
+    category: ['install', 'update']
+};

--- a/lib/commands/doctor/index.js
+++ b/lib/commands/doctor/index.js
@@ -2,55 +2,55 @@
 const Command = require('../../command');
 
 class DoctorCommand extends Command {
-    run(argv) {
+    async run(argv, ctx) {
         const intersection = require('lodash/intersection');
         const flatten = require('lodash/flatten');
         const checks = require('./checks');
 
-        return this.system.hook('doctor').then((extensionChecks) => {
-            const combinedChecks = checks.concat(flatten(extensionChecks).filter(Boolean));
+        const extensionChecks = await this.system.hook('doctor');
+        const combinedChecks = checks.concat(flatten(extensionChecks).filter(Boolean));
 
-            const checksToRun = argv.categories && argv.categories.length ?
-                combinedChecks.filter(check => intersection(argv.categories, check.category || []).length) :
-                combinedChecks;
+        const checksToRun = argv.categories && argv.categories.length ?
+            combinedChecks.filter(check => intersection(argv.categories, check.category || []).length) :
+            combinedChecks;
 
-            if (!checksToRun.length) {
-                if (!argv.quiet) {
-                    const additional = argv.categories && argv.categories.length ? ` for categories "${argv.categories.join(', ')}"` : '';
-                    this.ui.log(`No checks found to run${additional}.`);
-                }
-
-                return Promise.resolve();
+        if (!checksToRun.length) {
+            if (!argv.quiet) {
+                const additional = argv.categories && argv.categories.length ? ` for categories "${argv.categories.join(', ')}"` : '';
+                this.ui.log(`No checks found to run${additional}.`);
             }
 
-            let instance;
+            return;
+        }
 
-            if (
-                !argv.skipInstanceCheck &&
-                !(argv.categories && argv.categories.length === 1 && argv.categories[0] === 'install')
-            ) {
-                const findValidInstall = require('../../utils/find-valid-install');
+        let instance;
 
-                findValidInstall('doctor');
-                instance = this.system.getInstance();
-                instance.checkEnvironment();
-            } else {
-                instance = this.system.getInstance();
-            }
+        if (
+            !argv.skipInstanceCheck &&
+            !(argv.categories && argv.categories.length === 1 && argv.categories[0] === 'install')
+        ) {
+            const findValidInstall = require('../../utils/find-valid-install');
 
-            const context = {
-                argv: argv,
-                system: this.system,
-                instance: instance,
-                ui: this.ui,
-                local: argv.local || false,
-                // This is set to true whenever the command is `ghost doctor` itself,
-                // rather than something like `ghost start` or `ghost update`
-                isDoctorCommand: Boolean(argv._ && argv._.length && argv._[0] === 'doctor')
-            };
+            findValidInstall('doctor');
+            instance = this.system.getInstance();
+            instance.checkEnvironment();
+        } else {
+            instance = this.system.getInstance();
+        }
 
-            return this.ui.listr(checksToRun, context, {exitOnError: false});
-        });
+        const context = {
+            argv: argv,
+            system: this.system,
+            instance: instance,
+            ui: this.ui,
+            local: argv.local || false,
+            version: ctx && ctx.version, // used during install + update to toggle pnpm check
+            // This is set to true whenever the command is `ghost doctor` itself,
+            // rather than something like `ghost start` or `ghost update`
+            isDoctorCommand: Boolean(argv._ && argv._.length && argv._[0] === 'doctor')
+        };
+
+        return await this.ui.listr(checksToRun, context, {exitOnError: false});
     }
 }
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -42,19 +42,23 @@ class InstallCommand extends Command {
             this.ui.log(`Warning: Using release channel '${argv.channel}' in production is intended for testing purposes only.`, 'yellow');
         }
 
+        const context = {
+            argv: {...argv, version},
+            cliVersion: this.system.cliVersion
+        };
+
+        await this.ui.run(() => this.version(context), 'Checking for latest Ghost version');
+
         await this.runCommand(DoctorCommand, {
             categories: ['install'],
             skipInstanceCheck: true,
             quiet: true,
             ...argv,
             local
-        });
+        }, {version: context.version});
 
         try {
             await this.ui.listr([{
-                title: 'Checking for latest Ghost version',
-                task: this.version
-            }, {
                 title: 'Setting up install directory',
                 task: ensureStructure
             }, {
@@ -72,10 +76,7 @@ class InstallCommand extends Command {
                     title: 'Linking built-in themes',
                     task: this.defaultThemes
                 }], false)
-            }], {
-                argv: {...argv, version},
-                cliVersion: this.system.cliVersion
-            });
+            }], context);
         } catch (error) {
             this.cleanInstallDirectory();
             throw error;
@@ -103,7 +104,7 @@ class InstallCommand extends Command {
             exportVersion = parsed.version;
 
             if (semver.major(exportVersion) === 0) {
-                ctx.ui.log('Detected a v0.x export file. Installing latest v1.x version.', 'green');
+                this.ui.log('Detected a v0.x export file. Installing latest v1.x version.', 'green');
                 version = 'v1';
             } else if (!version) {
                 version = exportVersion;
@@ -111,7 +112,7 @@ class InstallCommand extends Command {
         }
 
         if (version && zip) {
-            ctx.ui.log('Warning: you specified both a specific version and an archive file. The version in the archive will be used.', 'yellow');
+            this.ui.log('Warning: you specified both a specific version and an archive file. The version in the archive will be used.', 'yellow');
         }
 
         let resolvedVersion = null;

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -117,9 +117,14 @@ class UpdateCommand extends Command {
             task: this.removeOldVersions
         }];
 
-        await this.runCommand(DoctorCommand, {quiet: true, categories: ['update'], ...argv});
-        await this.runCommand(MigrateCommand, {quiet: true});
         const result = await this.ui.run(() => this.version(context), 'Checking for latest Ghost version');
+
+        await this.runCommand(
+            DoctorCommand,
+            {quiet: true, categories: ['update'], ...argv},
+            {version: context.version}
+        );
+        await this.runCommand(MigrateCommand, {quiet: true});
 
         if (!result) {
             this.ui.log('All up to date!', 'cyan');

--- a/lib/tasks/install-dependencies.js
+++ b/lib/tasks/install-dependencies.js
@@ -99,7 +99,7 @@ module.exports = function installDependencies(ui, archiveFile) {
             let observable;
 
             if (usePnpm(ctx.installPath)) {
-                observable = pnpm(['install'], {
+                observable = pnpm(['install', '--prod', '--reporter=append-only'], {
                     cwd: ctx.installPath,
                     env: {NODE_ENV: 'production'},
                     observe: true

--- a/lib/utils/pnpm.js
+++ b/lib/utils/pnpm.js
@@ -1,7 +1,26 @@
 'use strict';
+const chalk = require('chalk');
 const execa = require('execa');
+const which = require('which');
 const {Observable} = require('rxjs');
-const {ProcessError} = require('../errors');
+const {ProcessError, SystemError} = require('../errors');
+
+function runPnpm(pnpmArgs, options) {
+    const hasPnpm = which.sync('pnpm', {nothrow: true});
+    if (hasPnpm) {
+        return execa('pnpm', pnpmArgs, options);
+    }
+
+    const hasCorepack = which.sync('corepack', {nothrow: true});
+    if (hasCorepack) {
+        return execa('corepack', ['pnpm'].concat(pnpmArgs), options);
+    }
+
+    return Promise.reject(new SystemError({
+        message: 'pnpm is not installed and corepack is not available to provide it.',
+        help: `Please install pnpm manually from ${chalk.underline.blue('https://pnpm.io/installation')} before continuing.`
+    }));
+}
 
 /**
  * Runs a pnpm command. Can return an Observer which allows
@@ -13,13 +32,10 @@ module.exports = function pnpm(pnpmArgs, options) {
     const observe = options.observe || false;
     delete options.observe;
 
-    pnpmArgs = pnpmArgs || [];
-
-    const execaOpts = {...options, preferLocal: true, localDir: __dirname};
-    const cp = execa('pnpm', pnpmArgs, execaOpts);
+    const cp = runPnpm(pnpmArgs || [], options);
 
     if (!observe) {
-        return cp.catch(error => Promise.reject(new ProcessError(error)));
+        return cp.catch(error => Promise.reject(error instanceof SystemError ? error : new ProcessError(error)));
     }
 
     return new Observable((observer) => {
@@ -31,7 +47,7 @@ module.exports = function pnpm(pnpmArgs, options) {
         cp.then(() => {
             observer.complete();
         }).catch((error) => {
-            observer.error(new ProcessError(error));
+            observer.error(error instanceof SystemError ? error : new ProcessError(error));
         });
     });
 };

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "tail": "2.2.6",
     "tough-cookie": "6.0.1",
     "validator": "7.2.0",
+    "which": "^6.0.1",
     "yargs": "17.7.2",
     "yarn": "1.22.22"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       validator:
         specifier: 7.2.0
         version: 7.2.0
+      which:
+        specifier: ^6.0.1
+        version: 6.0.1
       yargs:
         specifier: 17.7.2
         version: 17.7.2
@@ -2104,6 +2107,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -3643,6 +3650,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   widest-line@5.0.0:
@@ -5928,6 +5940,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@4.0.0: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-hook@3.0.0:
@@ -7507,6 +7521,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
 
   widest-line@5.0.0:
     dependencies:

--- a/test/unit/command-spec.js
+++ b/test/unit/command-spec.js
@@ -594,7 +594,7 @@ describe('Unit: Command', function () {
 
             await testInstance.runCommand(Test2Command, {argv: true});
             expect(runSpy.calledOnce).to.be.true;
-            expect(runSpy.calledWithExactly({argv: true})).to.be.true;
+            expect(runSpy.calledWithExactly({argv: true}, undefined)).to.be.true;
         });
 
         it('defaults to empty object if argv is not passed', async function () {
@@ -610,7 +610,7 @@ describe('Unit: Command', function () {
 
             await testInstance.runCommand(Test2Command);
             expect(runSpy.calledOnce).to.be.true;
-            expect(runSpy.calledWithExactly({})).to.be.true;
+            expect(runSpy.calledWithExactly({}, undefined)).to.be.true;
         });
     });
 });

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -31,12 +31,15 @@ describe('Unit: Commands > Install', function () {
     });
 
     describe('run', function () {
+        let uiRunStub;
+
         afterEach(() => {
             sinon.restore();
         });
 
         beforeEach(() => {
             sinon.stub(fs, 'removeSync');
+            uiRunStub = sinon.stub().callsFake(task => task());
         });
 
         it('rejects if directory is not empty', function () {
@@ -64,8 +67,11 @@ describe('Unit: Commands > Install', function () {
                 '../utils/dir-is-empty': dirEmptyStub,
                 './doctor': {doctorCommand: true}
             });
-            const testInstance = new InstallCommand({listr: listrStub}, {});
+            const testInstance = new InstallCommand({listr: listrStub, run: uiRunStub}, {});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
+            sinon.stub(testInstance, 'version').callsFake(async (ctx) => {
+                ctx.version = '1.0.0';
+            });
 
             return testInstance.run({argv: true}).then(() => {
                 expect(false, 'run should have rejected').to.be.true;
@@ -74,7 +80,8 @@ describe('Unit: Commands > Install', function () {
                 expect(runCommandStub.calledOnce).to.be.true;
                 expect(runCommandStub.calledWithExactly(
                     {doctorCommand: true},
-                    {categories: ['install'], skipInstanceCheck: true, quiet: true, argv: true, local: false}
+                    {categories: ['install'], skipInstanceCheck: true, quiet: true, argv: true, local: false},
+                    {version: '1.0.0'}
                 )).to.be.true;
                 expect(listrStub.calledOnce).to.be.true;
             });
@@ -90,8 +97,11 @@ describe('Unit: Commands > Install', function () {
             const InstallCommand = proxyquire(modulePath, {
                 '../utils/dir-is-empty': dirEmptyStub
             });
-            const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
+            const testInstance = new InstallCommand({listr: listrStub, run: uiRunStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
+            sinon.stub(testInstance, 'version').callsFake(async (ctx) => {
+                ctx.version = '1.0.0';
+            });
 
             return testInstance.run({version: 'local', zip: '', v1: true, 'check-empty': true}).then(() => {
                 expect(false, 'run should have rejected').to.be.true;
@@ -101,7 +111,8 @@ describe('Unit: Commands > Install', function () {
                 expect(listrStub.calledOnce).to.be.true;
                 expect(listrStub.args[0][1]).to.deep.equal({
                     argv: {version: null, zip: '', v1: true, 'check-empty': true},
-                    cliVersion: '1.0.0'
+                    cliVersion: '1.0.0',
+                    version: '1.0.0'
                 });
                 expect(setEnvironmentStub.calledOnce).to.be.true;
                 expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
@@ -118,8 +129,11 @@ describe('Unit: Commands > Install', function () {
             const InstallCommand = proxyquire(modulePath, {
                 '../utils/dir-is-empty': dirEmptyStub
             });
-            const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
+            const testInstance = new InstallCommand({listr: listrStub, run: uiRunStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
+            sinon.stub(testInstance, 'version').callsFake(async (ctx) => {
+                ctx.version = '1.0.0';
+            });
 
             return testInstance.run({version: '1.5.0', local: true, zip: '', v1: false, 'check-empty': true}).then(() => {
                 expect(false, 'run should have rejected').to.be.true;
@@ -129,7 +143,8 @@ describe('Unit: Commands > Install', function () {
                 expect(listrStub.calledOnce).to.be.true;
                 expect(listrStub.args[0][1]).to.deep.equal({
                     argv: {version: '1.5.0', zip: '', v1: false, local: true, 'check-empty': true},
-                    cliVersion: '1.0.0'
+                    cliVersion: '1.0.0',
+                    version: '1.0.0'
                 });
                 expect(setEnvironmentStub.calledOnce).to.be.true;
                 expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
@@ -146,8 +161,11 @@ describe('Unit: Commands > Install', function () {
             const InstallCommand = proxyquire(modulePath, {
                 '../utils/dir-is-empty': dirEmptyStub
             });
-            const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
+            const testInstance = new InstallCommand({listr: listrStub, run: uiRunStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
+            sinon.stub(testInstance, 'version').callsFake(async (ctx) => {
+                ctx.version = '1.0.0';
+            });
 
             return testInstance.run({version: '1.5.0', zip: '', v1: false, _: ['install', 'local'], 'check-empty': true}).then(() => {
                 expect(false, 'run should have rejected').to.be.true;
@@ -157,7 +175,8 @@ describe('Unit: Commands > Install', function () {
                 expect(listrStub.calledOnce).to.be.true;
                 expect(listrStub.args[0][1]).to.deep.equal({
                     argv: {version: '1.5.0', zip: '', v1: false, _: ['install', 'local'], 'check-empty': true},
-                    cliVersion: '1.0.0'
+                    cliVersion: '1.0.0',
+                    version: '1.0.0'
                 });
                 expect(setEnvironmentStub.calledOnce).to.be.true;
                 expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
@@ -174,8 +193,11 @@ describe('Unit: Commands > Install', function () {
             const InstallCommand = proxyquire(modulePath, {
                 '../utils/dir-is-empty': dirEmptyStub
             });
-            const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
+            const testInstance = new InstallCommand({listr: listrStub, run: uiRunStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
+            sinon.stub(testInstance, 'version').callsFake(async (ctx) => {
+                ctx.version = '1.0.0';
+            });
 
             return testInstance.run({version: 2, zip: '', v1: false, _: ['install', 'local'], 'check-empty': true}).then(() => {
                 expect(false, 'run should have rejected').to.be.true;
@@ -185,7 +207,8 @@ describe('Unit: Commands > Install', function () {
                 expect(listrStub.calledOnce).to.be.true;
                 expect(listrStub.args[0][1]).to.deep.equal({
                     argv: {version: '2', zip: '', v1: false, _: ['install', 'local'], 'check-empty': true},
-                    cliVersion: '1.0.0'
+                    cliVersion: '1.0.0',
+                    version: '1.0.0'
                 });
                 expect(setEnvironmentStub.calledOnce).to.be.true;
                 expect(setEnvironmentStub.calledWithExactly(true, true)).to.be.true;
@@ -203,7 +226,7 @@ describe('Unit: Commands > Install', function () {
                 '../tasks/ensure-structure': ensureStructureStub,
                 '../utils/dir-is-empty': dirEmptyStub
             });
-            const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0'});
+            const testInstance = new InstallCommand({listr: listrStub, run: uiRunStub}, {cliVersion: '1.0.0'});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
             const versionStub = sinon.stub(testInstance, 'version').resolves();
             const linkStub = sinon.stub(testInstance, 'link').resolves();
@@ -230,8 +253,11 @@ describe('Unit: Commands > Install', function () {
                 '../utils/dir-is-empty': dirEmptyStub,
                 './setup': {SetupCommand: true}
             });
-            const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
+            const testInstance = new InstallCommand({listr: listrStub, run: uiRunStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
+            sinon.stub(testInstance, 'version').callsFake(async (ctx) => {
+                ctx.version = '1.0.0';
+            });
 
             return testInstance.run({version: 'local', setup: true, zip: '', 'check-empty': true}).then(() => {
                 expect(dirEmptyStub.calledOnce).to.be.true;
@@ -255,8 +281,11 @@ describe('Unit: Commands > Install', function () {
                 '../utils/dir-is-empty': dirEmptyStub,
                 './setup': {SetupCommand: true}
             });
-            const testInstance = new InstallCommand({listr: listrStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
+            const testInstance = new InstallCommand({listr: listrStub, run: uiRunStub}, {cliVersion: '1.0.0', setEnvironment: setEnvironmentStub});
             const runCommandStub = sinon.stub(testInstance, 'runCommand').resolves();
+            sinon.stub(testInstance, 'version').callsFake(async (ctx) => {
+                ctx.version = '1.0.0';
+            });
 
             return testInstance.run({version: 'local', setup: true, zip: '', 'check-empty': false}).then(() => {
                 expect(dirEmptyStub.calledOnce).to.be.true;
@@ -333,8 +362,8 @@ describe('Unit: Commands > Install', function () {
             });
             const log = sinon.stub();
 
-            const testInstance = new InstallCommand({}, {});
-            const context = {argv: {version: '1.0.0', zip: '/some/zip/file.zip'}, ui: {log}};
+            const testInstance = new InstallCommand({log}, {});
+            const context = {argv: {version: '1.0.0', zip: '/some/zip/file.zip'}};
 
             await testInstance.version(context);
             expect(resolveVersion.called).to.be.false;
@@ -354,8 +383,8 @@ describe('Unit: Commands > Install', function () {
             });
             const log = sinon.stub();
 
-            const testInstance = new InstallCommand({}, {});
-            const context = {argv: {version: '2.0.0', fromExport: 'test-export.json'}, ui: {log}};
+            const testInstance = new InstallCommand({log}, {});
+            const context = {argv: {version: '2.0.0', fromExport: 'test-export.json'}};
 
             await testInstance.version(context);
             expect(resolveVersion.calledOnceWithExactly('v1', null, {v1: undefined, force: undefined, channel: undefined})).to.be.true;
@@ -374,8 +403,8 @@ describe('Unit: Commands > Install', function () {
             });
             const log = sinon.stub();
 
-            const testInstance = new InstallCommand({}, {});
-            const context = {argv: {fromExport: 'test-export.json'}, ui: {log}};
+            const testInstance = new InstallCommand({log}, {});
+            const context = {argv: {fromExport: 'test-export.json'}};
 
             await testInstance.version(context);
             expect(resolveVersion.calledOnceWithExactly('2.0.0', null, {v1: undefined, force: undefined, channel: undefined})).to.be.true;
@@ -394,8 +423,8 @@ describe('Unit: Commands > Install', function () {
             });
             const log = sinon.stub();
 
-            const testInstance = new InstallCommand({}, {});
-            const context = {argv: {version: 'v2', fromExport: 'test-export.json'}, ui: {log}};
+            const testInstance = new InstallCommand({log}, {});
+            const context = {argv: {version: 'v2', fromExport: 'test-export.json'}};
 
             try {
                 await testInstance.version(context);

--- a/test/unit/tasks/install-dependencies-spec.js
+++ b/test/unit/tasks/install-dependencies-spec.js
@@ -158,7 +158,7 @@ describe('Unit: Tasks > install-dependencies', function () {
             expect(downloadTaskStub.calledOnce).to.be.true;
             expect(pnpmStub.calledOnce).to.be.true;
             expect(yarnStub.called).to.be.false;
-            expect(pnpmStub.args[0][0]).to.deep.equal(['install']);
+            expect(pnpmStub.args[0][0]).to.deep.equal(['install', '--prod', '--reporter=append-only']);
             expect(pnpmStub.args[0][1]).to.deep.equal({
                 cwd: '/var/www/ghost/versions/1.5.0',
                 env: {NODE_ENV: 'production'},

--- a/test/unit/utils/pnpm-spec.js
+++ b/test/unit/utils/pnpm-spec.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const {isObservable} = require('rxjs');
 const {getReadableStream} = require('../../utils/stream');
-const {ProcessError} = require('../../../lib/errors');
+const {ProcessError, SystemError} = require('../../../lib/errors');
 
 const modulePath = '../../../lib/utils/pnpm';
 
@@ -24,6 +24,35 @@ describe('Unit: pnpm', function () {
         });
     });
 
+    it('uses corepack pnpm when pnpm not available', function () {
+        const execa = sinon.stub().resolves();
+        const which = {
+            sync: sinon.fake(cmd => (cmd !== 'corepack' ? null : '/usr/bin/corepack'))
+        };
+        const pnpm = setup({execa, which});
+
+        return pnpm().then(function () {
+            expect(execa.calledOnce).to.be.true;
+            expect(execa.args[0][0]).to.equal('corepack');
+            expect(execa.args[0][1]).to.deep.equal(['pnpm']);
+        });
+    });
+
+    it('throws SystemError when neither pnpm nor corepack are available', function () {
+        const which = {
+            sync: sinon.stub().returns(null)
+        };
+        const pnpm = setup({which});
+
+        return pnpm().then(() => {
+            expect(false, 'Promise should have rejected').to.be.true;
+        }).catch((error) => {
+            expect(which.sync.calledWith('pnpm', {nothrow: true})).to.be.true;
+            expect(which.sync.calledWith('corepack', {nothrow: true})).to.be.true;
+            expect(error).to.be.an.instanceOf(SystemError);
+        });
+    });
+
     it('spawns pnpm process with correct arguments', function () {
         const execa = sinon.stub().resolves();
         const pnpm = setup({execa});
@@ -31,20 +60,6 @@ describe('Unit: pnpm', function () {
         return pnpm(['install']).then(function () {
             expect(execa.calledOnce).to.be.true;
             expect(execa.args[0][1]).to.deep.equal(['install']);
-        });
-    });
-
-    it('uses preferLocal and localDir like yarn', function () {
-        const execa = sinon.stub().resolves();
-        const pnpm = setup({execa});
-
-        return pnpm([], {cwd: 'test'}).then(function () {
-            expect(execa.calledOnce).to.be.true;
-            const opts = execa.args[0][2];
-            expect(opts).to.be.an('object');
-            expect(opts.cwd).to.equal('test');
-            expect(opts.preferLocal).to.be.true;
-            expect(opts.localDir).to.be.a('string');
         });
     });
 


### PR DESCRIPTION
closes #2125,#2126
- refactor doctor command to use async function
- allow runCommand to pass context through
- refactor install/update checks to pass resolved version to doctor checks
- add new pnpm check that checks for pnpm installation, or enables it via corepack
- update pnpm install command to only install prod dependencies