### PR TITLE
Fixed Corepack pnpm signature error handling

### DIFF
--- a/lib/tasks/install-dependencies.js
+++ b/lib/tasks/install-dependencies.js
@@ -101,7 +101,7 @@ module.exports = function installDependencies(ui, archiveFile) {
             if (usePnpm(ctx.installPath)) {
                 observable = pnpm(['install', '--prod', '--reporter=append-only'], {
                     cwd: ctx.installPath,
-                    env: {NODE_ENV: 'production'},
+                    env: {NODE_ENV: 'production', COREPACK_DEFAULT_TO_LATEST: '0'},
                     observe: true
                 });
             } else {

--- a/lib/utils/pnpm.js
+++ b/lib/utils/pnpm.js
@@ -22,6 +22,34 @@ function runPnpm(pnpmArgs, options) {
     }));
 }
 
+function isCorepackSignatureError(error) {
+    const output = [
+        error.message,
+        error.stderr,
+        error.stdout,
+        error.shortMessage,
+        error.originalMessage
+    ].filter(Boolean).join('\n');
+
+    return output.includes('Cannot find matching keyid') && output.includes('corepack');
+}
+
+function toPnpmError(error) {
+    if (error instanceof SystemError) {
+        return error;
+    }
+
+    if (isCorepackSignatureError(error)) {
+        return new SystemError({
+            message: 'Corepack could not verify pnpm because its package-signing keys are out of date.',
+            help: 'Update Corepack, enable it, and activate pnpm before running the Ghost command again.',
+            suggestion: 'npm install -g corepack@latest && corepack enable'
+        });
+    }
+
+    return new ProcessError(error);
+}
+
 /**
  * Runs a pnpm command. Can return an Observer which allows
  * listr to output the current status of pnpm
@@ -35,7 +63,7 @@ module.exports = function pnpm(pnpmArgs, options) {
     const cp = runPnpm(pnpmArgs || [], options);
 
     if (!observe) {
-        return cp.catch(error => Promise.reject(error instanceof SystemError ? error : new ProcessError(error)));
+        return cp.catch(error => Promise.reject(toPnpmError(error)));
     }
 
     return new Observable((observer) => {
@@ -47,7 +75,7 @@ module.exports = function pnpm(pnpmArgs, options) {
         cp.then(() => {
             observer.complete();
         }).catch((error) => {
-            observer.error(error instanceof SystemError ? error : new ProcessError(error));
+            observer.error(toPnpmError(error));
         });
     });
 };

--- a/test/unit/tasks/install-dependencies-spec.js
+++ b/test/unit/tasks/install-dependencies-spec.js
@@ -161,7 +161,7 @@ describe('Unit: Tasks > install-dependencies', function () {
             expect(pnpmStub.args[0][0]).to.deep.equal(['install', '--prod', '--reporter=append-only']);
             expect(pnpmStub.args[0][1]).to.deep.equal({
                 cwd: '/var/www/ghost/versions/1.5.0',
-                env: {NODE_ENV: 'production'},
+                env: {NODE_ENV: 'production', COREPACK_DEFAULT_TO_LATEST: '0'},
                 observe: true
             });
         });
@@ -229,7 +229,7 @@ describe('Unit: Tasks > install-dependencies', function () {
 
         return installDependencies({listr: listrStub}).then(() => {
             const pnpmOpts = pnpmStub.args[0][1];
-            expect(pnpmOpts.env).to.deep.equal({NODE_ENV: 'production'});
+            expect(pnpmOpts.env).to.deep.equal({NODE_ENV: 'production', COREPACK_DEFAULT_TO_LATEST: '0'});
             expect(pnpmOpts.env).to.not.have.property('YARN_IGNORE_PATH');
         });
     });

--- a/test/unit/utils/pnpm-spec.js
+++ b/test/unit/utils/pnpm-spec.js
@@ -96,6 +96,22 @@ describe('Unit: pnpm', function () {
         });
     });
 
+    it('returns a helpful system error when corepack cannot verify pnpm signatures', function () {
+        const execa = sinon.stub().rejects({
+            message: 'Command failed: pnpm install',
+            stderr: '/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21535\nError: Cannot find matching keyid'
+        });
+        const pnpm = setup({execa});
+
+        return pnpm(['install']).then(() => {
+            expect(false, 'Promise should have rejected').to.be.true;
+        }).catch((error) => {
+            expect(error).to.be.an.instanceOf(SystemError);
+            expect(error.message).to.equal('Corepack could not verify pnpm because its package-signing keys are out of date.');
+            expect(error.options.suggestion).to.equal('npm install -g corepack@latest && corepack enable');
+        });
+    });
+
     describe('can return observables', function () {
         it('ends properly', function () {
             const execa = sinon.stub().callsFake(() => {
@@ -149,6 +165,35 @@ describe('Unit: pnpm', function () {
                 expect(subscriber.next.called).to.be.false;
                 expect(subscriber.error.calledOnce).to.be.true;
                 expect(subscriber.error.args[0][0]).to.be.an.instanceOf(ProcessError);
+                expect(subscriber.complete.called).to.be.false;
+            });
+        });
+
+        it('passes corepack signature errors through as helpful system errors', function () {
+            const execa = sinon.stub().callsFake(() => {
+                const promise = Promise.reject({
+                    message: 'Command failed: pnpm install',
+                    stderr: '/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21535\nError: Cannot find matching keyid'
+                });
+                promise.stdout = getReadableStream();
+                return promise;
+            });
+            const pnpm = setup({execa});
+
+            const res = pnpm([], {observe: true});
+            const subscriber = {
+                next: sinon.stub(),
+                error: sinon.stub(),
+                complete: sinon.stub()
+            };
+
+            res.subscribe(subscriber);
+
+            return res.toPromise().catch(() => {
+                expect(subscriber.error.calledOnce).to.be.true;
+                expect(subscriber.error.args[0][0]).to.be.an.instanceOf(SystemError);
+                expect(subscriber.error.args[0][0].options.suggestion).to.contain('corepack@latest');
+                expect(subscriber.error.args[0][0].options.suggestion).to.not.contain('prepare');
                 expect(subscriber.complete.called).to.be.false;
             });
         });


### PR DESCRIPTION
## Summary
- prevent Corepack from defaulting to pnpm@latest during Ghost dependency installs
- translate Corepack `Cannot find matching keyid` failures into actionable CLI guidance
- add unit coverage for the pnpm install env and signature-error handling

## Why
Some early pnpm-based Ghost releases can be installed from artifacts that contain `pnpm-lock.yaml` but do not expose package manager metadata. In that path, Corepack may resolve pnpm@latest and older bundled Corepack versions can fail with an opaque signing-key error.

## Testing
- `pnpm test -- --grep "Unit: pnpm|install-dependencies"`
