### PR TITLE
Fix: prevent global environment pollution in multi-site ls check

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -202,10 +202,13 @@ class Instance {
         if (!this._cliConfig.has('running')) {
             const currentEnvironment = this.system.development;
 
-            const envIsRunning = async (environment) => {
+			const envIsRunning = async (environment) => {
                 if (!Config.exists(path.join(this.dir, `config.${environment}.json`))) {
                     return false;
                 }
+
+                // 1. Save original environment state
+                const originalEnv = this.system.environment;
 
                 this.system.setEnvironment(environment === 'development');
                 const running = await this.process.isRunning(this.dir);
@@ -213,9 +216,12 @@ class Instance {
                     this._cliConfig.set('running', environment).save();
                 }
 
+                // 2. Restore original environment state
+                this.system.setEnvironment(originalEnv === 'development');
+
                 return running;
             };
-
+			
             const production = await envIsRunning('production');
             if (production) {
                 return true;
@@ -386,7 +392,7 @@ class Instance {
             dir: this.dir.replace(os.homedir(), '~'),
             running: true,
             version: this.version,
-            mode: this.system.environment,
+            mode: this._cliConfig.get('running') || this.system.environment,
             url: this.config.get('url'),
             port: this.config.get('server.port'),
             process: this.process.name


### PR DESCRIPTION
**The Issue:**
In environments managing multiple Ghost instances, the `ghost ls` command misreports the environment mode of running production instances if a preceding instance in the registry is stopped.

**Root Cause Analysis:**
1. **State Pollution:** During the `isRunning()` check for a stopped site, the `envIsRunning` helper is called to probe for a development process. This calls `this.system.setEnvironment(true)`, which globally mutates the singleton `System` object without restoring it.
2. **Race Condition:** Because `ghost ls` evaluates all instances concurrently using `Promise.all()`, a stopped site can temporarily flip the global `this.system.environment` variable in the exact microsecond a running site evaluates its `summary()`.

**The Fix:**
- Modified `envIsRunning` in `lib/instance.js` to save and restore the global environment state before and after the probe.
- Modified `summary()` in `lib/instance.js` to prioritize reading the local instance configuration (`this._cliConfig.get('running')`) rather than relying exclusively on the thread-unsafe global `this.system.environment`.