### PR TITLE
Fix: prevent environment hijacking/crash in multi-site setups

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -250,9 +250,14 @@ class Instance {
      * @method checkEnvironment
      * @public
      */
-    checkEnvironment() {
+	checkEnvironment() {
+        // Count how many instances this CLI is managing
+        const instances = this.system.globalConfig.get('instances', {});
+        const isMultiSite = Object.keys(instances).length > 1;
+
         if (
             this.system.production &&
+            !isMultiSite &&
             Config.exists(path.join(this.dir, 'config.development.json')) &&
             !Config.exists(path.join(this.dir, 'config.production.json'))
         ) {


### PR DESCRIPTION
**The Issue:**
In multi-site environments, the CLI's `checkEnvironment` shortcut can globally hijack the process environment. If one registered site is missing a `config.production.json` while others are running, the CLI may attempt to force a global development mode, leading to crashes or state pollution.

**The Fix:**
Modified `checkEnvironment` in `lib/instance.js` to only allow the automatic development-mode fallback if the CLI is managing a single instance. In multi-site configurations, the CLI now bypasses this shortcut, maintaining environment stability across the stack.