### PR TITLE
Revert to pnpm@10

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,5 @@
     "standard-version": "4.3.0",
     "tmp": "0.2.5"
   },
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
+  "packageManager": "pnpm@10.34.1+sha512.b58fbde6dca66a929538021581f648b4570b6ca19b18e7cbd7f2c07a7b24454155388dacdf08f2af3678e88a6d1fe04f9d609df24bf51735a060ea041b374ab7"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": ["pnpm"],
+      "allowedVersions": "<11"
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "automerge": true,
       "automergeType": "branch"


### PR DESCRIPTION
- pnpm 11 drops support for node 20, so hold off on updating until we drop support for node 20