### PR TITLE
fix typos within comments and strings inside .md and .js files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -640,7 +640,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### Bug Fixes
 
 * **engines:** update node version restrictions to match Ghost ([c45909d](https://github.com/TryGhost/Ghost-CLI/commit/c45909d))
-* **utils:** prerelease statisfies engine definition ([8bfcc38](https://github.com/TryGhost/Ghost-CLI/commit/8bfcc38))
+* **utils:** prerelease satisfies engine definition ([8bfcc38](https://github.com/TryGhost/Ghost-CLI/commit/8bfcc38))
 
 
 
@@ -1317,7 +1317,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* **extensions:** remove unecessary getters from systemd and nginx extensions ([f5f6e05](https://github.com/TryGhost/Ghost-CLI/commit/f5f6e05))
+* **extensions:** remove unnecessary getters from systemd and nginx extensions ([f5f6e05](https://github.com/TryGhost/Ghost-CLI/commit/f5f6e05))
 * **instance:** clean up config usage around application (#254) ([22c804c](https://github.com/TryGhost/Ghost-CLI/commit/22c804c))
 * **setup:** reset setup default to true ([7c4cdf3](https://github.com/TryGhost/Ghost-CLI/commit/7c4cdf3))
 * **systemd:** fix is-enabled error handling in systemd process manager ([ff6cfba](https://github.com/TryGhost/Ghost-CLI/commit/ff6cfba))

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -8,7 +8,7 @@ const findExtensions = require('./utils/find-extensions');
 
 const debug = createDebug('ghost-cli:bootstrap');
 
-// Extra alises for commands
+// Extra aliases for commands
 const extraAliases = {
     '--version': 'version',
     '-v': 'version',

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -40,7 +40,7 @@ class CliError extends Error {
 
                 // TODO: we receive all possible properties now, except the excluded ones above
                 // Currently we're logging only the message and the stack property.
-                // This part of the code could probably be simplyfied if we won't need other
+                // This part of the code could probably be simplified if we won't need other
                 // properties in the future
                 originalError[property] = options.err[property];
             });

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -282,7 +282,7 @@ class Instance {
     }
 
     /**
-     * Gets a list of availble configurations for this instance
+     * Gets a list of available configurations for this instance
      *
      * @method getAvailableConfigs
      * @return {Promise<{[s: string]: Config}>}

--- a/lib/tasks/configure/get-prompts.js
+++ b/lib/tasks/configure/get-prompts.js
@@ -4,7 +4,7 @@ const {validate: validateUrl, ensureProtocol} = require('../../utils/url');
 /**
  * Gets inquirer prompts based on passed argv and current config values
  *
- * @param {Config} config Config instane
+ * @param {Config} config Config instance
  * @param {Object} argv Argv options
  */
 module.exports = function getPrompts(config, argv, environment) {

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -372,7 +372,7 @@ class UI {
     }
 
     /**
-     * Error handler for the CLI. Takes a given error and outputs a formated and more human-readable
+     * Error handler for the CLI. Takes a given error and outputs a formatted and more human-readable
      * error to the specified out stream.
      *
      * @param {Error|Object} error Error to handle
@@ -469,7 +469,7 @@ class UI {
             this.log(`\nTry running ${(chalk.cyan('ghost doctor'))} to check your system for known issues.`);
         } else if (error !== false) {
             // If the error is false, we're just exiting (makes the promise chains easier)
-            this.log('An unknown error occured.', null, true);
+            this.log('An unknown error occurred.', null, true);
             this.log(`\nTry running ${(chalk.cyan('ghost doctor'))} to check your system for known issues.`);
         }
     }
@@ -478,7 +478,7 @@ class UI {
      * Helper method to format the debug information whenever an error occurs
      *
      * @param {System} system System instance
-     * @return string Formated debug info
+     * @return string Formatted debug info
      *
      * @method _formatString
      * @private

--- a/test/unit/commands/migrate-spec.js
+++ b/test/unit/commands/migrate-spec.js
@@ -70,7 +70,7 @@ describe('Unit: Commands > Migrate', function () {
         });
     });
 
-    it('quiet supresses output', function () {
+    it('quiet suppresses output', function () {
         const {cmd, instance, parse} = build([]);
 
         return cmd.run({quiet: true}).then(() => {

--- a/test/unit/tasks/install-dependencies-spec.js
+++ b/test/unit/tasks/install-dependencies-spec.js
@@ -70,7 +70,7 @@ describe('Unit: Tasks > install-dependencies', function () {
         });
     });
 
-    it('base function calls subtasks and yarn util correctly with GHOST_NODE_VERISON_CHECK set', function () {
+    it('base function calls subtasks and yarn util correctly with GHOST_NODE_VERSION_CHECK set', function () {
         const yarnStub = sinon.stub().returns(new Observable(o => o.complete()));
         const installDependencies = proxyquire(modulePath, {
             '../utils/yarn': yarnStub
@@ -306,7 +306,7 @@ describe('Unit: Tasks > install-dependencies', function () {
     });
 
     describe('dist subtask', function () {
-        it('rejects if Ghost version isn\'t compatible with the current Node version and GHOST_NODE_VERISON_CHECK is not set', function () {
+        it('rejects if Ghost version isn\'t compatible with the current Node version and GHOST_NODE_VERSION_CHECK is not set', function () {
             const data = {
                 engines: {node: '^0.10.0'},
                 dist: {shasum: 'asdf1234', tarball: 'something.tgz'}
@@ -327,7 +327,7 @@ describe('Unit: Tasks > install-dependencies', function () {
             });
         });
 
-        it('resolves if Ghost version isn\'t compatible with the current Node version and GHOST_NODE_VERISON_CHECK is set', function () {
+        it('resolves if Ghost version isn\'t compatible with the current Node version and GHOST_NODE_VERSION_CHECK is set', function () {
             const data = {
                 engines: {node: '^0.10.0'},
                 dist: {shasum: 'asdf1234', tarball: 'something.tgz'}

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -927,7 +927,7 @@ describe('Unit: UI', function () {
 
             expect(formatDebug.calledOnce).to.be.true;
             expect(log.calledTwice).to.be.true;
-            expect(log.args[0][0]).to.match(/error occured/);
+            expect(log.args[0][0]).to.match(/error occurred/);
             expect(stripAnsi(log.args[1][0])).to.match(/Try running ghost doctor to check your system for known issues./);
             expect(log.args[0][2]).to.be.true;
         });

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -645,7 +645,7 @@ describe('Unit: UI', function () {
             ui.log('my message', 'testing', 'green', 'link');
         });
 
-        it('displays a multi-line help message with extra line when called with 5 args', function (done) {
+        it('displays a multi-line help message with exta line when called with 5 args', function (done) {
             const stdout = streamTestUtils.getWritableStream(function (output) {
                 expect(output, 'output exists').to.be.ok;
                 expect(output, 'output value').to.include(chalk.white(`\nmy message: \n\n    ${chalk.yellow('testing')}\n`));

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -645,7 +645,7 @@ describe('Unit: UI', function () {
             ui.log('my message', 'testing', 'green', 'link');
         });
 
-        it('displays a multi-line help message with exta line when called with 5 args', function (done) {
+        it('displays a multi-line help message with extra line when called with 5 args', function (done) {
             const stdout = streamTestUtils.getWritableStream(function (output) {
                 expect(output, 'output exists').to.be.ok;
                 expect(output, 'output value').to.include(chalk.white(`\nmy message: \n\n    ${chalk.yellow('testing')}\n`));


### PR DESCRIPTION
Hello,

This PR addresses typo's within comments and strings inside .js and .md files.
Fixes were manually verified to be confinined only within strings and comments and do not effect any logic.
Tests were run using `pnpm test` and all tests passed.

