### PR TITLE
perf: cache CLI update check results

### DIFF
--- a/lib/utils/pre-checks.js
+++ b/lib/utils/pre-checks.js
@@ -6,12 +6,38 @@ const latestVersion = require('latest-version');
 const pkg = require('../../package.json');
 const getProxyAgent = require('./get-proxy-agent');
 
+const configDir = path.join(os.homedir(), '.config', 'ghost-cli');
+const cacheFile = path.join(configDir, 'update-cache.json');
 const configstore = path.join(os.homedir(), '.config');
 
 async function updateCheck({ui}) {
-    const latest = await latestVersion(pkg.name, {
-        agent: getProxyAgent()
-    });
+    let latest;
+    const now = Date.now();
+    const cacheTTL = 24 * 60 * 60 * 1000; // 24 hours
+
+    try {
+        if (await fs.pathExists(cacheFile)) {
+            const cache = await fs.readJson(cacheFile);
+            if (now - cache.timestamp < cacheTTL) {
+                latest = cache.version;
+            }
+        }
+    } catch (e) {
+        // Ignore cache errors
+    }
+
+    if (!latest) {
+        try {
+            latest = await latestVersion(pkg.name, {
+                agent: getProxyAgent()
+            });
+            await fs.ensureDir(configDir);
+            await fs.writeJson(cacheFile, {version: latest, timestamp: now});
+        } catch (e) {
+            // Ignore errors (e.g. offline)
+            return;
+        }
+    }
 
     if (semver.lt(pkg.version, latest)) {
         const chalk = require('chalk');
@@ -19,7 +45,7 @@ async function updateCheck({ui}) {
         ui.log(
             'You are running an outdated version of Ghost-CLI.\n' +
             'It is recommended that you upgrade before continuing.\n' +
-            `Run ${chalk.cyan('`npm install -g ghost-cli@latest`')} to upgrade.\n`,
+            `Run ${chalk.cyan('`npm install -g ghost-cli @latest`')} to upgrade.\n`,
             'yellow'
         );
     }


### PR DESCRIPTION
This PR introduces a 24-hour cache for the Ghost-CLI update check. Previously, the CLI would fetch the latest version of itself from npm on every command invocation, causing unnecessary network traffic and latency, particularly for users with high-latency connections. The check result is now stored in `~/.config/ghost-cli/update-cache.json` and persisted for 24 hours, significantly improving command responsiveness.

Technical Impact: Reduces redundant network calls and CLI execution overhead.