### PR TITLE
🐛 Improved local process isRunning/stop pid check

### DIFF
--- a/lib/utils/local-process.js
+++ b/lib/utils/local-process.js
@@ -98,37 +98,48 @@ Ensure the content folder has correct permissions and try again.`));
      * @method stop
      * @public
      */
-    stop(cwd) {
+    async stop(cwd) {
         const fkill = require('fkill').default;
         const errors = require('../errors');
 
+        const pidfile = path.join(cwd, PID_FILE);
         let pid;
 
         try {
-            pid = parseInt(fs.readFileSync(path.join(cwd, PID_FILE)));
+            pid = parseInt(fs.readFileSync(pidfile));
         } catch (e) {
             if (e.code === 'ENOENT') {
-                // pid was not found, exit
-                return Promise.resolve();
+                // pidfile was not found, nothing to stop
+                return;
             }
 
-            return Promise.reject(new errors.CliError({
+            throw new errors.CliError({
                 message: 'An unexpected error occurred when reading the pidfile.',
                 error: e
-            }));
+            });
         }
 
-        return fkill(pid, {force: this.system.platform.windows, waitForExit: 30000}).catch((error) => {
+        // If we can't confirm the recorded pid is still a running Ghost process
+        // (stale/copied pidfile, or the pid was reused by an unrelated process),
+        // don't kill anything — just clean up the pidfile.
+        if (!await this._isGhostProcess(pid)) {
+            fs.removeSync(pidfile);
+            return;
+        }
+
+        try {
+            await fkill(pid, {force: this.system.platform.windows, waitForExit: 30000});
+        } catch (error) {
             // TODO: verify windows outputs same error message as mac/linux
             if (!error.message.match(/No such process/)) {
-                return Promise.reject(new errors.CliError({
+                throw new errors.CliError({
                     message: 'An unexpected error occurred while stopping Ghost.',
                     err: error
-                }));
+                });
             }
-        }).then(() => {
-            fs.removeSync(path.join(cwd, PID_FILE));
-        });
+        }
+
+        fs.removeSync(pidfile);
     }
 
     /**
@@ -170,9 +181,7 @@ Ensure the content folder has correct permissions and try again.`));
      * @method isRunning
      * @public
      */
-    isRunning(cwd) {
-        const isRunning = require('is-running');
-
+    async isRunning(cwd) {
         const pidfile = path.join(cwd, PID_FILE);
 
         if (!fs.existsSync(pidfile)) {
@@ -182,7 +191,7 @@ Ensure the content folder has correct permissions and try again.`));
         }
 
         const pid = parseInt(fs.readFileSync(pidfile));
-        const running = isRunning(pid);
+        const running = await this._isGhostProcess(pid);
 
         if (!running) {
             // If not running, cleanup the pid file
@@ -190,6 +199,35 @@ Ensure the content folder has correct permissions and try again.`));
         }
 
         return running;
+    }
+
+    /**
+     * Verifies that a pid maps to a live process that is actually this Ghost
+     * instance, rather than a dead pid or one the OS has reused for an unrelated
+     * process. Works on any OS via systeminformation.
+     *
+     * The process is spawned as `node <ghost-bin> run`, where the ghost binary
+     * is named `ghost`, so its command line contains `ghost run`. We confirm the
+     * pid exists and that its command line carries that signature.
+     *
+     * @param {Number} pid
+     * @return {Promise<Boolean>} whether the pid is a running Ghost process
+     */
+    async _isGhostProcess(pid) {
+        if (!pid || Number.isNaN(pid)) {
+            return false;
+        }
+
+        const sysinfo = require('systeminformation');
+        const {list} = await sysinfo.processes();
+        const proc = list.find(p => p.pid === pid);
+
+        if (!proc) {
+            return false;
+        }
+
+        const commandLine = `${proc.command || ''} ${proc.params || ''}`;
+        return commandLine.includes('ghost run');
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "https-proxy-agent": "9.1.0",
     "ini": "7.0.0",
     "inquirer": "14.0.2",
-    "is-running": "2.1.0",
     "jsonwebtoken": "9.0.3",
     "latest-version": "5.1.0",
     "listr": "0.14.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       inquirer:
         specifier: 14.0.2
         version: 14.0.2(@types/node@26.0.0)
-      is-running:
-        specifier: 2.1.0
-        version: 2.1.0
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -2045,9 +2042,6 @@ packages:
   is-retry-allowed@1.2.0:
     resolution: {integrity: sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==}
     engines: {node: '>=0.10.0'}
-
-  is-running@2.1.0:
-    resolution: {integrity: sha512-mjJd3PujZMl7j+D395WTIO5tU5RIDBfVSRtRR4VOJou3H66E38UjbjvDGh3slJzPuolsb+yQFqwHNNdyp5jg3w==}
 
   is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
@@ -5896,8 +5890,6 @@ snapshots:
   is-property@1.0.2: {}
 
   is-retry-allowed@1.2.0: {}
-
-  is-running@2.1.0: {}
 
   is-stream@1.1.0: {}
 

--- a/test/unit/utils/local-process-spec.js
+++ b/test/unit/utils/local-process-spec.js
@@ -49,53 +49,49 @@ describe('Unit: Utils > local-process', function () {
     });
 
     describe('isRunning', function () {
-        it('returns false if pidfile doesn\'t exist', function () {
+        it('returns false if pidfile doesn\'t exist', async function () {
             const existsStub = sinon.stub(fs, 'existsSync').returns(false);
             const LocalProcess = require(modulePath);
             const instance = new LocalProcess({}, {}, {});
-            const result = instance.isRunning('/var/www/ghost');
+            const result = await instance.isRunning('/var/www/ghost');
 
             expect(result).to.be.false;
             expect(existsStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
         });
 
-        it('fetches pid from file, removes pidfile and returns false if not running', function () {
+        it('fetches pid from file, removes pidfile and returns false if not a ghost process', async function () {
             const existsStub = sinon.stub(fs, 'existsSync').returns(true);
             const readFileStub = sinon.stub(fs, 'readFileSync').returns('42');
             const removeStub = sinon.stub(fs, 'removeSync');
-            const isRunningStub = sinon.stub().returns(false);
 
-            const LocalProcess = proxyquire(modulePath, {
-                'is-running': isRunningStub
-            });
-
+            const LocalProcess = require(modulePath);
             const instance = new LocalProcess({}, {}, {});
-            const result = instance.isRunning('/var/www/ghost');
+            const ghostProcessStub = sinon.stub(instance, '_isGhostProcess').resolves(false);
+
+            const result = await instance.isRunning('/var/www/ghost');
 
             expect(result).to.be.false;
             expect(existsStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
             expect(readFileStub.calledOnce).to.be.true;
-            expect(isRunningStub.calledWithExactly(42)).to.be.true;
+            expect(ghostProcessStub.calledWithExactly(42)).to.be.true;
             expect(removeStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
         });
 
-        it('fetches pid from file, returns true if running', function () {
+        it('fetches pid from file, returns true if running ghost process', async function () {
             const existsStub = sinon.stub(fs, 'existsSync').returns(true);
             const readFileStub = sinon.stub(fs, 'readFileSync').returns('42');
             const removeStub = sinon.stub(fs, 'removeSync');
-            const isRunningStub = sinon.stub().returns(true);
 
-            const LocalProcess = proxyquire(modulePath, {
-                'is-running': isRunningStub
-            });
-
+            const LocalProcess = require(modulePath);
             const instance = new LocalProcess({}, {}, {});
-            const result = instance.isRunning('/var/www/ghost');
+            const ghostProcessStub = sinon.stub(instance, '_isGhostProcess').resolves(true);
+
+            const result = await instance.isRunning('/var/www/ghost');
 
             expect(result).to.be.true;
             expect(existsStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
             expect(readFileStub.calledOnce).to.be.true;
-            expect(isRunningStub.calledWithExactly(42)).to.be.true;
+            expect(ghostProcessStub.calledWithExactly(42)).to.be.true;
             expect(removeStub.called).to.be.false;
         });
     });
@@ -285,6 +281,27 @@ describe('Unit: Utils > local-process', function () {
             });
         });
 
+        it('does not kill the process but removes the pidfile if not a ghost process', async function () {
+            const readFileStub = sinon.stub(fs, 'readFileSync').returns('42');
+            const removeStub = sinon.stub(fs, 'removeSync');
+            const fkillStub = sinon.stub();
+
+            const LocalProcess = proxyquire(modulePath, {
+                fkill: {default: fkillStub}
+            });
+            const instance = new LocalProcess({}, {
+                platform: {macos: true, windows: false}
+            }, {});
+            const ghostProcessStub = sinon.stub(instance, '_isGhostProcess').resolves(false);
+
+            await instance.stop('/var/www/ghost');
+
+            expect(readFileStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
+            expect(ghostProcessStub.calledWithExactly(42)).to.be.true;
+            expect(fkillStub.called).to.be.false;
+            expect(removeStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
+        });
+
         it('kills the process and removes the pidfile', async function () {
             let isChildRunning = true;
             const program = os.platform() === 'win32' ? 'timeout' : 'sleep';
@@ -300,6 +317,7 @@ describe('Unit: Utils > local-process', function () {
             const instance = new LocalProcess({}, {
                 platform: {windows: true}
             }, {});
+            sinon.stub(instance, '_isGhostProcess').resolves(true);
 
             expect(isChildRunning).to.be.true;
 
@@ -321,6 +339,7 @@ describe('Unit: Utils > local-process', function () {
             const instance = new LocalProcess({}, {
                 platform: {macos: true, windows: false}
             }, {});
+            sinon.stub(instance, '_isGhostProcess').resolves(true);
 
             return instance.stop('/var/www/ghost').then(() => {
                 expect(readFileStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
@@ -340,6 +359,7 @@ describe('Unit: Utils > local-process', function () {
             const instance = new LocalProcess({}, {
                 platform: {macos: true, windows: false}
             }, {});
+            sinon.stub(instance, '_isGhostProcess').resolves(true);
 
             instance.stop('/var/www/ghost').then(() => {
                 done(new Error('stop should have rejected'));
@@ -351,6 +371,47 @@ describe('Unit: Utils > local-process', function () {
                 expect(removeStub.calledOnce).to.be.false;
                 done();
             });
+        });
+    });
+
+    describe('_isGhostProcess', function () {
+        it('returns false for a falsy or NaN pid', async function () {
+            const LocalProcess = require(modulePath);
+            const instance = new LocalProcess({}, {}, {});
+
+            expect(await instance._isGhostProcess(0)).to.be.false;
+            expect(await instance._isGhostProcess(NaN)).to.be.false;
+        });
+
+        it('returns false if no process matches the pid', async function () {
+            const processesStub = sinon.stub().resolves({list: [{pid: 99, command: 'node', params: '/usr/lib/ghost-cli/bin/ghost run'}]});
+            const LocalProcess = proxyquire(modulePath, {
+                systeminformation: {processes: processesStub}
+            });
+            const instance = new LocalProcess({}, {}, {});
+
+            expect(await instance._isGhostProcess(42)).to.be.false;
+            expect(processesStub.calledOnce).to.be.true;
+        });
+
+        it('returns false if the process is not a ghost run process', async function () {
+            const processesStub = sinon.stub().resolves({list: [{pid: 42, command: 'sleep', params: '10000'}]});
+            const LocalProcess = proxyquire(modulePath, {
+                systeminformation: {processes: processesStub}
+            });
+            const instance = new LocalProcess({}, {}, {});
+
+            expect(await instance._isGhostProcess(42)).to.be.false;
+        });
+
+        it('returns true if the process command line contains "ghost run"', async function () {
+            const processesStub = sinon.stub().resolves({list: [{pid: 42, command: 'node', params: '/usr/lib/ghost-cli/bin/ghost run'}]});
+            const LocalProcess = proxyquire(modulePath, {
+                systeminformation: {processes: processesStub}
+            });
+            const instance = new LocalProcess({}, {}, {});
+
+            expect(await instance._isGhostProcess(42)).to.be.true;
         });
     });
 


### PR DESCRIPTION
closes #2211
Use systeminformation processes() to get the command/params for the recorded pid. If the pid's command doesn't match Ghost, treat it as not running.