### PR TITLE
💡 Dropped support for Node 20

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20.x, 22.x, 24.x]
+        node: [22.x, 24.x]
     env:
       FORCE_COLOR: 1
     name: Node ${{ matrix.node }}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "engines": {
-    "node": "^20.11.1 || ^22.11.0 || ^24.0.0"
+    "node": "^22.13.0 || ^24.0.0"
   },
   "preferGlobal": true,
   "dependencies": {
@@ -105,5 +105,5 @@
     "standard-version": "4.3.0",
     "tmp": "0.2.7"
   },
-  "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 allowBuilds:
   yarn: true
+
+minimumReleaseAge: 4320 # 3 days in minutes; matches Renovate's minimumReleaseAge
+blockExoticSubdeps: true
+

--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,8 @@
     "standard-version",
     "validator"
   ],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
-    {
-      "matchPackageNames": ["pnpm"],
-      "allowedVersions": "<11"
-    },
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true,


### PR DESCRIPTION
no ref
- remove support for Node 20 (Ghost support was removed once Node 20 was EOL)
- bump pnpm to v11 now that node 20 is no longer supported