### PR TITLE
🐛 Fixed non-writable pnpm store db error

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           cd /opt/ghost-e2e-test
           sudo find ./ -type d -exec chmod 00775 {} \;
-          sudo find ./ ! -path "./versions/*" -type f -exec chmod 664 {} \;
+          sudo find ./ ! -path "./versions/*" ! -path "./.pnpm-store/*" -type f -exec chmod 664 {} \;
       - name: Recording running service pid
         run: |
           BEFORE_PID="$(sudo systemctl show -p MainPID --value ghost_cli-testing-ghost-org)"
@@ -288,7 +288,7 @@ jobs:
         run: |
           cd "$UPDATE_DIR"
           sudo find ./ -type d -exec chmod 00775 {} \;
-          sudo find ./ ! -path "./versions/*" -type f -exec chmod 664 {} \;
+          sudo find ./ ! -path "./versions/*" ! -path "./.pnpm-store/*" -type f -exec chmod 664 {} \;
       - name: Recording running service pid before update
         run: |
           BEFORE_PID="$(sudo systemctl show -p MainPID --value "$UPDATE_SERVICE")"

--- a/lib/commands/doctor/checks/check-permissions.js
+++ b/lib/commands/doctor/checks/check-permissions.js
@@ -22,8 +22,8 @@ module.exports = function checkPermissions(type, task) {
             help: `Run ${chalk.green('sudo find ./ -type d -exec chmod 00775 {} \\;')} and try again.`
         },
         files: {
-            command: 'find ./  -type f ! -path "./versions/*" ! -perm 664 ! -perm 644',
-            help: `Run ${chalk.green('sudo find ./ ! -path "./versions/*" -type f -exec chmod 664 {} \\;')} and try again.`
+            command: 'find ./  -type f ! -path "./versions/*" ! -path "./.pnpm-store/*" ! -perm 664 ! -perm 644',
+            help: `Run ${chalk.green('sudo find ./ ! -path "./versions/*" ! -path "./.pnpm-store/*" -type f -exec chmod 664 {} \\;')} and try again.`
         }
     };
 

--- a/lib/tasks/install-dependencies.js
+++ b/lib/tasks/install-dependencies.js
@@ -99,7 +99,15 @@ module.exports = function installDependencies(ui, archiveFile) {
             let observable;
 
             if (usePnpm(ctx.installPath)) {
-                observable = pnpm(['install', '--prod', '--reporter=append-only'], {
+                // Keep pnpm's content-addressable store inside the instance directory
+                // (a sibling of `versions/`) instead of the invoking user's home dir.
+                // This keeps the store on the same filesystem as node_modules (so pnpm
+                // can hardlink), guarantees it's writable by the invoking user, and
+                // avoids pnpm 11's SQLite store index failing with "attempt to write a
+                // readonly database" when $HOME is on a network mount (NFS/SMB) or the
+                // default store was left owned by another user (e.g. a prior root run).
+                const storeDir = path.join(path.dirname(path.dirname(ctx.installPath)), '.pnpm-store');
+                observable = pnpm(['install', '--prod', `--store-dir=${storeDir}`, '--reporter=append-only'], {
                     cwd: ctx.installPath,
                     env: {NODE_ENV: 'production', COREPACK_DEFAULT_TO_LATEST: '0'},
                     observe: true

--- a/lib/utils/pnpm.js
+++ b/lib/utils/pnpm.js
@@ -34,6 +34,11 @@ function isCorepackSignatureError(error) {
     return output.includes('Cannot find matching keyid') && output.includes('corepack');
 }
 
+function isReadonlyStoreError(error) {
+    const output = [error.stderr, error.stdout].filter(Boolean).join('\n');
+    return output.includes('attempt to write a readonly database') || output.includes('SQLITE_READONLY');
+}
+
 function toPnpmError(error) {
     if (error instanceof SystemError) {
         return error;
@@ -44,6 +49,13 @@ function toPnpmError(error) {
             message: 'Corepack could not verify pnpm because its package-signing keys are out of date.',
             help: 'Update Corepack, enable it, and activate pnpm before running the Ghost command again.',
             suggestion: 'npm install -g corepack@latest && corepack enable'
+        });
+    }
+
+    if (isReadonlyStoreError(error)) {
+        return new SystemError({
+            message: 'pnpm could not write to its package store because the store database is read-only.',
+            help: 'Ensure the Ghost install directory is on local disk (not a network mount) and owned by the current user, then try again.'
         });
     }
 

--- a/test/unit/commands/doctor/checks/check-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/check-permissions-spec.js
@@ -40,7 +40,7 @@ describe('Unit: Doctor Checks > Util > checkPermissions', function () {
         }).catch((error) => {
             expect(error).to.be.an.instanceof(errors.ProcessError);
             expect(error.message).to.match(/oops, cmd could not be executed/);
-            expect(execaStub.calledWithExactly('find ./  -type f ! -path "./versions/*" ! -perm 664 ! -perm 644', {maxBuffer: Infinity})).to.be.true;
+            expect(execaStub.calledWithExactly('find ./  -type f ! -path "./versions/*" ! -path "./.pnpm-store/*" ! -perm 664 ! -perm 644', {maxBuffer: Infinity})).to.be.true;
         });
     });
 });

--- a/test/unit/commands/doctor/checks/file-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/file-permissions-spec.js
@@ -39,7 +39,7 @@ describe('Unit: Doctor Checks > Checking file permissions', function () {
             expect(error).to.be.an.instanceof(errors.SystemError);
             expect(error.message).to.match(/Your installation folder contains some directories or files with incorrect permissions:/);
             expect(error.message).to.match(/- \.\/system\/apps/);
-            expect(error.message).to.match(/sudo find \.\/ ! -path "\.\/versions\/\*" -type f -exec chmod 664 \{\} \\;/);
+            expect(error.message).to.match(/sudo find \.\/ ! -path "\.\/versions\/\*" ! -path "\.\/\.pnpm-store\/\*" -type f -exec chmod 664 \{\} \\;/);
             expect(execaStub.called).to.be.true;
         });
     });
@@ -53,7 +53,7 @@ describe('Unit: Doctor Checks > Checking file permissions', function () {
             expect(error).to.be.an.instanceof(errors.SystemError);
             expect(error.message).to.match(/Your installation folder contains a directory or file with incorrect permissions:/);
             expect(error.message).to.match(/- .\/content\/images\/test.jpg/);
-            expect(error.message).to.match(/sudo find \.\/ ! -path "\.\/versions\/\*" -type f -exec chmod 664 \{\} \\;/);
+            expect(error.message).to.match(/sudo find \.\/ ! -path "\.\/versions\/\*" ! -path "\.\/\.pnpm-store\/\*" -type f -exec chmod 664 \{\} \\;/);
             expect(execaStub.called).to.be.true;
         });
     });

--- a/test/unit/tasks/install-dependencies-spec.js
+++ b/test/unit/tasks/install-dependencies-spec.js
@@ -158,7 +158,7 @@ describe('Unit: Tasks > install-dependencies', function () {
             expect(downloadTaskStub.calledOnce).to.be.true;
             expect(pnpmStub.calledOnce).to.be.true;
             expect(yarnStub.called).to.be.false;
-            expect(pnpmStub.args[0][0]).to.deep.equal(['install', '--prod', '--reporter=append-only']);
+            expect(pnpmStub.args[0][0]).to.deep.equal(['install', '--prod', '--store-dir=/var/www/ghost/.pnpm-store', '--reporter=append-only']);
             expect(pnpmStub.args[0][1]).to.deep.equal({
                 cwd: '/var/www/ghost/versions/1.5.0',
                 env: {NODE_ENV: 'production', COREPACK_DEFAULT_TO_LATEST: '0'},

--- a/test/unit/utils/pnpm-spec.js
+++ b/test/unit/utils/pnpm-spec.js
@@ -112,6 +112,21 @@ describe('Unit: pnpm', function () {
         });
     });
 
+    it('returns a helpful system error when the pnpm store is read-only', function () {
+        const execa = sinon.stub().rejects({
+            message: 'Command failed: pnpm install',
+            stderr: 'ERR_SQLITE_ERROR: attempt to write a readonly database'
+        });
+        const pnpm = setup({execa});
+
+        return pnpm(['install']).then(() => {
+            expect(false, 'Promise should have rejected').to.be.true;
+        }).catch((error) => {
+            expect(error).to.be.an.instanceOf(SystemError);
+            expect(error.message).to.equal('pnpm could not write to its package store because the store database is read-only.');
+        });
+    });
+
     describe('can return observables', function () {
         it('ends properly', function () {
             const execa = sinon.stub().callsFake(() => {


### PR DESCRIPTION
refs https://forum.ghost.org/t/install-fails-due-to-corepack-sqlite-readonly/63230
- on certain filesystems/permission modes, pnpm v11 fails because it attempts to write to a 'readonly' db from the perspective of sqlite
- bypass this issue by making pnpm store dir a sibling of versions
- add more helpful error message for pnpm sqlite errors