### PR TITLE
🐛 Fixed X-Forwarded-For header in nginx config

### DIFF
--- a/extensions/nginx/templates/nginx-ssl.conf
+++ b/extensions/nginx/templates/nginx-ssl.conf
@@ -35,7 +35,7 @@ server {
     }
 
     location <%= location %> {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $http_host;

--- a/extensions/nginx/templates/nginx.conf
+++ b/extensions/nginx/templates/nginx.conf
@@ -31,7 +31,7 @@ server {
     }
 
     location <%= location %> {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
no ref
- this change was made awhile back but reverted without context, likely as part of debugging a separate issue
- acme.sh is still able to provision certs with this change re-added, so we'll make it again to the default nginx config