### PR TITLE
fix(nginx): resolve ActivityPub upstream at request time

### DIFF
--- a/extensions/nginx/templates/nginx-ssl.conf
+++ b/extensions/nginx/templates/nginx-ssl.conf
@@ -14,6 +14,12 @@ server {
     ssl_certificate_key <%= privkey %>;
     include <%= sslparams %>;
 
+    # Resolve ap.ghost.org at request time so nginx can start when DNS is briefly
+    # unavailable (reboot / systemd-resolved restart). Literal proxy_pass hostnames
+    # are resolved at config load and fail the whole site otherwise.
+    resolver 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
+    resolver_timeout 5s;
+
     location ~ /.ghost/activitypub/* {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -21,7 +27,8 @@ server {
         proxy_set_header Host $http_host;
         add_header X-Content-Type-Options $header_content_type_options;
         proxy_ssl_server_name on;
-        proxy_pass https://ap.ghost.org;
+        set $ghost_activitypub_upstream https://ap.ghost.org;
+        proxy_pass $ghost_activitypub_upstream;
     }
 
     location ~ /.well-known/(webfinger|nodeinfo) {
@@ -31,7 +38,8 @@ server {
         proxy_set_header Host $http_host;
         add_header X-Content-Type-Options $header_content_type_options;
         proxy_ssl_server_name on;
-        proxy_pass https://ap.ghost.org;
+        set $ghost_activitypub_upstream https://ap.ghost.org;
+        proxy_pass $ghost_activitypub_upstream;
     }
 
     location <%= location %> {

--- a/extensions/nginx/templates/nginx.conf
+++ b/extensions/nginx/templates/nginx.conf
@@ -10,6 +10,12 @@ server {
     server_name <%= url %>;
     root <%= webroot %>; # Used for acme.sh SSL verification (https://acme.sh)
 
+    # Resolve ap.ghost.org at request time so nginx can start when DNS is briefly
+    # unavailable (reboot / systemd-resolved restart). Literal proxy_pass hostnames
+    # are resolved at config load and fail the whole site otherwise.
+    resolver 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
+    resolver_timeout 5s;
+
     location ~ /.ghost/activitypub/* {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -17,7 +23,8 @@ server {
         proxy_set_header Host $http_host;
         add_header X-Content-Type-Options $header_content_type_options;
         proxy_ssl_server_name on;
-        proxy_pass https://ap.ghost.org;
+        set $ghost_activitypub_upstream https://ap.ghost.org;
+        proxy_pass $ghost_activitypub_upstream;
     }
 
     location ~ /.well-known/(webfinger|nodeinfo) {
@@ -27,7 +34,8 @@ server {
         proxy_set_header Host $http_host;
         add_header X-Content-Type-Options $header_content_type_options;
         proxy_ssl_server_name on;
-        proxy_pass https://ap.ghost.org;
+        set $ghost_activitypub_upstream https://ap.ghost.org;
+        proxy_pass $ghost_activitypub_upstream;
     }
 
     location <%= location %> {


### PR DESCRIPTION
## Summary
- Nginx resolves hostnames in literal \`proxy_pass\` directives at config load.
- If \`ap.ghost.org\` is briefly unresolvable (reboot / systemd-resolved restart), nginx fails to start and the site stays down.
- ActivityPub locations now use a variable upstream plus \`resolver\` so DNS happens at request time.

## Notes
- Regenerates on next \`ghost setup nginx\` / SSL setup using the CLI templates.
- Existing site configs need a regenerate (or manual edit) to pick this up.

## Test plan
- [ ] Diff generated nginx conf and confirm ActivityPub blocks use \`set \$ghost_activitypub_upstream\` + \`proxy_pass \$ghost_activitypub_upstream\`
- [ ] Confirm site still proxies \`/.ghost/activitypub/\` and webfinger/nodeinfo

Closes #2044
