### PR TITLE
Disabled python check for Ghost 6.50+

### DIFF
--- a/lib/commands/doctor/checks/python-setuptools.js
+++ b/lib/commands/doctor/checks/python-setuptools.js
@@ -5,6 +5,9 @@ const {SystemError} = require('../../../errors');
 
 const taskTitle = 'Checking SQLite build dependencies';
 
+// Ghost 6.50.0 swapped sqlite3 for better-sqlite3, which ships prebuilt binaries
+const GHOST_VERSION_WITH_BETTER_SQLITE = '6.50.0';
+
 async function checkPython3() {
     try {
         const {stdout} = await execa('python3', ['--version'], {timeout: 5000});
@@ -60,6 +63,13 @@ function pythonSetuptoolsIsRequired(ctx) {
 
     // SQLite3 provides binaries for node versions < 22
     if (!isNode22Plus) {
+        return false;
+    }
+
+    // version is set by the install/update commands, otherwise fall back to the installed version
+    const ghostVersion = ctx.version || (ctx.instance && ctx.instance.version);
+
+    if (ghostVersion && semver.gte(ghostVersion, GHOST_VERSION_WITH_BETTER_SQLITE)) {
         return false;
     }
 

--- a/test/unit/commands/doctor/checks/python-setuptools-spec.js
+++ b/test/unit/commands/doctor/checks/python-setuptools-spec.js
@@ -99,6 +99,36 @@ describe('Unit: Doctor Checks > pythonSetuptools', function () {
             const result = pythonSetuptools.enabled(ctx);
             expect(result).to.be.false;
         });
+
+        it('returns false for Ghost 6.50.0+ (better-sqlite3)', function () {
+            const ctx = {local: true, instance: {}, version: '6.50.0'};
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.false;
+        });
+
+        it('returns true for Ghost < 6.50.0', function () {
+            const ctx = {local: true, instance: {}, version: '6.49.0'};
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.true;
+        });
+
+        it('returns false when the installed instance is on 6.50.0+', function () {
+            const ctx = {
+                instance: {
+                    isSetup: true,
+                    version: '6.51.0',
+                    config: {
+                        values: {
+                            database: {
+                                client: 'sqlite3'
+                            }
+                        }
+                    }
+                }
+            };
+            const result = pythonSetuptools.enabled(ctx);
+            expect(result).to.be.false;
+        });
     });
 
     describe('task', function () {


### PR DESCRIPTION
no ref
- Ghost >= 6.50.0 uses better-sqlite3 which doesn't require python/setuptools for installation, so we can disable this check there