### PR TITLE
🐛 Fixed HttpsProxyAgent constructor error behind a proxy

### DIFF
--- a/lib/utils/get-proxy-agent.js
+++ b/lib/utils/get-proxy-agent.js
@@ -7,7 +7,7 @@ module.exports = function getProxyAgent() {
     // Initialize Proxy Agent for proxy support if needed
     const proxyAddress = getProxyForUrl(NPM_REGISTRY);
     if (proxyAddress && !proxyAgent) {
-        const HttpsProxyAgent = require('https-proxy-agent');
+        const {HttpsProxyAgent} = require('https-proxy-agent');
         proxyAgent = new HttpsProxyAgent(proxyAddress);
     }
 

--- a/test/unit/utils/get-proxy-agent-spec.js
+++ b/test/unit/utils/get-proxy-agent-spec.js
@@ -1,0 +1,22 @@
+const {expect} = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
+
+function load(proxyAddress) {
+    return proxyquire('../../../lib/utils/get-proxy-agent', {
+        'proxy-from-env': {getProxyForUrl: () => proxyAddress}
+    });
+}
+
+describe('Unit: Utils > get-proxy-agent', function () {
+    it('returns false if no proxy is configured', function () {
+        expect(load('')()).to.be.false;
+    });
+
+    it('returns an agent instance if a proxy is configured', function () {
+        const {HttpsProxyAgent} = require('https-proxy-agent');
+        const agent = load('http://localhost:8080')();
+
+        expect(agent).to.be.an.instanceof(HttpsProxyAgent);
+        expect(agent.proxy.href).to.equal('http://localhost:8080/');
+    });
+});


### PR DESCRIPTION
closes #2263

`https-proxy-agent` v7+ dropped the default export — `require('https-proxy-agent')` now returns `{HttpsProxyAgent}` rather than the constructor itself. We're on v9, so `new HttpsProxyAgent(...)` in `lib/utils/get-proxy-agent.js` threw `TypeError: HttpsProxyAgent is not a constructor`.

This only triggers when `HTTP_PROXY`/`HTTPS_PROXY` is set, which is why it went unnoticed — but in that case it broke every command that hits the network (`install`, `update`, and the pre-check update lookup).

- destructure the named export
- add unit tests for `get-proxy-agent` (both the no-proxy and proxy-configured paths), which would have caught this

🤖 Generated with [Claude Code](https://claude.com/claude-code)