### PR TITLE
🐛 Fixed invalid inquirer prompt name in backup/import command

### DIFF
--- a/lib/tasks/import/tasks.js
+++ b/lib/tasks/import/tasks.js
@@ -6,7 +6,7 @@ const parseExport = require('./parse-export');
 const {isSetup, setup, runImport, downloadContentExport, downloadMembersExport, TOKEN_AUTH_MIN_VERSION} = require('./api');
 
 const sessionAuthPrompts = [{
-    type: 'string',
+    type: 'input',
     name: 'username',
     message: 'Enter your Ghost administrator email address',
     validate: val => validator.isEmail(`${val}`) || 'You must specify a valid email'
@@ -20,7 +20,7 @@ const sessionAuthPrompts = [{
 const staffTokenRegex = /^[0-9a-f]{24}:[0-9a-f]{64}$/;
 
 const staffTokenAuthPrompts = [{
-    type: 'string',
+    type: 'input',
     name: 'token',
     message: 'Enter your Ghost Staff access token',
     validate: val => staffTokenRegex.test(val) || 'Token must follow the "{A}:{B}" format, where A is 24 hex characters and B is 64 hex characters'

--- a/test/unit/tasks/import/tasks-spec.js
+++ b/test/unit/tasks/import/tasks-spec.js
@@ -47,6 +47,8 @@ describe('Unit: Tasks > Import > Tasks', function () {
             const usernamePrompt = prompt.args[0][0][0];
             const passwordPrompt = prompt.args[0][0][1];
 
+            expect(usernamePrompt.type).to.equal('input');
+            expect(passwordPrompt.type).to.equal('password');
             expect(usernamePrompt.validate('test@example.com')).to.be.true;
             expect(usernamePrompt.validate('not an email')).to.include('valid email');
             expect(passwordPrompt.validate('1234567890')).to.be.true;
@@ -215,6 +217,7 @@ describe('Unit: Tasks > Import > Tasks', function () {
             expect(isSetup.calledOnceWithExactly(TOKEN_AUTH_MIN_VERSION, 'http://localhost:2368')).to.be.true;
             expect(prompt.calledOnce).to.be.true;
             expect(prompt.args[0][0].map(prompt => prompt.name)).to.deep.equal(['token']);
+            expect(prompt.args[0][0][0].type).to.equal('input');
             expect(downloadContentExport.calledOnceWithExactly('1.0.0', 'http://localhost:2368', {
                 token: 'abcd'
             }, 'test-export.json'));


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost-CLI/issues/2281
- use `input` rather than `string` as string is not a valid inquirer prompt type