### PR TITLE
🎨 Switched the test suite from mocha/chai to vitest

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,4 +24,15 @@ jobs:
           FORCE_COLOR: 0
       - run: pnpm install
       - run: pnpm lint
-      - run: pnpm test
+      # `pnpm coverage` runs the same specs as `pnpm test`, minus the posttest
+      # lint that's already run above
+      - run: pnpm coverage
+      # Every matrix leg covers the same lines, so one upload is enough. Forks
+      # don't report to Ghost-CLI's Codecov project, so skip them too
+      - name: Upload coverage
+        if: matrix.node == '22.x' && github.repository == 'TryGhost/Ghost-CLI'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          flags: unit-tests
+          files: coverage/cobertura-coverage.xml
+          disable_search: true

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,3 +1,0 @@
-{
-    "require": "./test/root-hooks.mjs"
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ These instructions apply to the entire repository.
 
 - Follow the existing CommonJS module style and current file structure.
 - Keep changes targeted; prefer updating existing commands, tasks, utils, or extensions over introducing new abstractions.
-- Match the existing test style with Mocha, Chai, Sinon, Proxyquire, and Nock where applicable.
+- Match the existing test style with Vitest, Sinon, Proxyquire, and Nock where applicable. Vitest's `expect` is chai-based, so the existing `expect(...).to.be.true` style still applies; globals are enabled, so specs don't import the runner.
 - Add or update tests for behavior changes, especially command flows, task execution, and extension behavior.
 
 ## Product Boundaries

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![E2E Tests](https://github.com/TryGhost/Ghost-CLI/actions/workflows/e2e-test.yml/badge.svg)](https://github.com/TryGhost/Ghost-CLI/actions/workflows/e2e-test.yml)
 [![Local E2E Tests](https://github.com/TryGhost/Ghost-CLI/actions/workflows/local-e2e-test.yml/badge.svg)](https://github.com/TryGhost/Ghost-CLI/actions/workflows/local-e2e-test.yml)
 [![Unit Tests](https://github.com/TryGhost/Ghost-CLI/actions/workflows/unit-test.yml/badge.svg)](https://github.com/TryGhost/Ghost-CLI/actions/workflows/unit-test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/TryGhost/Ghost-CLI/badge.svg?branch=master)](https://coveralls.io/github/TryGhost/Ghost-CLI?branch=master)
+[![Coverage Status](https://codecov.io/gh/TryGhost/Ghost-CLI/branch/main/graph/badge.svg)](https://codecov.io/gh/TryGhost/Ghost-CLI)
 [![npm version](https://img.shields.io/npm/v/ghost-cli.svg)](https://npmjs.com/package/ghost-cli/)
 
 ## Basic Setup

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,12 @@ const ghostPreset = name => compat.extends(`plugin:ghost/${name}`).map(config =>
     ))
 } : config));
 
+// the globals package doesn't ship a vitest set, and vitest.config.mjs turns globals on
+const vitestGlobals = Object.fromEntries([
+    'suite', 'test', 'describe', 'it', 'expect', 'assert', 'vi',
+    'beforeAll', 'afterAll', 'beforeEach', 'afterEach', 'onTestFailed', 'onTestFinished'
+].map(name => [name, 'readonly']));
+
 const plugins = {ghost};
 const base = {
     ...js.configs.recommended,
@@ -70,7 +76,7 @@ export default defineConfig([
         extends: ghostPreset('test'),
         languageOptions: {
             ...base.languageOptions,
-            globals: {...globals.node, ...globals.mocha}
+            globals: {...globals.node, ...vitestGlobals}
         },
         rules: {
             ...base.rules,

--- a/extensions/mysql/test/extension-spec.js
+++ b/extensions/mysql/test/extension-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const configStub = require('../../../test/utils/config-stub');

--- a/extensions/nginx/test/acme-spec.js
+++ b/extensions/nginx/test/acme-spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const os = require('os');

--- a/extensions/nginx/test/extension-spec.js
+++ b/extensions/nginx/test/extension-spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const modulePath = '../index';

--- a/extensions/nginx/test/migrations-spec.js
+++ b/extensions/nginx/test/migrations-spec.js
@@ -1,7 +1,6 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/extensions/nginx/test/utils-spec.js
+++ b/extensions/nginx/test/utils-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 
 const {parseResolvers} = require('../utils');
 

--- a/extensions/systemd/test/doctor-spec.js
+++ b/extensions/systemd/test/doctor-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 
 const fs = require('fs-extra');
@@ -25,7 +24,7 @@ describe('Unit: Systemd > doctor checks', function () {
 
             const expectedPath = '/lib/systemd/system/ghost_test.service';
 
-            await expect(checkUnitFile(ctx)).to.be.rejectedWith(errors.SystemError);
+            await expect(checkUnitFile(ctx)).rejects.toThrow(errors.SystemError);
             expect(readFile.calledOnceWithExactly(expectedPath)).to.be.true;
             expect(ctx.systemd).to.deep.equal({unitFilePath: expectedPath});
         });
@@ -58,7 +57,7 @@ Test=Value
                 }
             };
 
-            await expect(checkUnitFile(ctx)).to.not.be.rejected;
+            await checkUnitFile(ctx);
             expect(readFile.calledOnceWithExactly(expectedPath)).to.be.true;
             expect(ctx.systemd).to.deep.equal(expectedCtx);
         });
@@ -74,7 +73,7 @@ Test=Value
             };
             const task = {};
 
-            await expect(checkNodeVersion(ctx, task)).to.be.rejectedWith(errors.SystemError);
+            await expect(checkNodeVersion(ctx, task)).rejects.toThrow(errors.SystemError);
         });
 
         it('rejects if node --version rejects', async function () {
@@ -93,7 +92,7 @@ Test=Value
             };
             const task = {};
 
-            await expect(checkNodeVersion(ctx, task)).to.be.rejectedWith(errors.SystemError);
+            await expect(checkNodeVersion(ctx, task)).rejects.toThrow(errors.SystemError);
             expect(execaStub.calledOnceWithExactly('/usr/bin/node', ['--version'])).to.be.true;
         });
 
@@ -113,7 +112,7 @@ Test=Value
             };
             const task = {};
 
-            await expect(checkNodeVersion(ctx, task)).to.be.rejectedWith(errors.SystemError);
+            await expect(checkNodeVersion(ctx, task)).rejects.toThrow(errors.SystemError);
             expect(execaStub.calledOnceWithExactly('/usr/bin/node', ['--version'])).to.be.true;
         });
 
@@ -137,7 +136,7 @@ Test=Value
             };
             const task = {};
 
-            await expect(checkNodeVersion(ctx, task)).to.not.be.rejected;
+            await checkNodeVersion(ctx, task);
             expect(execaStub.calledOnceWithExactly('/usr/bin/node', ['--version'])).to.be.true;
             expect(task.title).to.equal('Checking systemd node version - found v12.0.0');
             expect(readJson.calledOnceWithExactly('/var/www/ghost/current/package.json')).to.be.true;
@@ -164,7 +163,7 @@ Test=Value
             };
             const task = {};
 
-            await expect(checkNodeVersion(ctx, task)).to.not.be.rejected;
+            await checkNodeVersion(ctx, task);
             expect(execaStub.calledOnceWithExactly('/usr/bin/node', ['--version'])).to.be.true;
             expect(task.title).to.equal(`Checking systemd node version - found v${process.versions.node}`);
             expect(readJson.calledOnceWithExactly('/var/www/ghost/current/package.json')).to.be.true;
@@ -193,7 +192,7 @@ Test=Value
             };
             const task = {};
 
-            await expect(checkNodeVersion(ctx, task)).to.be.rejectedWith(errors.SystemError);
+            await expect(checkNodeVersion(ctx, task)).rejects.toThrow(errors.SystemError);
             expect(execaStub.calledOnceWithExactly('/usr/bin/node', ['--version'])).to.be.true;
             expect(task.title).to.equal(`Checking systemd node version - found v${process.versions.node}`);
             expect(readJson.calledOnceWithExactly('/var/www/ghost/current/package.json')).to.be.true;

--- a/extensions/systemd/test/extension-spec.js
+++ b/extensions/systemd/test/extension-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const path = require('path');
 const proxyquire = require('proxyquire').noCallThru();

--- a/extensions/systemd/test/get-uid-spec.js
+++ b/extensions/systemd/test/get-uid-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/extensions/systemd/test/systemd-spec.js
+++ b/extensions/systemd/test/systemd-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 
@@ -40,13 +39,13 @@ describe('Unit: Systemd > Process Manager', function () {
 
         it('Calls _precheck', function () {
             ext._precheck = sinon.stub();
-            ext.start().then(() => {
+            return ext.start().then(() => {
                 expect(ext._precheck.calledOnce).to.be.true;
             });
         });
 
         it('Runs as sudo', function () {
-            ext.start().then(() => {
+            return ext.start().then(() => {
                 const expectedCmd = 'systemctl start ghost_ghost_org';
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
@@ -55,7 +54,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
         it('Errors when sudo does', function () {
             ui.sudo = sinon.stub().rejects();
-            ext.start().then(() => {
+            return ext.start().then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.ok;
@@ -66,7 +65,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
         it('Errors when starting failed', function () {
             ext.ensureStarted = sinon.stub().rejects(new errors.CliError('Wasn\'t started'));
-            ext.start().then(() => {
+            return ext.start().then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.ok;
@@ -88,13 +87,13 @@ describe('Unit: Systemd > Process Manager', function () {
 
         it('Calls _precheck', function () {
             ext._precheck = sinon.stub();
-            ext.stop().then(() => {
+            return ext.stop().then(() => {
                 expect(ext._precheck.calledOnce).to.be.true;
             });
         });
 
         it('Runs as sudo', function () {
-            ext.stop().then(() => {
+            return ext.stop().then(() => {
                 const expectedCmd = 'systemctl stop ghost_ghost_org';
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
@@ -103,7 +102,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
         it('Errors when sudo does', function () {
             ui.sudo = sinon.stub().rejects();
-            ext.stop().then(() => {
+            return ext.stop().then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.ok;
@@ -125,13 +124,13 @@ describe('Unit: Systemd > Process Manager', function () {
 
         it('Calls _precheck', function () {
             ext._precheck = sinon.stub();
-            ext.restart().then(() => {
+            return ext.restart().then(() => {
                 expect(ext._precheck.calledOnce).to.be.true;
             });
         });
 
         it('Runs as sudo', function () {
-            ext.restart().then(() => {
+            return ext.restart().then(() => {
                 const expectedCmd = 'systemctl restart ghost_ghost_org';
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
@@ -140,7 +139,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
         it('Errors when sudo does', function () {
             ui.sudo = sinon.stub().rejects();
-            ext.restart().then(() => {
+            return ext.restart().then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.ok;
@@ -151,7 +150,7 @@ describe('Unit: Systemd > Process Manager', function () {
 
         it('Errors when starting failed', function () {
             ext.ensureStarted = sinon.stub().rejects(new errors.CliError('Wasn\'t started'));
-            ext.restart().then(() => {
+            return ext.restart().then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(error).to.be.ok;
@@ -167,7 +166,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const expectedCmd = 'systemctl is-enabled ghost_ghost_org';
             const ext = makeSystemd(null, ui);
 
-            ext.isEnabled().then((result) => {
+            return ext.isEnabled().then((result) => {
                 expect(result).to.be.true;
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
@@ -179,7 +178,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const ext = makeSystemd(null, ui);
             const expectedCmd = 'systemctl is-enabled ghost_ghost_org';
 
-            ext.isEnabled().then(() => {
+            return ext.isEnabled().then(() => {
                 expect(false, 'An error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error.message).to.equal('unknown');
@@ -193,7 +192,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const ext = makeSystemd(null, ui);
             const expectedCmd = 'systemctl is-enabled ghost_ghost_org';
 
-            ext.isEnabled().then((result) => {
+            return ext.isEnabled().then((result) => {
                 expect(result).to.be.false;
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
@@ -206,7 +205,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const expectedCmd = 'systemctl enable ghost_ghost_org --quiet';
             const ui = {sudo: sinon.stub().resolves()};
             const ext = makeSystemd(null, ui);
-            ext.enable().then(() => {
+            return ext.enable().then(() => {
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
             });
@@ -215,7 +214,7 @@ describe('Unit: Systemd > Process Manager', function () {
         it('Passes errors through', function () {
             const ui = {sudo: sinon.stub().rejects(new Error('red'))};
             const ext = makeSystemd(null, ui);
-            ext.enable().then(() => {
+            return ext.enable().then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(ui.sudo.calledOnce).to.be.true;
@@ -230,7 +229,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const expectedCmd = 'systemctl disable ghost_ghost_org --quiet';
             const ui = {sudo: sinon.stub().resolves()};
             const ext = makeSystemd(null, ui);
-            ext.disable().then(() => {
+            return ext.disable().then(() => {
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
             });
@@ -239,7 +238,7 @@ describe('Unit: Systemd > Process Manager', function () {
         it('Passes errors through', function () {
             const ui = {sudo: sinon.stub().rejects(new Error('green'))};
             const ext = makeSystemd(null, ui);
-            ext.disable().then(() => {
+            return ext.disable().then(() => {
                 expect(false, 'Promise should have rejected').to.be.true;
             }).catch((error) => {
                 expect(ui.sudo.calledOnce).to.be.true;
@@ -255,7 +254,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const expectedCmd = 'systemctl is-active ghost_ghost_org';
             const ext = makeSystemd(null, ui);
 
-            ext.isRunning().then((result) => {
+            return ext.isRunning().then((result) => {
                 expect(result).to.be.true;
                 expect(ui.sudo.calledOnce).to.be.true;
                 expect(ui.sudo.args[0][0]).to.equal(expectedCmd);
@@ -267,7 +266,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const ext = makeSystemd(null, {sudo});
             const expectedCmd = 'systemctl is-active ghost_ghost_org';
 
-            ext.isRunning().then(() => {
+            return ext.isRunning().then(() => {
                 expect(false, 'An error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error.message).to.equal('unknown');
@@ -282,7 +281,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const ext = makeSystemd(null, {sudo});
             const expectedCmd = 'systemctl is-active ghost_ghost_org';
 
-            ext.isRunning().then((result) => {
+            return ext.isRunning().then((result) => {
                 expect(result).to.be.false;
                 expect(sudo.calledOnce).to.be.true;
                 expect(sudo.calledWithExactly(expectedCmd)).to.be.true;
@@ -298,7 +297,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const expectedCmd = 'systemctl is-active ghost_ghost_org';
             const resetCmd = 'systemctl reset-failed ghost_ghost_org';
 
-            ext.isRunning().then((result) => {
+            return ext.isRunning().then((result) => {
                 expect(result).to.be.false;
                 expect(sudo.calledTwice).to.be.true;
                 expect(sudo.firstCall.calledWithExactly(expectedCmd));
@@ -315,7 +314,7 @@ describe('Unit: Systemd > Process Manager', function () {
             const expectedCmd = 'systemctl is-active ghost_ghost_org';
             const resetCmd = 'systemctl reset-failed ghost_ghost_org';
 
-            ext.isRunning().then(() => {
+            return ext.isRunning().then(() => {
                 expect(false, 'An error should have been thrown').to.be.true;
             }).catch((error) => {
                 expect(error.message).to.equal('uh oh');

--- a/package.json
+++ b/package.json
@@ -26,18 +26,12 @@
     "ghost": "./bin/ghost"
   },
   "scripts": {
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "coverage": "vitest run --coverage",
     "lint": "eslint .",
-    "test": "nyc --reporter=html --reporter=text mocha -t 5000 --recursive test/unit extensions/**/test",
+    "test": "vitest run",
     "posttest": "pnpm lint",
     "release": "node scripts/release.js",
     "release-notes": "node scripts/release-notes.js"
-  },
-  "nyc": {
-    "exclude": [
-      "**/*-spec.js",
-      "test"
-    ]
   },
   "engines": {
     "node": "^22.13.0 || ^24.0.0"
@@ -87,18 +81,16 @@
   "devDependencies": {
     "@eslint/eslintrc": "3.3.6",
     "@eslint/js": "9.39.5",
-    "chai": "6.2.2",
-    "chai-as-promised": "8.0.2",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "9.39.5",
     "eslint-plugin-ghost": "3.5.0",
     "globals": "17.9.0",
     "has-ansi": "6.0.2",
-    "mocha": "11.8.0",
     "nock": "14.0.17",
-    "nyc": "18.0.0",
     "proxyquire": "2.1.3",
     "sinon": "22.1.0",
-    "tmp": "0.2.7"
+    "tmp": "0.2.7",
+    "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,12 +132,9 @@ importers:
       '@eslint/js':
         specifier: 9.39.5
         version: 9.39.5
-      chai:
-        specifier: 6.2.2
-        version: 6.2.2
-      chai-as-promised:
-        specifier: 8.0.2
-        version: 8.0.2(chai@6.2.2)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       eslint:
         specifier: 9.39.5
         version: 9.39.5(supports-color@8.1.1)
@@ -150,15 +147,9 @@ importers:
       has-ansi:
         specifier: 6.0.2
         version: 6.0.2
-      mocha:
-        specifier: 11.8.0
-        version: 11.8.0
       nock:
         specifier: 14.0.17
         version: 14.0.17
-      nyc:
-        specifier: 18.0.0
-        version: 18.0.0(supports-color@8.1.1)
       proxyquire:
         specifier: 2.1.3
         version: 2.1.3
@@ -168,6 +159,9 @@ importers:
       tmp:
         specifier: 0.2.7
         version: 0.2.7
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0))
 
 packages:
 
@@ -244,6 +238,10 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@ember-data/rfc395-data@0.0.4':
     resolution: {integrity: sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==}
@@ -456,21 +454,9 @@ packages:
       '@types/node':
         optional: true
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
-
-  '@istanbuljs/load-nyc-config@1.1.0':
-    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
-    engines: {node: '>=8'}
-
-  '@istanbuljs/schema@0.1.6':
-    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
-    engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -507,9 +493,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -522,6 +507,99 @@ packages:
   '@pnpm/npm-conf@3.0.3':
     resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
     engines: {node: '>=12'}
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -542,11 +620,20 @@ packages:
   '@sinonjs/samsam@10.0.2':
     resolution: {integrity: sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tryghost/errors@3.3.7':
     resolution: {integrity: sha512-dfP7FBHxKP0vRWggvlhtYSdzaPMAtsOM6MmY7OMSh39iPRlP8Hd+Kc2IUiO9KiG8gEqg0BMXmVd1zvvneyyyKg==}
 
   '@tryghost/zip@3.5.6':
     resolution: {integrity: sha512-rkKtBtsWE6uPHJJeinKDTKayn1tR3Om59ol2piHNYNTd/9ElyfqDU7QmHttsH4BAiPOymmXRr2cY8QBlfnoq9Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -628,6 +715,44 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   abbrev@5.0.0:
     resolution: {integrity: sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -645,10 +770,6 @@ packages:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -680,22 +801,19 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  append-transform@2.0.0:
-    resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
-    engines: {node: '>=8'}
-
   archiver@8.0.0:
     resolution: {integrity: sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==}
     engines: {node: '>=18'}
 
-  archy@1.0.0:
-    resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
-
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -771,15 +889,9 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.4:
-    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
-
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
-
-  browser-stdout@1.3.1:
-    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
 
   browserslist@4.28.8:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
@@ -803,21 +915,9 @@ packages:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
 
-  caching-transform@4.0.0:
-    resolution: {integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==}
-    engines: {node: '>=8'}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  camelcase@5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
-    engines: {node: '>=6'}
-
-  camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
-    engines: {node: '>=10'}
 
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
@@ -825,11 +925,6 @@ packages:
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
-
-  chai-as-promised@8.0.2:
-    resolution: {integrity: sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==}
-    peerDependencies:
-      chai: '>= 2.1.2 < 7'
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -850,14 +945,6 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
-
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
-
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -869,10 +956,6 @@ packages:
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
-
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
 
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -898,13 +981,6 @@ packages:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
-  cliui@6.0.0:
-    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
-
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
@@ -920,9 +996,6 @@ packages:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
     engines: {node: '>=0.1.90'}
 
-  commondir@1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
   compress-commons@7.0.1:
     resolution: {integrity: sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==}
     engines: {node: '>=18'}
@@ -935,9 +1008,6 @@ packages:
 
   content-tag@2.0.3:
     resolution: {integrity: sha512-htLIdtfhhKW2fHlFLnZH7GFzHSdSpHhDLrWVswkNiiPMZ5uXq5JfrGboQKFhNQuAAFF8VNB2EYUj3MsdJrKKpg==}
-
-  convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -982,14 +1052,6 @@ packages:
       supports-color:
         optional: true
 
-  decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
-
-  decamelize@4.0.0:
-    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
-    engines: {node: '>=10'}
-
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -997,13 +1059,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  default-require-extensions@3.0.1:
-    resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
-    engines: {node: '>=0.3.1'}
 
   diff@9.0.0:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
@@ -1011,9 +1069,6 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
-
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -1040,9 +1095,6 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -1061,8 +1113,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es6-error@4.1.1:
-    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1187,11 +1239,6 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -1207,6 +1254,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -1234,6 +1284,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -1285,10 +1339,6 @@ packages:
     resolution: {integrity: sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==}
     engines: {node: '>=0.10.0'}
 
-  find-cache-dir@3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
-
   find-plugins@1.1.7:
     resolution: {integrity: sha512-XcP3/mIepmyxp09SE6WeREEJBKZ8ljlmrWlhWAvVU9rlNbSx1fztFr3wW/92bpFPrKE9MN/UiOd2qYtK85BaaQ==}
     engines: {node: '>=6'}
@@ -1313,27 +1363,17 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flat@5.0.2:
-    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
-    hasBin: true
-
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
-
-  foreground-child@2.0.0:
-    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
-    engines: {node: '>=8.0.0'}
-
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
-  fromentries@1.3.2:
-    resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
 
   fs-extra@11.4.0:
     resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1356,10 +1396,6 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
-  get-package-type@0.1.0:
-    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
-    engines: {node: '>=8.0.0'}
-
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
@@ -1378,11 +1414,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -1425,17 +1456,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hasha@5.2.2:
-    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
-    engines: {node: '>=8'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
-
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -1542,24 +1565,12 @@ packages:
   is-object@1.0.2:
     resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
 
-  is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
-
-  is-plain-obj@2.1.0:
-    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
-    engines: {node: '>=8'}
-
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
 
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -1569,20 +1580,9 @@ packages:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
 
-  is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-
-  is-unicode-supported@0.1.0:
-    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
-    engines: {node: '>=10'}
-
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
-
-  is-windows@1.0.2:
-    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
-    engines: {node: '>=0.10.0'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -1598,39 +1598,19 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
-  istanbul-lib-hook@3.0.0:
-    resolution: {integrity: sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==}
-    engines: {node: '>=8'}
-
-  istanbul-lib-instrument@6.0.3:
-    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
-    engines: {node: '>=10'}
-
-  istanbul-lib-processinfo@3.0.1:
-    resolution: {integrity: sha512-s3mX05h5wGZeScG6XnOanygPh4SJu5ujMc9YbvpnLGXWy1cRiGbp0NdVcjHxgoZt3WfQppfBsa0y+gWdYJ2pGQ==}
-    engines: {node: 20 || >=22}
-
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
-
-  istanbul-lib-source-maps@4.0.1:
-    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
-    hasBin: true
 
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
@@ -1700,6 +1680,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -1725,9 +1779,6 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
-  lodash.flattendeep@4.4.0:
-    resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -1765,10 +1816,6 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
-  log-symbols@4.1.0:
-    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
-    engines: {node: '>=10'}
-
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
@@ -1783,9 +1830,6 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -1797,9 +1841,11 @@ packages:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -1836,10 +1882,6 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -1850,11 +1892,6 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
-
-  mocha@11.8.0:
-    resolution: {integrity: sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    hasBin: true
 
   module-not-found-error@1.0.1:
     resolution: {integrity: sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==}
@@ -1876,6 +1913,11 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -1885,10 +1927,6 @@ packages:
   nock@14.0.17:
     resolution: {integrity: sha512-EjRr1weMa4ALQX35AgZTEnP+weJJjlW1KGDiNM2IQC2069YDHas4f4B4UUYR+TTLyKWxJvOz2wObDKQs/LNreA==}
     engines: {node: '>=18.20.0 <20 || >=20.12.1'}
-
-  node-preload@0.2.1:
-    resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
-    engines: {node: '>=8'}
 
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
@@ -1913,14 +1951,13 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
-  nyc@18.0.0:
-    resolution: {integrity: sha512-G5UyHinFkB1BxqGTrmZdB6uIYH0+v7ZnVssuflUDi+J+RhKWyAhRT1RCehBSI6jLFLuUUgFDyLt49mUtdO1XeQ==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1968,10 +2005,6 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  p-map@3.0.0:
-    resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
-    engines: {node: '>=8'}
-
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
@@ -1979,13 +2012,6 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-
-  package-hash@4.0.0:
-    resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
-    engines: {node: '>=8'}
-
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
@@ -2029,10 +2055,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -2040,6 +2062,9 @@ packages:
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
     engines: {node: '>=4'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -2059,10 +2084,6 @@ packages:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
 
-  pkg-dir@4.2.0:
-    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
-    engines: {node: '>=8'}
-
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -2070,6 +2091,10 @@ packages:
   portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
     engines: {node: '>= 10.12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2089,10 +2114,6 @@ packages:
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
-  process-on-spawn@1.1.0:
-    resolution: {integrity: sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==}
-    engines: {node: '>=8'}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -2125,9 +2146,6 @@ packages:
 
   ramda@0.27.2:
     resolution: {integrity: sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==}
-
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2164,10 +2182,6 @@ packages:
     resolution: {integrity: sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==}
     engines: {node: '>=18'}
 
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
-
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
@@ -2180,21 +2194,10 @@ packages:
     resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
     engines: {node: '>=12'}
 
-  release-zalgo@1.0.0:
-    resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
-    engines: {node: '>=4'}
-
   replace-in-file@9.0.0:
     resolution: {integrity: sha512-ACFXyc5ninRlHSVw8ZRht0Fd/BKoje8mpbIDZjbOU/LCaaoZzD9uo3zDQNkULDhcrvhXyL38FCcF1D2SiHM6Vg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
-
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
-  require-main-filename@2.0.0:
-    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   requireindex@1.2.0:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
@@ -2207,10 +2210,6 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-
-  resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -2228,9 +2227,9 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
-  rimraf@6.1.3:
-    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
-    engines: {node: 20 || >=22}
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   run-async@4.0.6:
@@ -2262,12 +2261,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
-
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2275,6 +2268,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -2300,14 +2296,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
-  spawn-wrap@3.0.0:
-    resolution: {integrity: sha512-z+s5vv4KzFPJVddGab0xX2n7kQPGMdNUX5l9T8EJqsXdKTWpcxmAqWHpsgHEXoC1taGBCc7b79bi62M5kdbrxQ==}
-    engines: {node: '>=8'}
-
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -2320,16 +2308,19 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   sql-escaper@1.5.1:
     resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
@@ -2348,10 +2339,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -2382,10 +2369,6 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-
-  strip-bom@4.0.0:
-    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
-    engines: {node: '>=8'}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -2453,16 +2436,23 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
-  test-exclude@8.0.0:
-    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
-    engines: {node: 20 || >=22}
-
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.10:
     resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
@@ -2520,9 +2510,6 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  typedarray-to-buffer@3.1.5:
-    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2554,13 +2541,94 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-command@0.1.0:
     resolution: {integrity: sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==}
     engines: {node: '>=22'}
     hasBin: true
-
-  which-module@2.0.1:
-    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -2576,6 +2644,11 @@ packages:
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
     engines: {node: '>=18'}
@@ -2584,24 +2657,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerpool@9.3.4:
-    resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
-
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
     engines: {node: '>=20'}
-
-  wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
-
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -2609,12 +2667,6 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  write-file-atomic@3.0.3:
-    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
-
-  y18n@4.0.3:
-    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2627,29 +2679,9 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
-  yargs-parser@18.1.3:
-    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
-    engines: {node: '>=6'}
-
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs-unparser@2.0.0:
-    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
-    engines: {node: '>=10'}
-
-  yargs@15.4.1:
-    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
-    engines: {node: '>=8'}
-
-  yargs@17.7.3:
-    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
-    engines: {node: '>=12'}
 
   yargs@18.1.0:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
@@ -2784,6 +2816,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@ember-data/rfc395-data@0.0.4': {}
 
@@ -2991,28 +3025,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
-
-  '@istanbuljs/load-nyc-config@1.1.0':
-    dependencies:
-      camelcase: 5.3.1
-      find-up: 4.1.0
-      get-package-type: 0.1.0
-      js-yaml: 3.15.1
-      resolve-from: 5.0.0
-
-  '@istanbuljs/schema@0.1.6': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3057,8 +3072,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
+  '@oxc-project/types@0.143.0': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -3071,6 +3085,50 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -3091,6 +3149,8 @@ snapshots:
       '@sinonjs/commons': 3.0.1
       type-detect: 4.1.0
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tryghost/errors@3.3.7': {}
 
   '@tryghost/zip@3.5.6(supports-color@8.1.1)':
@@ -3103,6 +3163,13 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -3214,6 +3281,61 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0))
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@26.2.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   abbrev@5.0.0: {}
 
   abort-controller@3.0.0:
@@ -3225,11 +3347,6 @@ snapshots:
       acorn: 8.18.0
 
   acorn@8.18.0: {}
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
 
   ajv@6.15.0:
     dependencies:
@@ -3258,10 +3375,6 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  append-transform@2.0.0:
-    dependencies:
-      default-require-extensions: 3.0.1
-
   archiver@8.0.0:
     dependencies:
       async: 3.2.6
@@ -3278,13 +3391,15 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  archy@1.0.0: {}
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async@3.2.6: {}
 
@@ -3345,15 +3460,9 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.4:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
-
-  browser-stdout@1.3.1: {}
 
   browserslist@4.28.8:
     dependencies:
@@ -3376,27 +3485,11 @@ snapshots:
 
   builtin-modules@3.3.0: {}
 
-  caching-transform@4.0.0:
-    dependencies:
-      hasha: 5.2.2
-      make-dir: 3.1.0
-      package-hash: 4.0.0
-      write-file-atomic: 3.0.3
-
   callsites@3.1.0: {}
-
-  camelcase@5.3.1: {}
-
-  camelcase@6.3.0: {}
 
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001809: {}
-
-  chai-as-promised@8.0.2(chai@6.2.2):
-    dependencies:
-      chai: 6.2.2
-      check-error: 2.1.3
 
   chai@6.2.2: {}
 
@@ -3411,12 +3504,6 @@ snapshots:
 
   chardet@2.2.0: {}
 
-  check-error@2.1.3: {}
-
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
-
   chownr@3.0.0: {}
 
   ci-info@3.9.0: {}
@@ -3424,8 +3511,6 @@ snapshots:
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
-
-  clean-stack@2.2.0: {}
 
   cli-boxes@3.0.0: {}
 
@@ -3449,18 +3534,6 @@ snapshots:
 
   cli-width@4.1.0: {}
 
-  cliui@6.0.0:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
@@ -3474,8 +3547,6 @@ snapshots:
   color-name@1.1.4: {}
 
   colors@1.4.0: {}
-
-  commondir@1.0.1: {}
 
   compress-commons@7.0.1:
     dependencies:
@@ -3493,8 +3564,6 @@ snapshots:
       proto-list: 1.2.4
 
   content-tag@2.0.3: {}
-
-  convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -3532,19 +3601,11 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
-  decamelize@1.2.0: {}
-
-  decamelize@4.0.0: {}
-
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
-  default-require-extensions@3.0.1:
-    dependencies:
-      strip-bom: 4.0.0
-
-  diff@7.0.0: {}
+  detect-libc@2.1.2: {}
 
   diff@9.0.0: {}
 
@@ -3552,8 +3613,6 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
-
-  eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -3584,8 +3643,6 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
-  emoji-regex@9.2.2: {}
-
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -3603,7 +3660,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es6-error@4.1.1: {}
+  es-module-lexer@2.3.1: {}
 
   escalade@3.2.0: {}
 
@@ -3789,8 +3846,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 4.2.1
 
-  esprima@4.0.1: {}
-
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -3802,6 +3857,10 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -3857,6 +3916,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.2.0
 
+  expect-type@1.4.0: {}
+
   extract-zip@2.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -3906,12 +3967,6 @@ snapshots:
       is-object: 1.0.2
       merge-descriptors: 1.0.3
 
-  find-cache-dir@3.3.2:
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
-
   find-plugins@1.1.7(supports-color@8.1.1):
     dependencies:
       dag-map: 2.0.2
@@ -3950,27 +4005,16 @@ snapshots:
       flatted: 3.4.4
       keyv: 4.5.4
 
-  flat@5.0.2: {}
-
   flatted@3.4.4: {}
-
-  foreground-child@2.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 3.0.7
-
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
-  fromentries@1.3.2: {}
 
   fs-extra@11.4.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3985,8 +4029,6 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
-
-  get-package-type@0.1.0: {}
 
   get-stream@5.2.0:
     dependencies:
@@ -4006,15 +4048,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   glob@13.0.6:
     dependencies:
@@ -4050,16 +4083,9 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hasha@5.2.2:
-    dependencies:
-      is-stream: 2.0.1
-      type-fest: 0.8.1
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
-
-  he@1.2.0: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -4137,27 +4163,15 @@ snapshots:
 
   is-object@1.0.2: {}
 
-  is-path-inside@3.0.3: {}
-
-  is-plain-obj@2.1.0: {}
-
   is-plain-obj@4.1.0: {}
 
   is-property@1.0.2: {}
-
-  is-stream@2.0.1: {}
 
   is-stream@3.0.0: {}
 
   is-stream@4.0.1: {}
 
-  is-typedarray@1.0.0: {}
-
-  is-unicode-supported@0.1.0: {}
-
   is-unicode-supported@2.1.0: {}
-
-  is-windows@1.0.2: {}
 
   isarray@1.0.0: {}
 
@@ -4167,59 +4181,20 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-hook@3.0.0:
-    dependencies:
-      append-transform: 2.0.0
-
-  istanbul-lib-instrument@6.0.3(supports-color@8.1.1):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/parser': 7.29.8
-      '@istanbuljs/schema': 0.1.6
-      istanbul-lib-coverage: 3.2.2
-      semver: 7.8.5
-    transitivePeerDependencies:
-      - supports-color
-
-  istanbul-lib-processinfo@3.0.1:
-    dependencies:
-      archy: 1.0.0
-      cross-spawn: 7.0.6
-      istanbul-lib-coverage: 3.2.2
-      p-map: 3.0.0
-      rimraf: 6.1.3
-
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      istanbul-lib-coverage: 3.2.2
-      source-map: 0.6.1
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.15.1:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.3.1:
     dependencies:
@@ -4292,6 +4267,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lines-and-columns@1.2.4: {}
 
   listr2@11.0.0:
@@ -4322,8 +4346,6 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
-  lodash.flattendeep@4.4.0: {}
-
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -4348,11 +4370,6 @@ snapshots:
 
   lodash@4.18.1: {}
 
-  log-symbols@4.1.0:
-    dependencies:
-      chalk: 4.1.2
-      is-unicode-supported: 0.1.0
-
   log-symbols@7.0.1:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -4373,8 +4390,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  lru-cache@10.4.3: {}
-
   lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
@@ -4383,9 +4398,15 @@ snapshots:
 
   lru.min@1.1.4: {}
 
-  make-dir@3.1.0:
+  magic-string@0.30.21:
     dependencies:
-      semver: 6.3.1
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
@@ -4413,10 +4434,6 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.18
 
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.1.4
-
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -4424,30 +4441,6 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
-
-  mocha@11.8.0:
-    dependencies:
-      browser-stdout: 1.3.1
-      chokidar: 4.0.3
-      debug: 4.4.3(supports-color@8.1.1)
-      diff: 7.0.0
-      escape-string-regexp: 4.0.0
-      find-up: 5.0.0
-      glob: 10.5.0
-      he: 1.2.0
-      is-path-inside: 3.0.3
-      js-yaml: 4.3.1
-      log-symbols: 4.1.0
-      minimatch: 9.0.9
-      ms: 2.1.3
-      picocolors: 1.1.1
-      serialize-javascript: 6.0.2
-      strip-json-comments: 3.1.1
-      supports-color: 8.1.1
-      workerpool: 9.3.4
-      yargs: 17.7.3
-      yargs-parser: 21.1.1
-      yargs-unparser: 2.0.0
 
   module-not-found-error@1.0.1: {}
 
@@ -4470,6 +4463,8 @@ snapshots:
     dependencies:
       lru.min: 1.1.4
 
+  nanoid@3.3.18: {}
+
   natural-compare@1.4.0: {}
 
   no-case@3.0.4:
@@ -4482,10 +4477,6 @@ snapshots:
       '@mswjs/interceptors': 0.41.9
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
-
-  node-preload@0.2.1:
-    dependencies:
-      process-on-spawn: 1.1.0
 
   node-releases@2.0.53: {}
 
@@ -4509,39 +4500,9 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  nyc@18.0.0(supports-color@8.1.1):
-    dependencies:
-      '@istanbuljs/load-nyc-config': 1.1.0
-      '@istanbuljs/schema': 0.1.6
-      caching-transform: 4.0.0
-      convert-source-map: 1.9.0
-      decamelize: 1.2.0
-      find-cache-dir: 3.3.2
-      find-up: 4.1.0
-      foreground-child: 3.3.1
-      get-package-type: 0.1.0
-      glob: 13.0.6
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-hook: 3.0.0
-      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
-      istanbul-lib-processinfo: 3.0.1
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1(supports-color@8.1.1)
-      istanbul-reports: 3.2.0
-      make-dir: 3.1.0
-      node-preload: 0.2.1
-      p-map: 3.0.0
-      process-on-spawn: 1.1.0
-      resolve-from: 5.0.0
-      rimraf: 6.1.3
-      signal-exit: 3.0.7
-      spawn-wrap: 3.0.0
-      test-exclude: 8.0.0
-      yargs: 15.4.1
-    transitivePeerDependencies:
-      - supports-color
-
   object-assign@4.1.1: {}
+
+  obug@2.1.4: {}
 
   once@1.4.0:
     dependencies:
@@ -4601,22 +4562,9 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  p-map@3.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
-
   p-try@1.0.0: {}
 
   p-try@2.2.0: {}
-
-  package-hash@4.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      hasha: 5.2.2
-      lodash.flattendeep: 4.4.0
-      release-zalgo: 1.0.0
-
-  package-json-from-dist@1.0.1: {}
 
   package-json@10.0.1:
     dependencies:
@@ -4655,11 +4603,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
-
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.5.2
@@ -4668,6 +4611,8 @@ snapshots:
   path-type@3.0.0:
     dependencies:
       pify: 3.0.0
+
+  pathe@2.0.3: {}
 
   pend@1.2.0: {}
 
@@ -4681,10 +4626,6 @@ snapshots:
 
   pify@3.0.0: {}
 
-  pkg-dir@4.2.0:
-    dependencies:
-      find-up: 4.1.0
-
   pluralize@8.0.0: {}
 
   portfinder@1.0.38(supports-color@8.1.1):
@@ -4693,6 +4634,12 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -4710,10 +4657,6 @@ snapshots:
       ps-list: 8.1.1
 
   process-nextick-args@2.0.1: {}
-
-  process-on-spawn@1.1.0:
-    dependencies:
-      fromentries: 1.3.2
 
   process@0.11.10: {}
 
@@ -4739,10 +4682,6 @@ snapshots:
   punycode@2.3.1: {}
 
   ramda@0.27.2: {}
-
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   rc@1.2.8:
     dependencies:
@@ -4799,8 +4738,6 @@ snapshots:
     dependencies:
       minimatch: 10.2.6
 
-  readdirp@4.1.2: {}
-
   regexp-tree@0.1.27: {}
 
   registry-auth-token@5.1.1:
@@ -4811,27 +4748,17 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  release-zalgo@1.0.0:
-    dependencies:
-      es6-error: 4.1.1
-
   replace-in-file@9.0.0:
     dependencies:
       chalk: 6.0.0
       glob: 13.0.6
       yargs: 18.1.0
 
-  require-directory@2.1.1: {}
-
-  require-main-filename@2.0.0: {}
-
   requireindex@1.2.0: {}
 
   resolve-from@2.0.0: {}
 
   resolve-from@4.0.0: {}
-
-  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -4851,10 +4778,25 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  rimraf@6.1.3:
+  rolldown@1.2.3:
     dependencies:
-      glob: 13.0.6
-      package-json-from-dist: 1.0.1
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
 
   run-async@4.0.6: {}
 
@@ -4874,17 +4816,13 @@ snapshots:
 
   semver@7.8.5: {}
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
-
-  set-blocking@2.0.0: {}
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -4911,18 +4849,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.6.1: {}
-
-  spawn-wrap@3.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      foreground-child: 2.0.0
-      is-windows: 1.0.2
-      make-dir: 3.1.0
-      rimraf: 6.1.3
-      signal-exit: 3.0.7
-      which: 2.0.2
-
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -4937,11 +4863,13 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  sprintf-js@1.0.3: {}
-
   sql-escaper@1.5.1: {}
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.3.2: {}
 
@@ -4966,12 +4894,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -5006,8 +4928,6 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-bom@4.0.0: {}
-
   strip-final-newline@3.0.0: {}
 
   strip-final-newline@4.0.0: {}
@@ -5027,6 +4947,7 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+    optional: true
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -5070,22 +4991,22 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  test-exclude@8.0.0:
-    dependencies:
-      '@istanbuljs/schema': 0.1.6
-      glob: 13.0.6
-      minimatch: 10.2.6
-
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   tldts-core@7.4.10: {}
 
@@ -5126,10 +5047,6 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typedarray-to-buffer@3.1.5:
-    dependencies:
-      is-typedarray: 1.0.0
-
   typescript@5.9.3: {}
 
   undici-types@8.3.0: {}
@@ -5155,9 +5072,46 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  which-command@0.1.0: {}
+  vite@8.2.1(@types/node@26.2.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      fsevents: 2.3.3
 
-  which-module@2.0.1: {}
+  vitest@4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@26.2.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+
+  which-command@0.1.0: {}
 
   which@1.3.1:
     dependencies:
@@ -5171,36 +5125,21 @@ snapshots:
     dependencies:
       isexe: 4.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   widest-line@5.0.0:
     dependencies:
       string-width: 7.2.0
 
   word-wrap@1.2.5: {}
 
-  workerpool@9.3.4: {}
-
   wrap-ansi@10.0.0:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 8.2.2
-      strip-ansi: 7.2.0
-
-  wrap-ansi@6.2.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
       strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
@@ -5211,60 +5150,13 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  write-file-atomic@3.0.3:
-    dependencies:
-      imurmurhash: 0.1.4
-      is-typedarray: 1.0.0
-      signal-exit: 3.0.7
-      typedarray-to-buffer: 3.1.5
-
-  y18n@4.0.3: {}
-
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
 
-  yargs-parser@18.1.3:
-    dependencies:
-      camelcase: 5.3.1
-      decamelize: 1.2.0
-
-  yargs-parser@21.1.1: {}
-
   yargs-parser@22.0.0: {}
-
-  yargs-unparser@2.0.0:
-    dependencies:
-      camelcase: 6.3.0
-      decamelize: 4.0.0
-      flat: 5.0.2
-      is-plain-obj: 2.1.0
-
-  yargs@15.4.1:
-    dependencies:
-      cliui: 6.0.0
-      decamelize: 1.2.0
-      find-up: 4.1.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      require-main-filename: 2.0.0
-      set-blocking: 2.0.0
-      string-width: 4.2.3
-      which-module: 2.0.1
-      y18n: 4.0.3
-      yargs-parser: 18.1.3
-
-  yargs@17.7.3:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   yargs@18.1.0:
     dependencies:

--- a/test/root-hooks.mjs
+++ b/test/root-hooks.mjs
@@ -1,8 +1,0 @@
-import * as chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-
-export const mochaHooks = {
-    beforeAll() {
-        chai.use(chaiAsPromised);
-    }
-};

--- a/test/setup.mjs
+++ b/test/setup.mjs
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import {createRequire} from 'node:module';
+
+// Vitest runs specs through vite-node, which never populates require.main. Several
+// modules (and the specs covering them) read require.main.filename to work out which
+// ghost-cli install they belong to, so point it at this checkout's executable.
+const require = createRequire(import.meta.url);
+
+if (!require.main) {
+    process.mainModule = {filename: path.resolve(import.meta.dirname, '../bin/ghost')};
+}

--- a/test/unit/bootstrap-spec.js
+++ b/test/unit/bootstrap-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const {setupTestFolder, cleanupTestFolders} = require('../utils/test-folder');
 const path = require('path');
@@ -12,12 +11,16 @@ const yargsMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(yargs))
 
 const modulePath = '../../lib/bootstrap';
 
+// the test runner registers unhandledRejection listeners of its own, so snapshot them
+// before the CLI's handler is added in order to tell them apart later
+const preexistingRejectionListeners = process.listeners('unhandledRejection');
+
 describe('Unit: Bootstrap', function () {
     afterEach(function () {
         sinon.restore();
     });
 
-    after(() => {
+    afterAll(() => {
         cleanupTestFolders();
     });
 
@@ -119,6 +122,9 @@ describe('Unit: Bootstrap', function () {
     describe('process rejection handler', function () {
         require(modulePath);
 
+        const rejectionHandler = () => process.listeners('unhandledRejection')
+            .find(listener => !preexistingRejectionListeners.includes(listener));
+
         let consoleStub;
 
         beforeEach(function () {
@@ -126,12 +132,11 @@ describe('Unit: Bootstrap', function () {
         });
 
         it('is registered', function () {
-            // mocha itself registers an unhandledRejection listener, so this is 2 instead of 1
-            expect(process.listenerCount('unhandledRejection')).to.equal(2);
+            expect(rejectionHandler()).to.exist;
         });
 
         it('throws reason and logs to console if it exists', function () {
-            const handler = process.listeners('unhandledRejection')[0];
+            const handler = rejectionHandler();
             const testError = new Error('some problem');
 
             try {
@@ -145,7 +150,7 @@ describe('Unit: Bootstrap', function () {
         });
 
         it('logs reason if reason isn\'t an error', function () {
-            const handler = process.listeners('unhandledRejection')[0];
+            const handler = rejectionHandler();
 
             try {
                 handler('some problem');
@@ -158,7 +163,7 @@ describe('Unit: Bootstrap', function () {
         });
 
         it('logs promise if no reason given', function () {
-            const handler = process.listeners('unhandledRejection')[0];
+            const handler = rejectionHandler();
             const p = new Promise((resolve) => {
                 resolve();
             });
@@ -234,9 +239,8 @@ describe('Unit: Bootstrap', function () {
             });
         });
 
-        it('errors if no command name matches', function () {
-            this.timeout(10000); // this test can take awhile depending on the system
-
+        // this test can take awhile depending on the system
+        it('errors if no command name matches', {timeout: 10000}, function () {
             const error = sinon.stub(console, 'error');
             const exit = sinon.stub(process, 'exit');
 

--- a/test/unit/command-spec.js
+++ b/test/unit/command-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/test/unit/commands/buster-spec.js
+++ b/test/unit/commands/buster-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 

--- a/test/unit/commands/check-update-spec.js
+++ b/test/unit/commands/check-update-spec.js
@@ -1,6 +1,5 @@
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
-const {expect} = require('chai');
 
 const modulePath = '../../../lib/commands/check-update';
 

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/test/unit/commands/doctor/checks/binary-deps-spec.js
+++ b/test/unit/commands/doctor/checks/binary-deps-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const semver = require('semver');
 

--- a/test/unit/commands/doctor/checks/check-directory-spec.js
+++ b/test/unit/commands/doctor/checks/check-directory-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 

--- a/test/unit/commands/doctor/checks/check-memory-spec.js
+++ b/test/unit/commands/doctor/checks/check-memory-spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const sysinfo = require('systeminformation');

--- a/test/unit/commands/doctor/checks/check-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/check-permissions-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const proxyquire = require('proxyquire');

--- a/test/unit/commands/doctor/checks/content-folder-spec.js
+++ b/test/unit/commands/doctor/checks/content-folder-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const proxyquire = require('proxyquire');

--- a/test/unit/commands/doctor/checks/file-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/file-permissions-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const proxyquire = require('proxyquire');

--- a/test/unit/commands/doctor/checks/folder-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/folder-permissions-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const proxyquire = require('proxyquire');

--- a/test/unit/commands/doctor/checks/free-space-spec.js
+++ b/test/unit/commands/doctor/checks/free-space-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 
 const sysinfo = require('systeminformation');

--- a/test/unit/commands/doctor/checks/install-folder-permissions-spec.js
+++ b/test/unit/commands/doctor/checks/install-folder-permissions-spec.js
@@ -1,6 +1,5 @@
 'use strict';
 const fs = require('node:fs/promises');
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 

--- a/test/unit/commands/doctor/checks/logged-in-ghost-user-spec.js
+++ b/test/unit/commands/doctor/checks/logged-in-ghost-user-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const fs = require('fs');
 

--- a/test/unit/commands/doctor/checks/logged-in-user-owner-spec.js
+++ b/test/unit/commands/doctor/checks/logged-in-user-owner-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const fs = require('fs');
 

--- a/test/unit/commands/doctor/checks/logged-in-user-spec.js
+++ b/test/unit/commands/doctor/checks/logged-in-user-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const errors = require('../../../../../lib/errors');
 const ghostUser = require('../../../../../lib/utils/use-ghost-user');

--- a/test/unit/commands/doctor/checks/mysql-spec.js
+++ b/test/unit/commands/doctor/checks/mysql-spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const configStub = require('../../../../utils/config-stub');
 

--- a/test/unit/commands/doctor/checks/node-version-spec.js
+++ b/test/unit/commands/doctor/checks/node-version-spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const {stripVTControlCharacters: stripAnsi} = require('util');
 const proxyquire = require('proxyquire');

--- a/test/unit/commands/doctor/checks/python-setuptools-spec.js
+++ b/test/unit/commands/doctor/checks/python-setuptools-spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 

--- a/test/unit/commands/doctor/checks/system-stack-spec.js
+++ b/test/unit/commands/doctor/checks/system-stack-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 
 const sysinfo = require('systeminformation');

--- a/test/unit/commands/doctor/checks/validate-config-spec.js
+++ b/test/unit/commands/doctor/checks/validate-config-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const errors = require('../../../../../lib/errors');
@@ -14,7 +13,7 @@ describe('Unit: Doctor Checks > validateConfig', function () {
         sinon.restore();
     });
 
-    after(() => {
+    afterAll(() => {
         cleanupTestFolders();
     });
 

--- a/test/unit/commands/doctor/command-spec.js
+++ b/test/unit/commands/doctor/command-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 

--- a/test/unit/commands/export-spec.js
+++ b/test/unit/commands/export-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/test/unit/commands/import-spec.js
+++ b/test/unit/commands/import-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/test/unit/commands/install-spec.js
+++ b/test/unit/commands/install-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const each = require('../../utils/each');

--- a/test/unit/commands/log-spec.js
+++ b/test/unit/commands/log-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const Errors = require('../../../lib/errors');

--- a/test/unit/commands/ls-spec.js
+++ b/test/unit/commands/ls-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const {stripVTControlCharacters: stripAnsi} = require('util');
 

--- a/test/unit/commands/migrate-spec.js
+++ b/test/unit/commands/migrate-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 

--- a/test/unit/commands/restart-spec.js
+++ b/test/unit/commands/restart-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const modulePath = '../../../lib/commands/restart';

--- a/test/unit/commands/run-spec.js
+++ b/test/unit/commands/run-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const EventEmitter = require('events');
@@ -143,9 +142,7 @@ describe('Unit: Commands > Run', function () {
         }
     });
 
-    it('useDirect spawns child process and handles events correctly', function (done) {
-        this.timeout(5000);
-
+    it('useDirect spawns child process and handles events correctly', {timeout: 5000}, async function () {
         const childStub = new EventEmitter();
         childStub.stderr = getReadableStream();
 
@@ -190,21 +187,16 @@ describe('Unit: Commands > Run', function () {
         // check message handler with error
         childStub.emit('message', {error: 'oops I did it again'});
 
-        setTimeout(() => {
-            try {
-                expect(successStub.called).to.be.false;
-                expect(errorStub.calledOnce).to.be.true;
-                expect(errorStub.calledWithExactly({message: 'oops I did it again'})).to.be.true;
-                done();
-            } catch (e) {
-                done(e);
-            }
-        }, 2000);
+        await new Promise((resolve) => {
+            setTimeout(resolve, 2000);
+        });
+
+        expect(successStub.called).to.be.false;
+        expect(errorStub.calledOnce).to.be.true;
+        expect(errorStub.calledWithExactly({message: 'oops I did it again'})).to.be.true;
     });
 
-    it('useDirect spawns child process and handles events correctly (v4+)', async function () {
-        this.timeout(10000);
-
+    it('useDirect spawns child process and handles events correctly (v4+)', {timeout: 10000}, async function () {
         const childStub = new EventEmitter();
         childStub.stderr = getReadableStream();
 

--- a/test/unit/commands/setup-spec.js
+++ b/test/unit/commands/setup-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const path = require('path');

--- a/test/unit/commands/start-spec.js
+++ b/test/unit/commands/start-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const createConfigStub = require('../../utils/config-stub');

--- a/test/unit/commands/stop-spec.js
+++ b/test/unit/commands/stop-spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 

--- a/test/unit/commands/uninstall-spec.js
+++ b/test/unit/commands/uninstall-spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/test/unit/commands/update-spec.js
+++ b/test/unit/commands/update-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const configStub = require('../../utils/config-stub');
@@ -33,7 +32,7 @@ function createTestInstance(version, cliVersion, previousVersion = null, config 
 }
 
 describe('Unit: Commands > Update', function () {
-    after(() => {
+    afterAll(() => {
         cleanupTestFolders();
     });
 

--- a/test/unit/commands/version-spec.js
+++ b/test/unit/commands/version-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const {stripVTControlCharacters: stripAnsi} = require('util');

--- a/test/unit/errors-spec.js
+++ b/test/unit/errors-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const {stripVTControlCharacters: stripAnsi} = require('util');
 
 const errors = require('../../lib/errors');

--- a/test/unit/extension-spec.js
+++ b/test/unit/extension-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const fs = require('fs-extra');
 const os = require('os');

--- a/test/unit/index-spec.js
+++ b/test/unit/index-spec.js
@@ -1,6 +1,5 @@
 'use strict';
 const path = require('path');
-const expect = require('chai').expect;
 const proxyquire = require('proxyquire').noCallThru();
 
 const errors = require('../../lib/errors');

--- a/test/unit/instance-spec.js
+++ b/test/unit/instance-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const createConfigStub = require('../utils/config-stub');
 const {setupTestFolder} = require('../utils/test-folder');

--- a/test/unit/migrations-spec.js
+++ b/test/unit/migrations-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const createConfig = require('../utils/config-stub');
 
@@ -82,7 +81,7 @@ describe('Unit: Migrations', function () {
         expect(configs.production.save.called).to.be.false;
     });
 
-    it('ensureMediaFileAndPublicFolders', async () => {
+    describe('ensureMediaFileAndPublicFolders', () => {
         it('if ghost user owns directory, runs `sudo mkdir` as ghost user', function () {
             const ghostUserStub = sinon.stub(ghostUser, 'shouldUseGhostUser').returns(true);
             const sudoStub = sinon.stub().resolves();
@@ -94,7 +93,7 @@ describe('Unit: Migrations', function () {
                 ui: {sudo: sudoStub}
             };
 
-            return migrations[0].task(context).then(() => {
+            return migrations[2].task(context).then(() => {
                 expect(ghostUserStub.calledThrice).to.be.true;
                 expect(ghostUserStub.calledWithExactly('/var/www/ghost/content')).to.be.true;
                 expect(sudoStub.calledThrice).to.be.true;
@@ -121,7 +120,7 @@ describe('Unit: Migrations', function () {
 
             const context = {instance: {config: config}};
 
-            return migrations[0].task(context).then(() => {
+            return migrations[2].task(context).then(() => {
                 expect(ghostUserStub.calledThrice).to.be.true;
                 expect(ghostUserStub.calledWithExactly('/var/www/ghost/content')).to.be.true;
                 expect(fsStub.calledThrice).to.be.true;

--- a/test/unit/process-manager-spec.js
+++ b/test/unit/process-manager-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const getConfigStub = require('../utils/config-stub');

--- a/test/unit/scripts/release-notes-spec.js
+++ b/test/unit/scripts/release-notes-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 
 const {buildReleaseNotes, NO_CHANGES_MESSAGE} = require('../../../scripts/release-notes');
 

--- a/test/unit/scripts/release-spec.js
+++ b/test/unit/scripts/release-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 
 const {detectBumpType} = require('../../../scripts/release');
 

--- a/test/unit/system-spec.js
+++ b/test/unit/system-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const os = require('os');

--- a/test/unit/tasks/configure/get-prompts-spec.js
+++ b/test/unit/tasks/configure/get-prompts-spec.js
@@ -1,5 +1,3 @@
-const {expect} = require('chai');
-
 const Config = require('../../../../lib/utils/config');
 const getPrompts = require('../../../../lib/tasks/configure/get-prompts');
 const {validate: validateUrl, ensureProtocol} = require('../../../../lib/utils/url');

--- a/test/unit/tasks/configure/index-spec.js
+++ b/test/unit/tasks/configure/index-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 

--- a/test/unit/tasks/configure/options-spec.js
+++ b/test/unit/tasks/configure/options-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const path = require('path');

--- a/test/unit/tasks/configure/parse-options-spec.js
+++ b/test/unit/tasks/configure/parse-options-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/test/unit/tasks/ensure-structure-spec.js
+++ b/test/unit/tasks/ensure-structure-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const {setupTestFolder, cleanupTestFolders} = require('../../utils/test-folder');
 const fs = require('fs');
@@ -8,7 +7,7 @@ const path = require('path');
 const ensureStructure = require('../../../lib/tasks/ensure-structure');
 
 describe('Unit: Tasks > ensure-structure', function () {
-    after(() => {
+    afterAll(() => {
         cleanupTestFolders();
     });
 

--- a/test/unit/tasks/import/api-spec.js
+++ b/test/unit/tasks/import/api-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const nock = require('nock');
 const path = require('path');
 const tmp = require('tmp');

--- a/test/unit/tasks/import/parse-export-spec.js
+++ b/test/unit/tasks/import/parse-export-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const fs = require('fs-extra');
 const path = require('path');

--- a/test/unit/tasks/import/tasks-spec.js
+++ b/test/unit/tasks/import/tasks-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const each = require('../../../utils/each');
@@ -315,7 +314,7 @@ describe('Unit: Tasks > Import > Tasks', function () {
             process.env.GHOST_CLI_STAFF_AUTH_TOKEN = 'invalid-token';
             await expect(
                 exportTask({prompt}, {config, version: TOKEN_AUTH_MIN_VERSION}, 'test-export.json')
-            ).to.be.rejectedWith('GHOST_CLI_STAFF_AUTH_TOKEN is not a valid token');
+            ).rejects.toThrow('GHOST_CLI_STAFF_AUTH_TOKEN is not a valid token');
             expect(isSetup.calledOnceWithExactly(TOKEN_AUTH_MIN_VERSION, 'http://localhost:2368')).to.be.true;
             expect(prompt.called).to.be.false;
             expect(downloadContentExport.called).to.be.false;

--- a/test/unit/tasks/install-dependencies-spec.js
+++ b/test/unit/tasks/install-dependencies-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noPreserveCache();
 const each = require('../../utils/each');
@@ -32,7 +31,7 @@ describe('Unit: Tasks > install-dependencies', function () {
         }
     });
 
-    after(() => {
+    afterAll(() => {
         cleanupTestFolders();
     });
 

--- a/test/unit/tasks/linux-spec.js
+++ b/test/unit/tasks/linux-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const each = require('../../utils/each');

--- a/test/unit/tasks/major-update/data-spec.js
+++ b/test/unit/tasks/major-update/data-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const {CliError} = require('../../../../lib/errors');

--- a/test/unit/tasks/major-update/ui-spec.js
+++ b/test/unit/tasks/major-update/ui-spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const configStub = require('../../../utils/config-stub');

--- a/test/unit/tasks/migrator-spec.js
+++ b/test/unit/tasks/migrator-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const configStub = require('../../utils/config-stub');

--- a/test/unit/tasks/release-notes-spec.js
+++ b/test/unit/tasks/release-notes-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const nock = require('nock');
 
@@ -23,12 +22,12 @@ function stubGithub() {
 }
 
 describe('Unit: Tasks > Release Notes', function () {
-    before(function () {
+    beforeAll(function () {
         // ky retries failed requests, so an unmocked attempt would otherwise hit the real API
         nock.disableNetConnect();
     });
 
-    after(function () {
+    afterAll(function () {
         nock.enableNetConnect();
     });
 

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const {expect} = require('chai');
 const chalk = require('chalk').default;
 const hasAnsi = require('has-ansi').default;
 const {stripVTControlCharacters: stripAnsi} = require('util');
@@ -12,7 +11,7 @@ const EventEmitter = require('events');
 const modulePath = '../../../lib/ui';
 
 describe('Unit: UI', function () {
-    before(() => {
+    beforeAll(() => {
         // Workaround because GitHub Actions doesn't currently report a TTY
         process.stdout.isTTY = true;
     });
@@ -105,19 +104,13 @@ describe('Unit: UI', function () {
             });
         });
 
-        it('with quiet enabled, passes through rejection', function (done) {
+        it('with quiet enabled, passes through rejection', async function () {
             const ui = new UI();
             const testFunc = sinon.stub().rejects(new Error('something went wrong!'));
 
-            ui.run(testFunc, null, {quiet: true}).then(() => {
-                done(new Error('then should not be called'));
-            }).catch((error) => {
-                expect(error, 'run catch error').to.be.an.instanceOf(Error);
-                expect(error.message, 'run catch error message').to.equal('something went wrong!');
-                expect(testFunc.calledOnce).to.be.true;
-                expect(oraStub.called).to.be.false;
-                done();
-            }).catch(done);
+            await expect(ui.run(testFunc, null, {quiet: true})).rejects.toThrow('something went wrong!');
+            expect(testFunc.calledOnce).to.be.true;
+            expect(oraStub.called).to.be.false;
         });
 
         it('with json enabled, skips the spinner', function () {
@@ -187,28 +180,22 @@ describe('Unit: UI', function () {
             });
         });
 
-        it('starts spinner with options, handles rejection', function (done) {
+        it('starts spinner with options, handles rejection', async function () {
             const ui = new UI({stdout: {stdout: true}});
             const testFunc = sinon.stub().rejects(new Error('something went wrong!'));
 
-            ui.run(testFunc, 'test').then(() => {
-                done(new Error('then should not be called'));
-            }).catch((error) => {
-                expect(error, 'run catch error').to.be.an.instanceOf(Error);
-                expect(error.message, 'run catch error message').to.equal('something went wrong!');
-                expect(testFunc.calledOnce).to.be.true;
-                expect(oraStub.calledOnce).to.be.true;
-                expect(oraStub.calledWithExactly({
-                    text: 'test',
-                    spinner: 'dots',
-                    stream: {stdout: true}
-                })).to.be.true;
-                expect(startStub.calledOnce).to.be.true;
-                expect(spinner.succeed.called).to.be.false;
-                expect(spinner.fail.calledOnce).to.be.true;
-                expect(ui.spinner, 'spinner is set to null').to.be.null;
-                done();
-            }).catch(done);
+            await expect(ui.run(testFunc, 'test')).rejects.toThrow('something went wrong!');
+            expect(testFunc.calledOnce).to.be.true;
+            expect(oraStub.calledOnce).to.be.true;
+            expect(oraStub.calledWithExactly({
+                text: 'test',
+                spinner: 'dots',
+                stream: {stdout: true}
+            })).to.be.true;
+            expect(startStub.calledOnce).to.be.true;
+            expect(spinner.succeed.called).to.be.false;
+            expect(spinner.fail.calledOnce).to.be.true;
+            expect(ui.spinner, 'spinner is set to null').to.be.null;
         });
     });
 
@@ -240,23 +227,17 @@ describe('Unit: UI', function () {
     describe('prompt', function () {
         const UI = require(modulePath);
 
-        it('fails when prompting is disabled', function (done) {
+        it('fails when prompting is disabled', function () {
             const ui = new UI();
             ui.allowPrompt = false;
             const noSpinStub = sinon.stub(ui, 'noSpin');
 
-            try {
-                ui.prompt({
-                    name: 'test',
-                    type: 'input',
-                    message: 'Enter anything'
-                });
-                done(new Error('error should have been thrown'));
-            } catch (error) {
-                expect(error.message).to.match(/Prompts have been disabled/);
-                expect(noSpinStub.called).to.be.false;
-                done();
-            }
+            expect(() => ui.prompt({
+                name: 'test',
+                type: 'input',
+                message: 'Enter anything'
+            })).to.throw(/Prompts have been disabled/);
+            expect(noSpinStub.called).to.be.false;
         });
 
         it('returns default if auto is true and prompts is an object', function () {
@@ -516,7 +497,8 @@ describe('Unit: UI', function () {
             const UI = proxyquire(modulePath, {listr2: {Listr: ListrStub}});
             const ui = new UI();
 
-            const error = await expect(ui.listr(['tasks'], false).run({})).to.be.rejectedWith(AggregateError);
+            const error = await ui.listr(['tasks'], false).run({}).catch(e => e);
+            expect(error).to.be.an.instanceof(AggregateError);
             expect(error.errors).to.deep.equal(collected);
         });
 
@@ -525,14 +507,14 @@ describe('Unit: UI', function () {
             const UI = proxyquire(modulePath, {listr2: {Listr: ListrStub}});
             const ui = new UI();
 
-            await expect(ui.listr(['tasks'], false).run({})).to.be.fulfilled;
+            await ui.listr(['tasks'], false).run({});
         });
     });
 
     describe('sudo', function () {
         const setupUI = execa => proxyquire(modulePath, {execa: {execa}});
 
-        it('runs a sudo command', function (done) {
+        it('runs a sudo command', async function () {
             const shellStub = sinon.stub();
             const UI = setupUI(shellStub);
             const ui = new UI();
@@ -541,25 +523,25 @@ describe('Unit: UI', function () {
             const promptStub = sinon.stub(ui, 'prompt').resolves({password: 'password'});
             const stderr = new EventEmitter();
 
-            const eCall = new RegExp(`sudo -S -p '#node-sudo-passwd#' -E -u ghost ${process.argv.slice(0, 2).join(' ')} -v`);
+            // argv contains the test runner's own path, which isn't regex-safe
+            const eCall = `sudo -S -p '#node-sudo-passwd#' -E -u ghost ${process.argv.slice(0, 2).join(' ')} -v`;
 
-            const stdin = streamTestUtils.getWritableStream((output) => {
-                expect(output).to.equal('password\n');
-                expect(logStub.calledOnce).to.be.true;
-                expect(logStub.calledWithExactly('+ sudo ghost -v', 'gray')).to.be.true;
-                expect(shellStub.calledOnce).to.be.true;
-                expect(shellStub.args[0][0]).to.match(eCall);
-                expect(shellStub.args[0][1]).to.deep.equal({cwd: '/var/foo', shell: true});
-                expect(promptStub.calledOnce).to.be.true;
-                done();
-            });
+            const {stream: stdin, written} = streamTestUtils.captureFirstWrite();
             shellStub.returns(Object.assign(new Promise(() => {}), {stdin: stdin, stderr: stderr}));
 
             ui.sudo('ghost -v', {cwd: '/var/foo', sudoArgs: ['-E -u ghost']});
             stderr.emit('data', '#node-sudo-passwd#');
+
+            expect(await written).to.equal('password\n');
+            expect(logStub.calledOnce).to.be.true;
+            expect(logStub.calledWithExactly('+ sudo ghost -v', 'gray')).to.be.true;
+            expect(shellStub.calledOnce).to.be.true;
+            expect(shellStub.args[0][0]).to.contain(eCall);
+            expect(shellStub.args[0][1]).to.deep.equal({cwd: '/var/foo', shell: true});
+            expect(promptStub.calledOnce).to.be.true;
         });
 
-        it('prompts for a password when sudo-rs wraps the prompt', function (done) {
+        it('prompts for a password when sudo-rs wraps the prompt', async function () {
             const shellStub = sinon.stub();
             const UI = setupUI(shellStub);
             const ui = new UI();
@@ -568,16 +550,15 @@ describe('Unit: UI', function () {
             const promptStub = sinon.stub(ui, 'prompt').resolves({password: 'password'});
             const stderr = new EventEmitter();
 
-            const stdin = streamTestUtils.getWritableStream((output) => {
-                expect(output).to.equal('password\n');
-                expect(promptStub.calledOnce).to.be.true;
-                done();
-            });
+            const {stream: stdin, written} = streamTestUtils.captureFirstWrite();
             shellStub.returns(Object.assign(new Promise(() => {}), {stdin: stdin, stderr: stderr}));
 
             ui.sudo('ghost -v', {sudoArgs: ['-E -u ghost']});
             // sudo-rs (default on Ubuntu 26+) wraps the `-p` value rather than replacing the prompt
             stderr.emit('data', '[sudo: #node-sudo-passwd#] Password: ');
+
+            expect(await written).to.equal('password\n');
+            expect(promptStub.calledOnce).to.be.true;
         });
 
         it('can handle defaults', function () {
@@ -652,32 +633,28 @@ describe('Unit: UI', function () {
     describe('log', function () {
         const UI = require(modulePath);
 
-        it('outputs message without color when no color is supplied', function (done) {
-            const stdout = streamTestUtils.getWritableStream(function (output) {
-                expect(output, 'output exists').to.be.ok;
-                expect(hasAnsi(output), 'output has color').to.be.false;
-                expect(output, 'output value').to.equal('test\n');
-
-                done();
-            });
-            stdout.on('error', done);
+        it('outputs message without color when no color is supplied', async function () {
+            const {stream: stdout, written} = streamTestUtils.captureFirstWrite();
 
             const UI = require(modulePath);
             const ui = new UI({stdout: stdout});
             ui.log('test');
+
+            const output = await written;
+            expect(output, 'output exists').to.be.ok;
+            expect(hasAnsi(output), 'output has color').to.be.false;
+            expect(output, 'output value').to.equal('test\n');
         });
 
-        it('outputs message with color when color is supplied', function (done) {
-            const stdout = streamTestUtils.getWritableStream(function (output) {
-                expect(output, 'output exists').to.be.ok;
-                expect(output, 'output value').to.equal(chalk.green('test') + '\n');
-
-                done();
-            });
-            stdout.on('error', done);
+        it('outputs message with color when color is supplied', async function () {
+            const {stream: stdout, written} = streamTestUtils.captureFirstWrite();
 
             const ui = new UI({stdout: stdout});
             ui.log('test', 'green');
+
+            const output = await written;
+            expect(output, 'output exists').to.be.ok;
+            expect(output, 'output value').to.equal(chalk.green('test') + '\n');
         });
 
         it('outputs message to proper stream', function () {
@@ -732,32 +709,28 @@ describe('Unit: UI', function () {
             expect(stdout.write.args[1][0]).to.equal('best\n');
         });
 
-        it('displays a multi-line help message when called with 4 args', function (done) {
-            const stdout = streamTestUtils.getWritableStream(function (output) {
-                expect(output, 'output exists').to.be.ok;
-                expect(output, 'output value').to.include(chalk.green(`\nmy message: \n\n    ${chalk.cyan('testing')}`));
-
-                done();
-            });
-            stdout.on('error', done);
+        it('displays a multi-line help message when called with 4 args', async function () {
+            const {stream: stdout, written} = streamTestUtils.captureFirstWrite();
 
             const UI = require(modulePath);
             const ui = new UI({stdout: stdout});
             ui.log('my message', 'testing', 'green', 'link');
+
+            const output = await written;
+            expect(output, 'output exists').to.be.ok;
+            expect(output, 'output value').to.include(chalk.green(`\nmy message: \n\n    ${chalk.cyan('testing')}`));
         });
 
-        it('displays a multi-line help message with exta line when called with 5 args', function (done) {
-            const stdout = streamTestUtils.getWritableStream(function (output) {
-                expect(output, 'output exists').to.be.ok;
-                expect(output, 'output value').to.include(chalk.white(`\nmy message: \n\n    ${chalk.yellow('testing')}\n`));
-
-                done();
-            });
-            stdout.on('error', done);
+        it('displays a multi-line help message with exta line when called with 5 args', async function () {
+            const {stream: stdout, written} = streamTestUtils.captureFirstWrite();
 
             const UI = require(modulePath);
             const ui = new UI({stdout: stdout});
             ui.log('my message', 'testing', 'white', 'cmd', true);
+
+            const output = await written;
+            expect(output, 'output exists').to.be.ok;
+            expect(output, 'output value').to.include(chalk.white(`\nmy message: \n\n    ${chalk.yellow('testing')}\n`));
         });
     });
 
@@ -798,32 +771,28 @@ describe('Unit: UI', function () {
         });
     });
 
-    it('success outputs message with correct symbols', function (done) {
-        const stdout = streamTestUtils.getWritableStream(function (output) {
-            expect(output, 'output exists').to.be.ok;
-            expect(output, 'output value').to.equal(`${logSymbols.success} test\n`);
-
-            done();
-        });
-        stdout.on('error', done);
+    it('success outputs message with correct symbols', async function () {
+        const {stream: stdout, written} = streamTestUtils.captureFirstWrite();
 
         const UI = require(modulePath);
         const ui = new UI({stdout: stdout});
         ui.success('test');
+
+        const output = await written;
+        expect(output, 'output exists').to.be.ok;
+        expect(output, 'output value').to.equal(`${logSymbols.success} test\n`);
     });
 
-    it('fail outputs message with correct formatting', function (done) {
-        const stdout = streamTestUtils.getWritableStream(function (output) {
-            expect(output, 'output exists').to.be.ok;
-            expect(output, 'output value').to.equal(`${logSymbols.error} test\n`);
-
-            done();
-        });
-        stdout.on('error', done);
+    it('fail outputs message with correct formatting', async function () {
+        const {stream: stdout, written} = streamTestUtils.captureFirstWrite();
 
         const UI = require(modulePath);
         const ui = new UI({stdout: stdout});
         ui.fail('test');
+
+        const output = await written;
+        expect(output, 'output exists').to.be.ok;
+        expect(output, 'output value').to.equal(`${logSymbols.error} test\n`);
     });
 
     describe('error', function () {

--- a/test/unit/ui/pretty-stream-spec.js
+++ b/test/unit/ui/pretty-stream-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const streams = require('stream');
@@ -15,12 +14,12 @@ describe('Unit: UI > PrettyStream', function () {
     const originalChalkLevel = chalk.level;
     const originalColorsEnabled = colors.enabled;
 
-    before(() => {
+    beforeAll(() => {
         chalk.level = 1;
         colors.enabled = true;
     });
 
-    after(() => {
+    afterAll(() => {
         chalk.level = originalChalkLevel;
         colors.enabled = originalColorsEnabled;
     });

--- a/test/unit/ui/renderer-spec.js
+++ b/test/unit/ui/renderer-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const {expect} = require('chai');
 const sinon = require('sinon');
 const {stripVTControlCharacters: stripAnsi} = require('util');
 
@@ -36,21 +35,19 @@ describe('Unit: UI > Renderer', function () {
     describe('#render', function () {
         let rdr;
 
-        before(function () {
+        beforeAll(function () {
             rdr = new Renderer();
         });
 
-        it('returns when id is set', function (done) {
+        it('returns when id is set', function () {
             const ctx = {subscribeToEvents: sinon.stub(), id: 42};
             rdr.render.bind(ctx)();
 
             // Should be unreachable
             expect(ctx.subscribeToEvents.called).to.be.false;
-
-            done();
         });
 
-        it('subscribes to events', function (done) {
+        it('subscribes to events', async function () {
             const ctx = {
                 subscribeToEvents: sinon.stub(),
                 ui: {
@@ -64,11 +61,11 @@ describe('Unit: UI > Renderer', function () {
             expect(ctx.subscribeToEvents.calledOnce).to.be.true;
             expect(ctx.id).to.exist;
             // Give frame time to be called
-            setTimeout(function () {
-                expect(ctx.frame.called).to.be.true;
-                clearInterval(ctx.id);
-                done();
-            }, 10);
+            await new Promise((resolve) => {
+                setTimeout(resolve, 10);
+            });
+            expect(ctx.frame.called).to.be.true;
+            clearInterval(ctx.id);
         });
     });
 

--- a/test/unit/utils/archive-spec.js
+++ b/test/unit/utils/archive-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const fs = require('fs-extra');
 const path = require('path');
 const tar = require('tar');
@@ -26,7 +25,7 @@ function createTarball(dir, name, files) {
 }
 
 describe('Unit: Utils > archive', function () {
-    after(() => {
+    afterAll(() => {
         cleanupTestFolders();
     });
 

--- a/test/unit/utils/check-root-user-spec.js
+++ b/test/unit/utils/check-root-user-spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const os = require('os');
 const fs = require('fs');

--- a/test/unit/utils/check-valid-install-spec.js
+++ b/test/unit/utils/check-valid-install-spec.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const checkValidInstall = require('../../../lib/utils/check-valid-install');
 

--- a/test/unit/utils/config-spec.js
+++ b/test/unit/utils/config-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const fs = require('fs-extra');
 
 const Config = require('../../../lib/utils/config');

--- a/test/unit/utils/dir-is-empty-spec.js
+++ b/test/unit/utils/dir-is-empty-spec.js
@@ -1,5 +1,4 @@
 const proxyquire = require('proxyquire');
-const {expect} = require('chai');
 
 const proxy = files => proxyquire('../../../lib/utils/dir-is-empty', {
     fs: {readdirSync: () => files}

--- a/test/unit/utils/find-extensions-spec.js
+++ b/test/unit/utils/find-extensions-spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/test/unit/utils/get-instance-spec.js
+++ b/test/unit/utils/get-instance-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 const {SystemError} = require('../../../lib/errors');
@@ -19,7 +18,7 @@ describe('Unit: Utils > getInstance', function () {
         });
     });
 
-    this.afterEach(function () {
+    afterEach(function () {
         sinon.restore();
     });
 

--- a/test/unit/utils/local-process-spec.js
+++ b/test/unit/utils/local-process-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const errors = require('../../../lib/errors');
@@ -12,7 +11,7 @@ const childProcess = require('child_process');
 const modulePath = '../../../lib/utils/local-process';
 
 describe('Unit: Utils > local-process', function () {
-    before(() => {
+    beforeAll(() => {
         process.send = process.send || (() => {});
     });
 
@@ -97,24 +96,20 @@ describe('Unit: Utils > local-process', function () {
     });
 
     describe('start', function () {
-        it('errors if _checkContentFolder returns false', function (done) {
+        it('errors if _checkContentFolder returns false', async function () {
             const LocalProcess = require(modulePath);
             const instance = new LocalProcess({}, {}, {});
 
             const checkStub = sinon.stub(instance, '_checkContentFolder').returns(false);
 
-            instance.start('/var/www/ghost', 'development').then(() => {
-                done(new Error('start should have rejected'));
-            }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.SystemError);
-                expect(error.message).to.match(/content folder is not owned by the current user/);
-                expect(checkStub.calledWithExactly('/var/www/ghost')).to.be.true;
+            const error = await instance.start('/var/www/ghost', 'development').catch(e => e);
 
-                done();
-            });
+            expect(error).to.be.an.instanceof(errors.SystemError);
+            expect(error.message).to.match(/content folder is not owned by the current user/);
+            expect(checkStub.calledWithExactly('/var/www/ghost')).to.be.true;
         });
 
-        it('writes pid to file, rejects on error event', function (done) {
+        it('writes pid to file, rejects on error event', async function () {
             const cp = new EventEmitter();
             cp.stderr = {
                 on: sinon.stub(),
@@ -130,22 +125,19 @@ describe('Unit: Utils > local-process', function () {
             const startPromise = instance.start('/var/www/ghost', 'production');
 
             expect(checkStub.calledWithExactly('/var/www/ghost')).to.be.true;
-
-            startPromise.then(() => {
-                done(new Error('Start should have rejected'));
-            }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.CliError);
-                expect(error.message).to.equal('An error occurred while starting Ghost.');
-                expect(spawnStub.calledOnce).to.be.true;
-                expect(cp.stderr.on.calledOnce).to.be.true;
-                expect(writeFileStub.calledWithExactly('/var/www/ghost/.ghostpid', '42')).to.be.true;
-                done();
-            });
 
             cp.emit('error', {message: 'something happened'});
+
+            const error = await startPromise.catch(e => e);
+
+            expect(error).to.be.an.instanceof(errors.CliError);
+            expect(error.message).to.equal('An error occurred while starting Ghost.');
+            expect(spawnStub.calledOnce).to.be.true;
+            expect(cp.stderr.on.calledOnce).to.be.true;
+            expect(writeFileStub.calledWithExactly('/var/www/ghost/.ghostpid', '42')).to.be.true;
         });
 
-        it('writes pid to file, rejects on exit event', function (done) {
+        it('writes pid to file, rejects on exit event', async function () {
             const cp = new EventEmitter();
             cp.stderr = {
                 on: sinon.stub(),
@@ -162,23 +154,20 @@ describe('Unit: Utils > local-process', function () {
             const startPromise = instance.start('/var/www/ghost', 'production');
 
             expect(checkStub.calledWithExactly('/var/www/ghost')).to.be.true;
-
-            startPromise.then(() => {
-                done(new Error('Start should have rejected'));
-            }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.GhostError);
-                expect(error.message).to.equal('Ghost process exited with code: 1');
-                expect(spawnStub.calledOnce).to.be.true;
-                expect(cp.stderr.on.calledOnce).to.be.true;
-                expect(writeFileStub.calledWithExactly('/var/www/ghost/.ghostpid', '42')).to.be.true;
-                expect(removeStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
-                done();
-            });
 
             cp.emit('exit', 1);
+
+            const error = await startPromise.catch(e => e);
+
+            expect(error).to.be.an.instanceof(errors.GhostError);
+            expect(error.message).to.equal('Ghost process exited with code: 1');
+            expect(spawnStub.calledOnce).to.be.true;
+            expect(cp.stderr.on.calledOnce).to.be.true;
+            expect(writeFileStub.calledWithExactly('/var/www/ghost/.ghostpid', '42')).to.be.true;
+            expect(removeStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
         });
 
-        it('writes pid to file, rejects on message event with error', function (done) {
+        it('writes pid to file, rejects on message event with error', async function () {
             const cp = new EventEmitter();
             cp.stderr = {
                 on: sinon.stub(),
@@ -196,22 +185,19 @@ describe('Unit: Utils > local-process', function () {
 
             expect(checkStub.calledWithExactly('/var/www/ghost')).to.be.true;
 
-            startPromise.then(() => {
-                done(new Error('Start should have rejected'));
-            }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.GhostError);
-                expect(error.message).to.equal('Test Error Message');
-                expect(spawnStub.called).to.be.true;
-                expect(cp.stderr.on.calledOnce).to.be.true;
-                expect(writeFileStub.calledWithExactly('/var/www/ghost/.ghostpid', '42')).to.be.true;
-                expect(removeStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
-                done();
-            });
-
             cp.emit('message', {error: true, message: 'Test Error Message'});
+
+            const error = await startPromise.catch(e => e);
+
+            expect(error).to.be.an.instanceof(errors.GhostError);
+            expect(error.message).to.equal('Test Error Message');
+            expect(spawnStub.called).to.be.true;
+            expect(cp.stderr.on.calledOnce).to.be.true;
+            expect(writeFileStub.calledWithExactly('/var/www/ghost/.ghostpid', '42')).to.be.true;
+            expect(removeStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
         });
 
-        it('writes pid to file, resolves on start message', function (done) {
+        it('writes pid to file, resolves on start message', async function () {
             const cp = new EventEmitter();
             cp.stderr = {
                 on: sinon.stub(),
@@ -231,17 +217,16 @@ describe('Unit: Utils > local-process', function () {
 
             expect(checkStub.calledWithExactly('/var/www/ghost')).to.be.true;
 
-            startPromise.then(() => {
-                expect(spawnStub.calledOnce).to.be.true;
-                expect(writeFileStub.calledWithExactly('/var/www/ghost/.ghostpid', '42')).to.be.true;
-                expect(cp.stderr.on.calledOnce).to.be.true;
-                expect(cp.stderr.destroy.calledOnce).to.be.true;
-                expect(cp.disconnect.calledOnce).to.be.true;
-                expect(cp.unref.calledOnce).to.be.true;
-                done();
-            }).catch(done);
-
             cp.emit('message', {started: true});
+
+            await startPromise;
+
+            expect(spawnStub.calledOnce).to.be.true;
+            expect(writeFileStub.calledWithExactly('/var/www/ghost/.ghostpid', '42')).to.be.true;
+            expect(cp.stderr.on.calledOnce).to.be.true;
+            expect(cp.stderr.destroy.calledOnce).to.be.true;
+            expect(cp.disconnect.calledOnce).to.be.true;
+            expect(cp.unref.calledOnce).to.be.true;
         });
     });
 
@@ -261,7 +246,7 @@ describe('Unit: Utils > local-process', function () {
             });
         });
 
-        it('rejects if any unexpected error occurs during reading of pidfile', function (done) {
+        it('rejects if any unexpected error occurs during reading of pidfile', async function () {
             const readFileStub = sinon.stub(fs, 'readFileSync').throws(new Error('test error'));
             const fkillStub = sinon.stub();
 
@@ -270,15 +255,12 @@ describe('Unit: Utils > local-process', function () {
             });
             const instance = new LocalProcess({}, {}, {});
 
-            instance.stop('/var/www/ghost').then(() => {
-                done(new Error('stop should have rejected'));
-            }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.CliError);
-                expect(error.message).to.equal('An unexpected error occurred when reading the pidfile.');
-                expect(readFileStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
-                expect(fkillStub.called).to.be.false;
-                done();
-            });
+            const error = await instance.stop('/var/www/ghost').catch(e => e);
+
+            expect(error).to.be.an.instanceof(errors.CliError);
+            expect(error.message).to.equal('An unexpected error occurred when reading the pidfile.');
+            expect(readFileStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
+            expect(fkillStub.called).to.be.false;
         });
 
         it('does not kill the process but removes the pidfile if not a ghost process', async function () {
@@ -348,7 +330,7 @@ describe('Unit: Utils > local-process', function () {
             });
         });
 
-        it('rejects with an unknown error from fkill', function (done) {
+        it('rejects with an unknown error from fkill', async function () {
             const readFileStub = sinon.stub(fs, 'readFileSync').returns('42');
             const removeStub = sinon.stub(fs, 'removeSync');
             const fkillStub = sinon.stub().callsFake(() => Promise.reject(new Error('no idea')));
@@ -361,16 +343,13 @@ describe('Unit: Utils > local-process', function () {
             }, {});
             sinon.stub(instance, '_isGhostProcess').resolves(true);
 
-            instance.stop('/var/www/ghost').then(() => {
-                done(new Error('stop should have rejected'));
-            }).catch((error) => {
-                expect(error).to.be.an.instanceof(errors.CliError);
-                expect(error.message).to.equal('An unexpected error occurred while stopping Ghost.');
-                expect(readFileStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
-                expect(fkillStub.calledWithExactly(42, sinon.match({force: false}))).to.be.true;
-                expect(removeStub.calledOnce).to.be.false;
-                done();
-            });
+            const error = await instance.stop('/var/www/ghost').catch(e => e);
+
+            expect(error).to.be.an.instanceof(errors.CliError);
+            expect(error.message).to.equal('An unexpected error occurred while stopping Ghost.');
+            expect(readFileStub.calledWithExactly('/var/www/ghost/.ghostpid')).to.be.true;
+            expect(fkillStub.calledWithExactly(42, sinon.match({force: false}))).to.be.true;
+            expect(removeStub.calledOnce).to.be.false;
         });
     });
 

--- a/test/unit/utils/needed-migrations-spec.js
+++ b/test/unit/utils/needed-migrations-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 
 const modulePath = '../../../lib/utils/needed-migrations';

--- a/test/unit/utils/pnpm-spec.js
+++ b/test/unit/utils/pnpm-spec.js
@@ -1,8 +1,7 @@
 'use strict';
-const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const {getReadableStream, collect, isReadable} = require('../../utils/stream');
+const {getReadableStream, collect, isReadable, fakeSubprocess} = require('../../utils/stream');
 const {ProcessError, SystemError} = require('../../../lib/errors');
 
 const modulePath = '../../../lib/utils/pnpm';
@@ -190,14 +189,12 @@ describe('Unit: pnpm', function () {
         });
 
         it('passes data through', async function () {
-            const execa = sinon.stub().callsFake(() => {
-                const promise = Promise.resolve();
-                promise.stdout = getReadableStream(function () {
+            const execa = sinon.stub().callsFake(() => fakeSubprocess({
+                stdout: getReadableStream(function () {
                     this.push('test message\n');
                     this.push(null);
-                });
-                return promise;
-            });
+                })
+            }));
             const pnpm = setup({execa});
 
             const res = pnpm([], {observe: true});

--- a/test/unit/utils/port-polling-spec.js
+++ b/test/unit/utils/port-polling-spec.js
@@ -1,13 +1,10 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 const net = require('net');
 
 const portPolling = require('../../../lib/utils/port-polling');
 
 describe('Unit: Utils > portPolling', function () {
-    this.slow(1000);
-
     afterEach(function () {
         sinon.restore();
     });

--- a/test/unit/utils/pre-checks-spec.js
+++ b/test/unit/utils/pre-checks-spec.js
@@ -1,4 +1,3 @@
-const {expect} = require('chai');
 const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 const os = require('os');
@@ -52,7 +51,7 @@ describe('Unit: Utils > pre-checks', function () {
                 'latest-version': {default: latestVersion}
             });
 
-            await expect(updateCheck({ui})).to.be.rejectedWith(testError);
+            await expect(updateCheck({ui})).rejects.toBe(testError);
             expect(latestVersion.calledOnce).to.be.true;
             expect(latestVersion.calledWithExactly('ghost')).to.be.true;
         });
@@ -112,7 +111,7 @@ describe('Unit: Utils > pre-checks', function () {
 
             const {checkConfigPerms} = load();
 
-            await expect(checkConfigPerms({ui})).to.be.rejectedWith(testErr);
+            await expect(checkConfigPerms({ui})).rejects.toBe(testErr);
             expect(homedir.calledOnce).to.be.true;
             expect(lstat.calledOnce).to.be.true;
             expect(lstat.calledWithExactly('/home/ghost/.config')).to.be.true;

--- a/test/unit/utils/url-spec.js
+++ b/test/unit/utils/url-spec.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const {expect} = require('chai');
-
 const url = require('../../../lib/utils/url');
 
 describe('Unit: Utils > URL', function () {

--- a/test/unit/utils/use-ghost-user-spec.js
+++ b/test/unit/utils/use-ghost-user-spec.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chai').expect;
 const sinon = require('sinon');
 
 const proxyquire = require('proxyquire');

--- a/test/unit/utils/version-spec.js
+++ b/test/unit/utils/version-spec.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const {expect} = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 
@@ -376,7 +375,7 @@ describe('Unit: Utils: version', function () {
     describe('versionFromArchive', function () {
         const currentNodeVersion = process.versions.node;
 
-        before(function () {
+        beforeAll(function () {
             Object.defineProperty(process.versions, 'node', {
                 value: '8.11.0', // CHANGE THIS WHENEVER RECOMMENDED NODE VERSION CHANGES
                 writable: true,
@@ -389,7 +388,7 @@ describe('Unit: Utils: version', function () {
             delete process.env.GHOST_NODE_VERSION_CHECK;
         });
 
-        after(function () {
+        afterAll(function () {
             Object.defineProperty(process.versions, 'node', {
                 value: currentNodeVersion,
                 writeable: false,

--- a/test/unit/utils/yarn-spec.js
+++ b/test/unit/utils/yarn-spec.js
@@ -1,8 +1,7 @@
 'use strict';
-const expect = require('chai').expect;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const {getReadableStream, collect, isReadable} = require('../../utils/stream');
+const {getReadableStream, collect, isReadable, fakeSubprocess} = require('../../utils/stream');
 const {ProcessError} = require('../../../lib/errors');
 
 const modulePath = '../../../lib/utils/yarn';
@@ -131,14 +130,12 @@ describe('Unit: yarn', function () {
         });
 
         it('passes data through', async function () {
-            const execa = sinon.stub().callsFake(() => {
-                const promise = Promise.resolve();
-                promise.stdout = getReadableStream(function () {
+            const execa = sinon.stub().callsFake(() => fakeSubprocess({
+                stdout: getReadableStream(function () {
                     this.push('test message\n');
                     this.push(null);
-                });
-                return promise;
-            });
+                })
+            }));
             const yarn = setup({execa});
 
             const res = yarn([], {observe: true});
@@ -149,18 +146,16 @@ describe('Unit: yarn', function () {
         });
 
         it('passes data through with verbose', async function () {
-            const execa = sinon.stub().callsFake(() => {
-                const promise = Promise.resolve();
-                promise.stdout = getReadableStream(function () {
+            const execa = sinon.stub().callsFake(() => fakeSubprocess({
+                stdout: getReadableStream(function () {
                     this.push('test message\n');
                     this.push(null);
-                });
-                promise.stderr = getReadableStream(function () {
+                }),
+                stderr: getReadableStream(function () {
                     this.push('test stderr message\n');
                     this.push(null);
-                });
-                return promise;
-            });
+                })
+            }));
             const yarn = setup({execa});
 
             const res = yarn([], {observe: true, verbose: true});

--- a/test/utils/stream.js
+++ b/test/utils/stream.js
@@ -74,6 +74,41 @@ const streamUtils = {
         return writeStream;
     },
 
+    /**
+     * Stands in for an execa subprocess: a promise with the given streams hung off it that
+     * only resolves once they've all ended, which is the ordering the real thing guarantees.
+     * Resolving any earlier lets consumers end their output stream mid-pipe
+     */
+    fakeSubprocess: function fakeSubprocess(streams) {
+        const ended = Object.values(streams).map(
+            stream => new Promise((resolve) => {
+                stream.on('end', resolve);
+            })
+        );
+
+        return Object.assign(Promise.all(ended).then(() => {}), streams);
+    },
+
+    /**
+     * A writable stream plus a promise that resolves with the first chunk written to it,
+     * or rejects if the stream errors. Lets tests await output rather than assert inside
+     * the stream's write callback
+     */
+    captureFirstWrite: function captureFirstWrite() {
+        let resolve;
+        let reject;
+
+        const written = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+
+        const writeStream = streamUtils.getWritableStream(chunk => resolve(chunk.toString()));
+        writeStream.on('error', reject);
+
+        return {stream: writeStream, written};
+    },
+
     mockStandardStreams: function mockStandardStreams(streamCallbacks, errorCallback) {
         streamCallbacks = streamCallbacks || {};
 

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,16 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        include: ['test/unit/**/*-spec.js', 'extensions/*/test/**/*-spec.js'],
+        setupFiles: ['./test/setup.mjs'],
+        testTimeout: 5000,
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'html', 'cobertura'],
+            include: ['bin/**', 'lib/**', 'extensions/**'],
+            exclude: ['extensions/*/test/**']
+        }
+    }
+});


### PR DESCRIPTION
Brings the CLI in line with the rest of the Ghost repos. Vitest's `expect` is chai-based, so the existing assertion style carries over untouched and the `chai` dependency itself is gone - specs now use the global `expect`. Sinon, proxyquire and nock are unchanged.

- replaced .mocharc.json and test/root-hooks.mjs with vitest.config.mjs and test/setup.mjs, which points `require.main` at bin/ghost since vite-node never populates it
- dropped chai-as-promised in favour of vitest's `rejects` matchers
- dropped nyc in favour of @vitest/coverage-v8
- converted before/after hooks, done() callbacks and mocha's test context (this.timeout/this.slow) to their vitest equivalents
- renamed dir-is-empty.js and url.js to -spec.js so the spec glob picks them up; mocha found them by directory

Along the way this surfaced four tests that were passing vacuously:

- ensureMediaFileAndPublicFolders nested its cases inside an `it()`, so they never ran - and targeted the wrong migration once they did
- the systemd hook specs never returned their promises, so the assertions ran after the test had finished against a rebuilt instance
- the bootstrap spec assumed the CLI's unhandledRejection handler was the first one registered
- the sudo spec built a RegExp out of unescaped process.argv