### PR TITLE
🎨 Improved import/export HTTP error messages

### DIFF
--- a/lib/tasks/import/api-auth-strategies.js
+++ b/lib/tasks/import/api-auth-strategies.js
@@ -2,8 +2,7 @@
 const get = require('lodash/get');
 const {Cookie} = require('tough-cookie');
 
-// imports and exports can take a long time to generate, so no timeout - ky defaults to 10s
-const ky = require('ky').default.create({timeout: false});
+const ky = require('./client');
 
 /**
  * Performs authentication against the v1 Ghost API

--- a/lib/tasks/import/api.js
+++ b/lib/tasks/import/api.js
@@ -8,8 +8,7 @@ const {pipeline} = require('node:stream/promises');
 const {openAsBlob, createWriteStream} = require('node:fs');
 const fsp = require('node:fs/promises');
 
-// imports and exports can take a long time to generate, so no timeout - ky defaults to 10s
-const ky = require('ky').default.create({timeout: false});
+const ky = require('./client');
 
 const {SystemError} = require('../../errors');
 const {v1AuthStrategy, sessionAuthStrategy, tokenAuthStrategy} = require('./api-auth-strategies.js');
@@ -63,11 +62,23 @@ async function setup(version, url, data) {
     await ky.post('authentication/setup/', {prefixUrl, json});
 }
 
-function wrapAuthRequest(request) {
+function wrapAuthRequest(request, version) {
     return request.catch((error) => {
         const {response} = error;
         if (!response) {
             throw error;
+        }
+
+        // there's no way to enter a 2FA code from the CLI, so a Staff access token is the only way in
+        if (error.code === '2FA_TOKEN_REQUIRED' || error.code === '2FA_NEW_DEVICE_DETECTED') {
+            const hint = semver.gte(version, TOKEN_AUTH_MIN_VERSION) ?
+                'Use a Staff access token instead.' :
+                `Upgrade to Ghost v${TOKEN_AUTH_MIN_VERSION} or later to use a Staff access token instead.`;
+
+            throw new SystemError({
+                message: `Two-factor authentication is required, which Ghost-CLI can't complete.\n${hint}`,
+                err: error
+            });
         }
 
         if (response.status === 404) {
@@ -101,7 +112,7 @@ async function getAuthOpts(version, url, auth) {
             throw new SystemError({message: 'Ghost 1.0 does not support token-based authentication'});
         }
 
-        return wrapAuthRequest(v1AuthStrategy(prefixUrl, auth));
+        return wrapAuthRequest(v1AuthStrategy(prefixUrl, auth), version);
     }
 
     if ('token' in auth) {
@@ -109,10 +120,10 @@ async function getAuthOpts(version, url, auth) {
             throw new SystemError({message: `Token auth is only supported for Ghost v${TOKEN_AUTH_MIN_VERSION} and above`});
         }
 
-        return wrapAuthRequest(tokenAuthStrategy(prefixUrl, auth));
+        return wrapAuthRequest(tokenAuthStrategy(prefixUrl, auth), version);
     }
 
-    return wrapAuthRequest(sessionAuthStrategy(prefixUrl, {origin: url, ...auth}));
+    return wrapAuthRequest(sessionAuthStrategy(prefixUrl, {origin: url, ...auth}), version);
 }
 
 async function runImport(version, url, auth, exportFile) {

--- a/lib/tasks/import/client.js
+++ b/lib/tasks/import/client.js
@@ -1,0 +1,31 @@
+// @ts-check
+const get = require('lodash/get');
+
+/**
+ * Ghost's API returns errors as `{errors: [{message, context}]}`, which is a lot more
+ * useful than ky's generic "Request failed with status code 500". Surface the actual
+ * error, plus which request failed - ky's message includes neither the method nor the url.
+ *
+ * @param {import('ky').HTTPError} error
+ */
+async function describeError(error) {
+    const {request, response} = error;
+    const body = await response.json().catch(() => null);
+    const {message, context, code} = get(body, 'errors[0]', {});
+    const detail = [message, context].filter(Boolean).join(' ');
+    const {pathname} = new URL(request.url);
+
+    error.message = `${request.method} ${pathname} failed (${response.status})${detail ? `: ${detail}` : ''}`;
+    // the response body is consumed here, so keep the code around for callers that need it
+    error.code = code;
+
+    return error;
+}
+
+// imports and exports can take a long time to generate, so no timeout - ky defaults to 10s
+module.exports = require('ky').default.create({
+    timeout: false,
+    hooks: {
+        beforeError: [describeError]
+    }
+});

--- a/test/unit/tasks/import/api-spec.js
+++ b/test/unit/tasks/import/api-spec.js
@@ -631,4 +631,112 @@ describe('Unit > Tasks > Import > setup', function () {
             }
         });
     });
+
+    describe('http error messages', function () {
+        const sessionOk = () => nock(testUrl).post('/ghost/api/admin/session/').reply(201, 'Success', {
+            'Set-Cookie': 'ghost-admin-api-session=test-session-data; Path=/ghost; HttpOnly; Secure; Expires=Tue, 31 Dec 2099 23:59:59 GMT;'
+        });
+
+        const auth = {username: 'test@example.com', password: 'password'};
+        const exportFile = path.join(__dirname, 'fixtures/5.x.json');
+
+        it('surfaces the Ghost error from the response body', async function () {
+            const scope = nock(testUrl).post('/ghost/api/admin/session/').reply(500, {
+                errors: [{
+                    message: 'Failed to send email.',
+                    context: 'Check your mail configuration.'
+                }]
+            });
+
+            try {
+                await runImport('5.0.0', testUrl, auth, exportFile);
+            } catch (error) {
+                expect(error.message).to.equal(
+                    'POST /ghost/api/admin/session/ failed (500): Failed to send email. Check your mail configuration.'
+                );
+                expect(scope.isDone()).to.be.true;
+                return;
+            }
+
+            expect.fail('runImport should have errored');
+        });
+
+        it('includes the failing request when the body has no Ghost error', async function () {
+            const sessionScope = sessionOk();
+            const importScope = nock(testUrl).post('/ghost/api/admin/db/').reply(500, 'Internal Server Error');
+
+            try {
+                await runImport('5.0.0', testUrl, auth, exportFile);
+            } catch (error) {
+                expect(error.message).to.equal('POST /ghost/api/admin/db/ failed (500)');
+                expect(sessionScope.isDone()).to.be.true;
+                expect(importScope.isDone()).to.be.true;
+                return;
+            }
+
+            expect.fail('runImport should have errored');
+        });
+
+        it('points at Staff access tokens when 2FA is required', async function () {
+            const scope = nock(testUrl).post('/ghost/api/admin/session/').reply(403, {
+                errors: [{
+                    code: '2FA_NEW_DEVICE_DETECTED',
+                    message: 'User must verify session to login.'
+                }]
+            });
+
+            try {
+                await runImport('5.129.0', testUrl, auth, exportFile);
+            } catch (error) {
+                expect(error).to.be.an.instanceof(SystemError);
+                expect(error.message).to.equal(
+                    'Two-factor authentication is required, which Ghost-CLI can\'t complete.\nUse a Staff access token instead.'
+                );
+                expect(scope.isDone()).to.be.true;
+                return;
+            }
+
+            expect.fail('runImport should have errored');
+        });
+
+        it('suggests upgrading when 2FA is required and tokens are unsupported', async function () {
+            const scope = nock(testUrl).post('/ghost/api/admin/session/').reply(403, {
+                errors: [{
+                    code: '2FA_TOKEN_REQUIRED',
+                    message: 'User must verify session to login.'
+                }]
+            });
+
+            try {
+                await runImport('5.120.0', testUrl, auth, exportFile);
+            } catch (error) {
+                expect(error).to.be.an.instanceof(SystemError);
+                expect(error.message).to.equal(
+                    'Two-factor authentication is required, which Ghost-CLI can\'t complete.\n' +
+                    'Upgrade to Ghost v5.129.0 or later to use a Staff access token instead.'
+                );
+                expect(scope.isDone()).to.be.true;
+                return;
+            }
+
+            expect.fail('runImport should have errored');
+        });
+
+        it('keeps the friendly message for known auth errors', async function () {
+            const scope = nock(testUrl).post('/ghost/api/admin/session/').reply(422, {
+                errors: [{message: 'Validation error'}]
+            });
+
+            try {
+                await runImport('5.0.0', testUrl, auth, exportFile);
+            } catch (error) {
+                expect(error).to.be.an.instanceof(SystemError);
+                expect(error.message).to.equal('Your password is incorrect.');
+                expect(scope.isDone()).to.be.true;
+                return;
+            }
+
+            expect.fail('runImport should have errored');
+        });
+    });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost-CLI/issues/2284

Ghost's API returns errors as `{errors: [{message, context, code}]}`, but the CLI threw the body away and surfaced ky's generic `Request failed with status code 500` instead — with no indication of which request had failed. That's what [#2284](https://github.com/TryGhost/Ghost-CLI/issues/2284) reported: a 500 on `POST /ghost/api/admin/session/` with no way to tell why.

- added a shared ky client with a `beforeError` hook that rewrites the message to `METHOD /path failed (status): <ghost message> <context>`, and stashes the Ghost error code on the error (the hook consumes the response body, so callers can't read it themselves)
- `api.js` and `api-auth-strategies.js` each had their own ky instance; they now share this one
- this covers every import/export request, including the `db/` import & export calls that previously had no error handling at all
- 2FA failures (`2FA_TOKEN_REQUIRED` / `2FA_NEW_DEVICE_DETECTED`) now point at Staff access tokens, since there's no way to enter a verification code from the CLI — nothing calls `session/verify/`

Before:

```
Message: 'Request failed with status code 500 Internal Server Error'
```

After:

```
Message: 'POST /ghost/api/admin/session/ failed (500): Failed to send email. Check your mail configuration.'
```

Falls back to `POST /ghost/api/admin/db/ failed (500)` when the body isn't a Ghost error, so the failing request is always identified. The existing friendly 404/422 auth messages are unchanged.

This doesn't fix #2284 — it makes the next report diagnosable, so leaving it open.