### PR TITLE
🎨 Resolved open CodeQL scanning alerts

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
         with:

--- a/extensions/mysql/index.js
+++ b/extensions/mysql/index.js
@@ -165,7 +165,7 @@ class MySQLExtension extends Extension {
         // e.g. if we would rely on the instance name, the instance naming only auto increments if there are existing instances
         // the most important fact is, that if a MySQL user exists, we have no access to the password, which we need to autofill the Ghost config
         // disadvantage: the CLI could potentially create lot's of MySQL users (but this should only happen if the user installs Ghost over and over again with root credentials)
-        return `ghost-${Math.floor(Math.random() * 1000)}`;
+        return `ghost-${crypto.randomInt(1000)}`;
     }
 
     async getMySQL5Password() {

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -25,6 +25,12 @@ const defaultOptions = {
     json: false
 };
 
+// The sudo command runs through a shell, so the node/ghost binary paths need
+// quoting in case they contain spaces or other shell metacharacters
+function shellQuote(arg) {
+    return `'${arg.replace(/'/g, '\'\\\'\'')}'`;
+}
+
 function hasDefault(prompt = {}) {
     return isObject(prompt) && !isNil(prompt.default);
 }
@@ -259,7 +265,8 @@ class UI {
         this.log(`+ sudo ${command}`, 'gray');
 
         const prompt = '#node-sudo-passwd#';
-        const cmd = command.replace(/^ghost/, process.argv.slice(0, 2).join(' '));
+        const ghostBin = process.argv.slice(0, 2).map(shellQuote).join(' ');
+        const cmd = command.replace(/^ghost/, () => ghostBin);
         const cp = execa(`sudo -S -p '${prompt}' ${options.sudoArgs || ''} ${cmd}`, {
             ...omit(options, ['sudoArgs']),
             shell: true

--- a/test/unit/ui/index-spec.js
+++ b/test/unit/ui/index-spec.js
@@ -523,8 +523,9 @@ describe('Unit: UI', function () {
             const promptStub = sinon.stub(ui, 'prompt').resolves({password: 'password'});
             const stderr = new EventEmitter();
 
-            // argv contains the test runner's own path, which isn't regex-safe
-            const eCall = `sudo -S -p '#node-sudo-passwd#' -E -u ghost ${process.argv.slice(0, 2).join(' ')} -v`;
+            // argv contains the test runner's own path, which isn't regex-safe and gets shell-quoted
+            const quotedArgv = process.argv.slice(0, 2).map(arg => `'${arg.replace(/'/g, '\'\\\'\'')}'`).join(' ');
+            const eCall = `sudo -S -p '#node-sudo-passwd#' -E -u ghost ${quotedArgv} -v`;
 
             const {stream: stdin, written} = streamTestUtils.captureFirstWrite();
             shellStub.returns(Object.assign(new Promise(() => {}), {stdin: stdin, stderr: stderr}));


### PR DESCRIPTION
Cleans up the four open CodeQL code scanning alerts — three fixed here, one dismissed.

### Fixed

**`js/insecure-randomness` (extensions/mysql/index.js)** — `randomUsername()` used `Math.random()`, which CodeQL flags because the value feeds MySQL user creation. The username isn't a secret (the password is already generated with `crypto.randomInt`), but switching is free and spreads better across the 1000-value space.

**`js/shell-command-injection-from-environment` (lib/ui/index.js)** — `ui.sudo()` spliced `process.argv.slice(0, 2).join(' ')` unquoted into a command run with `shell: true`. Beyond the alert this is a real bug: an install path containing a space breaks every `sudo ghost ...` call. The paths are now shell-quoted, and the `replace()` uses a function replacement so `$&`/`$1` sequences in a path aren't treated as regex replacement patterns.

**`actions/missing-workflow-permissions` (.github/workflows/stale.yml)** — the job now declares explicit `issues: write` / `pull-requests: write` instead of inheriting the repo-default token scope.

### Dismissed

**`js/shell-command-constructed-from-input` (lib/ui/index.js)** — dismissed as won't fix. `sudo()` is a shell-command runner by design, with ~40 internal callers passing constructed command strings (`systemctl start ${name}`, `sed -i 's|…|' file`), and Ghost-CLI isn't consumed as a library. Fixing it properly means converting every caller to argv arrays, and some don't translate cleanly.

### Testing

`pnpm test` passes (1018 tests, lint clean). The `ui.sudo` spec was updated to expect the quoted argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)