### PR TITLE
🐛 Fixed error handling for `npm pack` issues

### DIFF
--- a/lib/tasks/install-dependencies.js
+++ b/lib/tasks/install-dependencies.js
@@ -24,17 +24,32 @@ function usePnpm(installPath) {
  * Returns the path to the downloaded tarball.
  */
 async function npmPack(version, destination) {
-    let stdout;
+    let result;
 
     try {
         // npm resolves its config (including proxy settings) relative to the cwd,
         // so run in the empty temp dir to avoid picking up any local project config
-        ({stdout} = await execa('npm', ['pack', `ghost@${version}`, '--json'], {cwd: destination}));
+        result = await execa('npm', ['pack', `ghost@${version}`, '--json'], {cwd: destination});
     } catch (error) {
         throw new ProcessError(error);
     }
 
-    const [{filename}] = JSON.parse(stdout);
+    // `npm pack --json` is expected to print a JSON array of packed tarballs, but a
+    // misbehaving npm/registry/proxy can exit 0 while printing an error object or
+    // other output. Guard so we surface npm's actual output instead of a cryptic
+    // "object is not iterable" from the array destructuring below.
+    let parsed;
+    try {
+        parsed = JSON.parse(result.stdout);
+    } catch {
+        throw new ProcessError({...result, message: `Could not parse 'npm pack' output for ghost@${version}.`});
+    }
+
+    const filename = Array.isArray(parsed) && parsed[0] && parsed[0].filename;
+    if (typeof filename !== 'string' || !filename.trim()) {
+        throw new ProcessError({...result, message: `'npm pack' did not return a tarball for ghost@${version}.`});
+    }
+
     return path.join(destination, filename);
 }
 

--- a/test/unit/tasks/install-dependencies-spec.js
+++ b/test/unit/tasks/install-dependencies-spec.js
@@ -464,6 +464,81 @@ describe('Unit: Tasks > install-dependencies', function () {
             });
         });
 
+        it('throws a ProcessError when npm pack output is not valid JSON', function () {
+            const env = setupTestFolder();
+            const execaStub = sinon.stub().resolves({stdout: 'npm notice not json', stderr: 'boom'});
+            const extractStub = sinon.stub().resolves();
+            const downloadTask = proxyquire(modulePath, {
+                execa: {execa: execaStub},
+                '../utils/archive': {extract: extractStub}
+            }).subTasks.download;
+            const ctx = {
+                version: '1.0.0',
+                installPath: path.join(env.dir, 'versions/1.0.0')
+            };
+
+            return downloadTask(ctx).then(() => {
+                expect(false, 'Error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.an.instanceof(errors.ProcessError);
+                expect(error.message).to.contain('Could not parse');
+                expect(error.options.stdout).to.equal('npm notice not json');
+                expect(error.options.stderr).to.equal('boom');
+                expect(extractStub.called).to.be.false;
+                expect(fs.existsSync(execaStub.args[0][2].cwd)).to.be.false;
+                expect(fs.existsSync(ctx.installPath)).to.be.false;
+            });
+        });
+
+        it('throws a ProcessError when npm pack returns no tarball', function () {
+            const env = setupTestFolder();
+            const execaStub = sinon.stub().resolves({stdout: JSON.stringify({error: {code: 'E404'}}), stderr: ''});
+            const extractStub = sinon.stub().resolves();
+            const downloadTask = proxyquire(modulePath, {
+                execa: {execa: execaStub},
+                '../utils/archive': {extract: extractStub}
+            }).subTasks.download;
+            const ctx = {
+                version: '1.0.0',
+                installPath: path.join(env.dir, 'versions/1.0.0')
+            };
+
+            return downloadTask(ctx).then(() => {
+                expect(false, 'Error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.an.instanceof(errors.ProcessError);
+                expect(error.message).to.contain('did not return a tarball');
+                expect(error.options.stdout).to.equal(JSON.stringify({error: {code: 'E404'}}));
+                expect(extractStub.called).to.be.false;
+                expect(fs.existsSync(execaStub.args[0][2].cwd)).to.be.false;
+                expect(fs.existsSync(ctx.installPath)).to.be.false;
+            });
+        });
+
+        it('throws a ProcessError when npm pack returns a non-string filename', function () {
+            const env = setupTestFolder();
+            const execaStub = sinon.stub().resolves({stdout: JSON.stringify([{filename: 42}]), stderr: ''});
+            const extractStub = sinon.stub().resolves();
+            const downloadTask = proxyquire(modulePath, {
+                execa: {execa: execaStub},
+                '../utils/archive': {extract: extractStub}
+            }).subTasks.download;
+            const ctx = {
+                version: '1.0.0',
+                installPath: path.join(env.dir, 'versions/1.0.0')
+            };
+
+            return downloadTask(ctx).then(() => {
+                expect(false, 'Error should have been thrown').to.be.true;
+            }).catch((error) => {
+                expect(error).to.be.an.instanceof(errors.ProcessError);
+                expect(error.message).to.contain('did not return a tarball');
+                expect(extractStub.called).to.be.false;
+                expect(fs.existsSync(execaStub.args[0][2].cwd)).to.be.false;
+                expect(fs.existsSync(ctx.installPath)).to.be.false;
+            });
+        });
+
         it('catches extraction errors and cleans up the install folder', function () {
             const env = setupTestFolder();
             const execaStub = sinon.stub().resolves(packResult);


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost-CLI/issues/2309
- adds better error handling if npm pack outputs an error message (if it's not able to fetch a tarball or something)