### PR TITLE
🐛 Supported npm >=12 `npm pack --json` object output

### DIFF
--- a/lib/tasks/install-dependencies.js
+++ b/lib/tasks/install-dependencies.js
@@ -34,10 +34,6 @@ async function npmPack(version, destination) {
         throw new ProcessError(error);
     }
 
-    // `npm pack --json` is expected to print a JSON array of packed tarballs, but a
-    // misbehaving npm/registry/proxy can exit 0 while printing an error object or
-    // other output. Guard so we surface npm's actual output instead of a cryptic
-    // "object is not iterable" from the array destructuring below.
     let parsed;
     try {
         parsed = JSON.parse(result.stdout);
@@ -45,7 +41,15 @@ async function npmPack(version, destination) {
         throw new ProcessError({...result, message: `Could not parse 'npm pack' output for ghost@${version}.`});
     }
 
-    const filename = Array.isArray(parsed) && parsed[0] && parsed[0].filename;
+    // npm <12 prints a JSON array of packed tarballs (`[{filename, ...}]`); npm >=12
+    // prints an object keyed by package name (`{"ghost": {filename, ...}}`), see
+    // npm/cli#9247. Normalize both shapes, and guard against unexpected output so we
+    // surface npm's actual stdout instead of a cryptic crash.
+    const entries = Array.isArray(parsed)
+        ? parsed
+        : (parsed && typeof parsed === 'object' ? Object.values(parsed) : []);
+
+    const filename = entries[0] && entries[0].filename;
     if (typeof filename !== 'string' || !filename.trim()) {
         throw new ProcessError({...result, message: `'npm pack' did not return a tarball for ghost@${version}.`});
     }

--- a/test/unit/tasks/install-dependencies-spec.js
+++ b/test/unit/tasks/install-dependencies-spec.js
@@ -464,6 +464,29 @@ describe('Unit: Tasks > install-dependencies', function () {
             });
         });
 
+        it('extracts the tarball when npm pack returns the npm >=12 object format', function () {
+            const env = setupTestFolder();
+            const execaStub = sinon.stub().resolves({stdout: JSON.stringify({ghost: {filename: 'ghost-1.0.0.tgz'}}), stderr: ''});
+            const extractStub = sinon.stub().resolves();
+            const downloadTask = proxyquire(modulePath, {
+                execa: {execa: execaStub},
+                '../utils/archive': {extract: extractStub}
+            }).subTasks.download;
+            const ctx = {
+                version: '1.0.0',
+                installPath: path.join(env.dir, 'versions/1.0.0')
+            };
+
+            return downloadTask(ctx).then(() => {
+                const tmpDir = execaStub.args[0][2].cwd;
+                expect(extractStub.calledOnce).to.be.true;
+                expect(extractStub.calledWithExactly(
+                    path.join(tmpDir, 'ghost-1.0.0.tgz'),
+                    ctx.installPath
+                )).to.be.true;
+            });
+        });
+
         it('throws a ProcessError when npm pack output is not valid JSON', function () {
             const env = setupTestFolder();
             const execaStub = sinon.stub().resolves({stdout: 'npm notice not json', stderr: 'boom'});


### PR DESCRIPTION
## Summary

Fixes [#2309](https://github.com/TryGhost/Ghost-CLI/issues/2309).

npm 12 ([npm/cli#9247](https://github.com/npm/cli/pull/9747), "sync json output of pack and publish") changed `npm pack --json` from a JSON **array** of packed tarballs to an **object keyed by package name**:

```jsonc
// npm <12
[{ "filename": "ghost-6.58.0.tgz", ... }]

// npm >=12
{ "ghost": { "filename": "ghost-6.58.0.tgz", ... } }
```

Node 22.x still bundles npm 10.9.x (array format), but users who run `npm install -g npm` get npm 12.x. `installDependencies` only handled the array shape, so those users hit a failed update:

- before 1.32.1: `object is not iterable (cannot read property Symbol(Symbol.iterator))`
- 1.32.1: the clean-but-still-failing `'npm pack' did not return a tarball for ghost@6.58.0.`

Confirmed against a reporter's debug log — their stdout was the object-keyed form.

## Change

Normalize both shapes to a list of entries before reading the tarball filename. The existing non-string / empty-filename guard is preserved, so malformed npm output still surfaces npm's actual stdout via `ProcessError` instead of crashing.

## Tests

Added coverage for the npm >=12 object format; existing array-format and malformed-output cases still pass (21 tests, lint clean).

## Workaround for affected users until release

```bash
npm install -g npm@11
```