### PR TITLE
🎨 Fix CLI to handle archives with + without package/ prefix

### DIFF
--- a/lib/utils/archive.js
+++ b/lib/utils/archive.js
@@ -1,12 +1,9 @@
 'use strict';
-const os = require('node:os');
 const fs = require('node:fs');
 const path = require('node:path');
 const tar = require('tar');
 
 const PACKAGE_JSON = 'package.json';
-// npm tarballs wrap everything in a `package/` dir, release zips don't
-const TARBALL_ROOT = 'package';
 
 const TARBALL_EXTENSIONS = ['.tar.gz', '.tgz'];
 const SUPPORTED_EXTENSIONS = [...TARBALL_EXTENSIONS, '.zip'];
@@ -21,6 +18,48 @@ function isTarball(archivePath) {
     return hasExtension(archivePath, TARBALL_EXTENSIONS);
 }
 
+// tar entry paths can be prefixed with `./`
+function normalizeEntryPath(entryPath) {
+    return entryPath.replace(/^\.\//, '');
+}
+
+// npm tarballs wrap everything in a `package/` dir, release zips usually don't,
+// so an entry matches if it's either at the top level or one dir deep
+function entryMatcher(entry) {
+    return (entryPath) => {
+        const normalized = normalizeEntryPath(entryPath);
+        return normalized === entry ||
+            (normalized.endsWith(`/${entry}`) && normalized.split('/').length === 2);
+    };
+}
+
+/**
+ * If everything ended up inside a single wrapper dir (as it does for npm
+ * tarballs and some release zips), move the contents up into the destination.
+ */
+async function unwrap(destination) {
+    if (fs.existsSync(path.join(destination, PACKAGE_JSON))) {
+        return;
+    }
+
+    const entries = await fs.promises.readdir(destination);
+    if (entries.length !== 1) {
+        return;
+    }
+
+    const wrapper = path.join(destination, entries[0]);
+    if (!fs.existsSync(path.join(wrapper, PACKAGE_JSON))) {
+        return;
+    }
+
+    const wrapped = await fs.promises.readdir(wrapper);
+    await Promise.all(wrapped.map(entry => fs.promises.rename(
+        path.join(wrapper, entry),
+        path.join(destination, entry)
+    )));
+    await fs.promises.rmdir(wrapper);
+}
+
 const utils = {
     /**
      * Whether the given path looks like an archive format we know how to read.
@@ -31,19 +70,22 @@ const utils = {
 
     /**
      * Extracts a Ghost release archive (an npm tarball or a zip file) into the
-     * destination directory, creating it if it doesn't exist.
+     * destination directory, creating it if it doesn't exist. Archives that wrap
+     * their contents in a single dir are unwrapped, so the destination always
+     * ends up with the release itself at the top level.
      */
     async extract(archivePath, destination) {
         await fs.promises.mkdir(destination, {recursive: true});
 
         if (isTarball(archivePath)) {
-            // strip the leading `package/` dir that npm tarballs are wrapped in
-            return tar.x({file: archivePath, cwd: destination, strip: 1});
+            await tar.x({file: archivePath, cwd: destination});
+        } else {
+            // zips are only used by `--zip` installs, so don't load the zip deps unless we need them
+            const zip = require('@tryghost/zip');
+            await zip.extract(archivePath, destination);
         }
 
-        // zips are only used by `--zip` installs, so don't load the zip deps unless we need them
-        const zip = require('@tryghost/zip');
-        return zip.extract(archivePath, destination);
+        return unwrap(destination);
     },
 
     /**
@@ -68,25 +110,36 @@ const utils = {
     },
 
     async readTarballEntry(archivePath, entry) {
-        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-cli-'));
+        const matches = entryMatcher(entry);
+        let contents = null;
 
-        try {
-            await tar.x({file: archivePath, cwd: tmpDir, strip: 1}, [`${TARBALL_ROOT}/${entry}`]);
+        await tar.t({
+            file: archivePath,
+            onReadEntry(tarEntry) {
+                if (contents || !matches(tarEntry.path)) {
+                    // entries have to be drained, otherwise the read stalls
+                    return tarEntry.resume();
+                }
 
-            const extracted = path.join(tmpDir, entry);
-            // tar resolves without error when nothing matches the entry list
-            return fs.existsSync(extracted) ? fs.readFileSync(extracted) : null;
-        } finally {
-            fs.rmSync(tmpDir, {recursive: true, force: true});
-        }
+                const chunks = [];
+                tarEntry.on('data', chunk => chunks.push(chunk));
+                tarEntry.on('end', () => {
+                    contents = Buffer.concat(chunks);
+                });
+            }
+        });
+
+        return contents;
     },
 
     async readZipEntry(archivePath, entry) {
         const StreamZip = require('node-stream-zip');
         const archive = new StreamZip.async({file: archivePath});
+        const matches = entryMatcher(entry);
 
         try {
-            return await archive.entry(entry) ? await archive.entryData(entry) : null;
+            const name = Object.keys(await archive.entries()).find(matches);
+            return name ? await archive.entryData(name) : null;
         } finally {
             await archive.close();
         }

--- a/test/unit/utils/archive-spec.js
+++ b/test/unit/utils/archive-spec.js
@@ -7,23 +7,47 @@ const {setupTestFolder, cleanupTestFolders} = require('../../utils/test-folder')
 const archive = require('../../../lib/utils/archive');
 const fixturePath = name => path.join(__dirname, '../../fixtures', name);
 
+let archiveCount = 0;
+
 /**
- * Builds an npm-style tarball (everything nested under `package/`) containing
- * the given files, and returns the path to it.
+ * Writes the given files into a fresh dir, optionally nested inside a wrapper
+ * dir, and returns the dir to archive along with the paths to add.
  */
-function createTarball(dir, name, files) {
-    const contents = path.join(dir, 'contents');
+function stageContents(dir, files, root) {
+    const contents = path.join(dir, `contents-${archiveCount += 1}`);
 
     Object.keys(files).forEach((file) => {
-        const target = path.join(contents, 'package', file);
+        const target = path.join(contents, root || '', file);
         fs.mkdirSync(path.dirname(target), {recursive: true});
         fs.writeFileSync(target, files[file]);
     });
 
+    return contents;
+}
+
+/**
+ * Builds a tarball containing the given files, nested under `root` (npm-style
+ * tarballs use `package/`), and returns the path to it.
+ */
+function createTarball(dir, name, files, root = 'package') {
+    const contents = stageContents(dir, files, root);
     const tarball = path.join(dir, name);
+
     // tar.c doesn't infer compression from the file name, so ask for it explicitly
-    tar.c({file: tarball, cwd: contents, sync: true, gzip: true}, ['package']);
+    tar.c({file: tarball, cwd: contents, sync: true, gzip: true}, fs.readdirSync(contents));
     return tarball;
+}
+
+/**
+ * Builds a zip containing the given files, optionally nested under `root`, and
+ * returns the path to it.
+ */
+async function createZip(dir, name, files, root = null) {
+    const contents = stageContents(dir, files, root);
+    const zipFile = path.join(dir, name);
+
+    await require('@tryghost/zip').compress(contents, zipFile);
+    return zipFile;
 }
 
 describe('Unit: Utils > archive', function () {
@@ -80,13 +104,64 @@ describe('Unit: Utils > archive', function () {
             expect(fs.existsSync(path.join(destination, 'package.json'))).to.be.true;
         });
 
-        it('extracts zip files as-is', async function () {
+        it('leaves tarballs without a wrapping dir alone', async function () {
+            const env = setupTestFolder();
+            const tarball = createTarball(env.dir, 'ghost.tgz', {
+                'package.json': '{"name":"ghost"}',
+                'index.js': 'module.exports = {};'
+            }, null);
+            const destination = path.join(env.dir, 'versions/1.0.0');
+
+            await archive.extract(tarball, destination);
+
+            expect(fs.readdirSync(destination).sort()).to.deep.equal(['index.js', 'package.json']);
+        });
+
+        it('extracts zip files without a wrapping dir as-is', async function () {
             const env = setupTestFolder();
             const destination = path.join(env.dir, 'versions/1.5.0');
 
             await archive.extract(fixturePath('ghostrelease.zip'), destination);
 
             expect(fs.readdirSync(destination)).to.deep.equal(['package.json']);
+        });
+
+        it('strips the wrapping dir from zip files', async function () {
+            const env = setupTestFolder();
+            const zipFile = await createZip(env.dir, 'ghost.zip', {
+                'package.json': '{"name":"ghost"}',
+                'index.js': 'module.exports = {};'
+            }, 'package');
+            const destination = path.join(env.dir, 'versions/1.5.0');
+
+            await archive.extract(zipFile, destination);
+
+            expect(fs.readdirSync(destination).sort()).to.deep.equal(['index.js', 'package.json']);
+            expect(fs.existsSync(path.join(destination, 'package'))).to.be.false;
+        });
+
+        it('strips a wrapping dir whatever it is called', async function () {
+            const env = setupTestFolder();
+            const zipFile = await createZip(env.dir, 'ghost.zip', {
+                'package.json': '{"name":"ghost"}'
+            }, 'Ghost-5.0.0');
+            const destination = path.join(env.dir, 'versions/5.0.0');
+
+            await archive.extract(zipFile, destination);
+
+            expect(fs.readdirSync(destination)).to.deep.equal(['package.json']);
+        });
+
+        it('leaves a single wrapping dir alone if it has no package.json', async function () {
+            const env = setupTestFolder();
+            const tarball = createTarball(env.dir, 'ghost.tgz', {
+                'guide.txt': 'not a package'
+            }, 'content');
+            const destination = path.join(env.dir, 'versions/1.0.0');
+
+            await archive.extract(tarball, destination);
+
+            expect(fs.readdirSync(destination)).to.deep.equal(['content']);
         });
 
         it('rejects if the archive cannot be read', async function () {
@@ -123,9 +198,39 @@ describe('Unit: Utils > archive', function () {
             expect(pkg).to.deep.equal({name: 'ghost', version: '1.5.0'});
         });
 
+        it('reads package.json from a tarball without a wrapping dir', async function () {
+            const env = setupTestFolder();
+            const tarball = createTarball(env.dir, 'ghost.tgz', {
+                'package.json': '{"name":"ghost","version":"1.5.0"}',
+                'index.js': 'module.exports = {};'
+            }, null);
+
+            const pkg = await archive.readPackageJson(tarball);
+            expect(pkg).to.deep.equal({name: 'ghost', version: '1.5.0'});
+        });
+
         it('reads package.json from a zip file', async function () {
             const pkg = await archive.readPackageJson(fixturePath('ghostrelease.zip'));
             expect(pkg).to.deep.equal({name: 'ghost', version: '1.5.0'});
+        });
+
+        it('reads package.json from a zip file with a wrapping dir', async function () {
+            const env = setupTestFolder();
+            const zipFile = await createZip(env.dir, 'ghost.zip', {
+                'package.json': '{"name":"ghost","version":"1.5.0"}'
+            }, 'package');
+
+            const pkg = await archive.readPackageJson(zipFile);
+            expect(pkg).to.deep.equal({name: 'ghost', version: '1.5.0'});
+        });
+
+        it('ignores a package.json nested deeper than the wrapping dir', async function () {
+            const env = setupTestFolder();
+            const tarball = createTarball(env.dir, 'ghost.tgz', {
+                'core/package.json': '{"name":"ghost-core"}'
+            }, 'package');
+
+            expect(await archive.readPackageJson(tarball)).to.be.null;
         });
 
         it('returns null if a tarball has no package.json', async function () {


### PR DESCRIPTION
no ref
- if we start publishing tarballs to github releases without the package prefix, the CLI needs to be able to handle both