### PR TITLE
Added a clear error when pnpm is too old for Ghost's pinned pnpm

### DIFF
--- a/lib/commands/doctor/checks/pnpm.js
+++ b/lib/commands/doctor/checks/pnpm.js
@@ -3,10 +3,15 @@ const {execa} = require('execa');
 const semver = require('semver');
 
 const {SystemError} = require('../../../errors');
+const {MINIMUM_PNPM_VERSION} = require('../../../utils/pnpm');
 
 const taskTitle = 'Checking pnpm installation';
 
 const GHOST_VERSION_WITH_PNPM = '6.30.0';
+// Ghost 6.62.0 is the first release to pin pnpm 12 in its `packageManager` field.
+// pnpm older than MINIMUM_PNPM_VERSION installs that pin without linking pnpm 12's
+// native binary, so the install later fails with a shell syntax error.
+const GHOST_VERSION_WITH_PNPM_12 = '6.62.0';
 
 async function checkPnpm() {
     try {
@@ -28,9 +33,28 @@ async function checkCorepack() {
     }
 }
 
-async function pnpmCheck(_, task) {
+function assertCanInstallPinnedPnpm(ctx, pnpmVersion) {
+    if (!semver.gte(ctx.version, GHOST_VERSION_WITH_PNPM_12)) {
+        return;
+    }
+
+    const installed = semver.coerce(pnpmVersion);
+    if (!installed || semver.gte(installed, MINIMUM_PNPM_VERSION)) {
+        return;
+    }
+
+    throw new SystemError({
+        message: `${chalk.red(`pnpm v${pnpmVersion} is too old to install the pnpm version Ghost v${ctx.version} requires.`)}`,
+        help: `Ghost v${ctx.version} pins pnpm 12, which only pnpm v${MINIMUM_PNPM_VERSION} and later can install correctly.`,
+        suggestion: 'npm install -g pnpm@latest',
+        task: taskTitle
+    });
+}
+
+async function pnpmCheck(ctx, task) {
     const pnpm = await checkPnpm();
     if (pnpm.available) {
+        assertCanInstallPinnedPnpm(ctx, pnpm.version);
         task.title = `${taskTitle} - found pnpm v${pnpm.version}`;
         return;
     }

--- a/lib/utils/pnpm.js
+++ b/lib/utils/pnpm.js
@@ -54,9 +54,14 @@ function isReadonlyStoreError(error) {
 // and `pnpm:4: parse error` (zsh).
 const PLACEHOLDER_BINARY_ERROR = /\/(?:pnpm|pnpx|pn|pnx): ?(?:line )?\d+: ?(?:[Ss]yntax|parse) error/;
 
+// The opening words of the placeholder file itself, in case a shell ever echoes it
+// rather than failing to parse it. Anchored on pnpm so that unrelated output that
+// happens to mention a placeholder isn't reported as a pnpm version problem.
+const PLACEHOLDER_BINARY_CONTENTS = 'This is a placeholder. pnpm';
+
 function isPlaceholderBinaryError(error) {
     const output = errorOutput(error);
-    return PLACEHOLDER_BINARY_ERROR.test(output) || output.includes('This is a placeholder');
+    return PLACEHOLDER_BINARY_ERROR.test(output) || output.includes(PLACEHOLDER_BINARY_CONTENTS);
 }
 
 function toPnpmError(error) {

--- a/lib/utils/pnpm.js
+++ b/lib/utils/pnpm.js
@@ -5,6 +5,12 @@ const which = require('which');
 const {PassThrough} = require('stream');
 const {ProcessError, SystemError} = require('../errors');
 
+// Recent Ghost releases pin pnpm 12 in their `packageManager` field. pnpm 12 ships
+// as a native binary that its npm package unpacks in an install script, and pnpm
+// older than this installs the pinned version without running that script - leaving
+// the package's placeholder text file in place of the binary.
+const MINIMUM_PNPM_VERSION = '11.10.0';
+
 function runPnpm(pnpmArgs, options) {
     const hasPnpm = which.sync('pnpm', {nothrow: true});
     if (hasPnpm) {
@@ -22,21 +28,35 @@ function runPnpm(pnpmArgs, options) {
     }));
 }
 
-function isCorepackSignatureError(error) {
-    const output = [
+function errorOutput(error) {
+    return [
         error.message,
         error.stderr,
         error.stdout,
         error.shortMessage,
         error.originalMessage
     ].filter(Boolean).join('\n');
+}
 
+function isCorepackSignatureError(error) {
+    const output = errorOutput(error);
     return output.includes('Cannot find matching keyid') && output.includes('corepack');
 }
 
 function isReadonlyStoreError(error) {
-    const output = [error.stderr, error.stdout].filter(Boolean).join('\n');
+    const output = errorOutput(error);
     return output.includes('attempt to write a readonly database') || output.includes('SQLITE_READONLY');
+}
+
+// The placeholder left behind by an incomplete pnpm 12 install isn't a script, so
+// the shell that ends up running it fails to parse it. Each shell words that
+// differently: `pnpm: 4: Syntax error` (dash), `pnpm: line 4: syntax error` (bash)
+// and `pnpm:4: parse error` (zsh).
+const PLACEHOLDER_BINARY_ERROR = /\/(?:pnpm|pnpx|pn|pnx): ?(?:line )?\d+: ?(?:[Ss]yntax|parse) error/;
+
+function isPlaceholderBinaryError(error) {
+    const output = errorOutput(error);
+    return PLACEHOLDER_BINARY_ERROR.test(output) || output.includes('This is a placeholder');
 }
 
 function toPnpmError(error) {
@@ -49,6 +69,14 @@ function toPnpmError(error) {
             message: 'Corepack could not verify pnpm because its package-signing keys are out of date.',
             help: 'Update Corepack, enable it, and activate pnpm before running the Ghost command again.',
             suggestion: 'npm install -g corepack@latest && corepack enable'
+        });
+    }
+
+    if (isPlaceholderBinaryError(error)) {
+        return new SystemError({
+            message: 'The pnpm version this version of Ghost requires was installed without its native binary, so it cannot run.',
+            help: `pnpm v${MINIMUM_PNPM_VERSION} or later is needed to install pnpm 12. Update pnpm, then run the command again.`,
+            suggestion: 'npm install -g pnpm@latest'
         });
     }
 
@@ -87,3 +115,5 @@ module.exports = function pnpm(pnpmArgs, options) {
 
     return output;
 };
+
+module.exports.MINIMUM_PNPM_VERSION = MINIMUM_PNPM_VERSION;

--- a/test/unit/commands/doctor/checks/pnpm-spec.js
+++ b/test/unit/commands/doctor/checks/pnpm-spec.js
@@ -1,0 +1,85 @@
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+const {SystemError} = require('../../../../../lib/errors');
+
+const modulePath = '../../../../../lib/commands/doctor/checks/pnpm';
+
+function setup(execa) {
+    return proxyquire(modulePath, {execa: {execa}});
+}
+
+function versionOf(command, versions) {
+    return versions[command] ? Promise.resolve({stdout: `${versions[command]}\n`}) : Promise.reject(new Error(`${command} not found`));
+}
+
+describe('Unit: Doctor Checks > pnpm', function () {
+    describe('enabled', function () {
+        const pnpmCheck = require(modulePath);
+
+        it('returns false when no version is in context', function () {
+            expect(pnpmCheck.enabled({})).to.be.false;
+        });
+
+        it('returns false for Ghost versions that do not use pnpm', function () {
+            expect(pnpmCheck.enabled({version: '6.29.0'})).to.be.false;
+        });
+
+        it('returns true for Ghost versions that use pnpm', function () {
+            expect(pnpmCheck.enabled({version: '6.30.0'})).to.be.true;
+        });
+    });
+
+    describe('task', function () {
+        it('passes when pnpm is new enough for the pinned pnpm version', async function () {
+            const execa = sinon.stub().callsFake(cmd => versionOf(cmd, {pnpm: '11.10.0'}));
+            const task = {};
+
+            await setup(execa).task({version: '6.62.0'}, task);
+            expect(task.title).to.contain('found pnpm v11.10.0');
+        });
+
+        it('errors when pnpm is too old to install the pnpm version Ghost pins', async function () {
+            const execa = sinon.stub().callsFake(cmd => versionOf(cmd, {pnpm: '10.33.0'}));
+
+            const error = await setup(execa).task({version: '6.62.0'}, {}).then(() => null, err => err);
+
+            expect(error).to.be.an.instanceOf(SystemError);
+            expect(error.message).to.contain('pnpm v10.33.0 is too old');
+            expect(error.options.suggestion).to.equal('npm install -g pnpm@latest');
+        });
+
+        it('allows an older pnpm for Ghost versions that do not pin pnpm 12', async function () {
+            const execa = sinon.stub().callsFake(cmd => versionOf(cmd, {pnpm: '10.33.0'}));
+            const task = {};
+
+            await setup(execa).task({version: '6.61.0'}, task);
+            expect(task.title).to.contain('found pnpm v10.33.0');
+        });
+
+        it('does not block on a pnpm version it cannot parse', async function () {
+            const execa = sinon.stub().callsFake(cmd => versionOf(cmd, {pnpm: 'unknown'}));
+            const task = {};
+
+            await setup(execa).task({version: '6.62.0'}, task);
+            expect(task.title).to.contain('found pnpm vunknown');
+        });
+
+        it('falls back to corepack when pnpm is not installed', async function () {
+            const execa = sinon.stub().callsFake(cmd => versionOf(cmd, {corepack: '0.34.6'}));
+            const task = {};
+
+            await setup(execa).task({version: '6.62.0'}, task);
+            expect(task.title).to.contain('found corepack v0.34.6');
+        });
+
+        it('errors when neither pnpm nor corepack is available', async function () {
+            const execa = sinon.stub().callsFake(cmd => versionOf(cmd, {}));
+
+            const error = await setup(execa).task({version: '6.62.0'}, {}).then(() => null, err => err);
+
+            expect(error).to.be.an.instanceOf(SystemError);
+            expect(error.message).to.contain('pnpm is not installed');
+        });
+    });
+});

--- a/test/unit/utils/pnpm-spec.js
+++ b/test/unit/utils/pnpm-spec.js
@@ -110,6 +110,58 @@ describe('Unit: pnpm', function () {
         });
     });
 
+    it('returns a helpful system error when the pinned pnpm was installed without its binary', function () {
+        const execa = sinon.stub().rejects({
+            message: 'Command failed with exit code 2: pnpm install --prod',
+            stderr: '/home/ghost/.local/share/pnpm/.tools/pnpm/12.2.1/bin/pnpm: 4: Syntax error: ")" unexpected'
+        });
+        const pnpm = setup({execa});
+
+        return pnpm(['install']).then(() => {
+            expect(false, 'Promise should have rejected').to.be.true;
+        }).catch((error) => {
+            expect(error).to.be.an.instanceOf(SystemError);
+            expect(error.message).to.match(/without its native binary/);
+            expect(error.options.help).to.contain('11.10.0');
+            expect(error.options.suggestion).to.equal('npm install -g pnpm@latest');
+        });
+    });
+
+    it('detects the placeholder pnpm binary across shells', function () {
+        const stderrs = [
+            '/root/.local/share/pnpm/.tools/pnpm/12.2.1/bin/pnpm: 4: Syntax error: ")" unexpected',
+            '/usr/local/bin/pnpm: line 4: syntax error near unexpected token `)\'',
+            '/usr/local/bin/pnpm:4: parse error near `)\'',
+            'This is a placeholder. pnpm\'s native binary replaces this file'
+        ];
+
+        return Promise.all(stderrs.map((stderr) => {
+            const execa = sinon.stub().rejects({message: 'Command failed', stderr});
+            const pnpm = setup({execa});
+
+            return pnpm(['install']).then(() => {
+                expect(false, `Promise should have rejected for: ${stderr}`).to.be.true;
+            }, (error) => {
+                expect(error, stderr).to.be.an.instanceOf(SystemError);
+                expect(error.message, stderr).to.match(/without its native binary/);
+            });
+        }));
+    });
+
+    it('does not mistake an unrelated syntax error for a broken pnpm binary', function () {
+        const execa = sinon.stub().rejects({
+            message: 'Command failed with exit code 1: pnpm install --prod \'--store-dir=/var/www/ghost/.pnpm-store\'',
+            stderr: '/var/www/ghost/versions/6.62.0/node_modules/.pnpm/sharp@0.34.0/install.js:12\nSyntaxError: Unexpected token'
+        });
+        const pnpm = setup({execa});
+
+        return pnpm(['install']).then(() => {
+            expect(false, 'Promise should have rejected').to.be.true;
+        }).catch((error) => {
+            expect(error).to.be.an.instanceOf(ProcessError);
+        });
+    });
+
     it('returns a helpful system error when the pnpm store is read-only', function () {
         const execa = sinon.stub().rejects({
             message: 'Command failed: pnpm install',

--- a/test/unit/utils/pnpm-spec.js
+++ b/test/unit/utils/pnpm-spec.js
@@ -148,6 +148,20 @@ describe('Unit: pnpm', function () {
         }));
     });
 
+    it('does not mistake unrelated placeholder output for a broken pnpm binary', function () {
+        const execa = sinon.stub().rejects({
+            message: 'Command failed with exit code 1: pnpm install --prod',
+            stderr: 'node-pre-gyp WARN This is a placeholder build, run `make` to replace it'
+        });
+        const pnpm = setup({execa});
+
+        return pnpm(['install']).then(() => {
+            expect(false, 'Promise should have rejected').to.be.true;
+        }).catch((error) => {
+            expect(error).to.be.an.instanceOf(ProcessError);
+        });
+    });
+
     it('does not mistake an unrelated syntax error for a broken pnpm binary', function () {
         const execa = sinon.stub().rejects({
             message: 'Command failed with exit code 1: pnpm install --prod \'--store-dir=/var/www/ghost/.pnpm-store\'',


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost-CLI/issues/2335

Ghost 6.62.0 is the first release to pin pnpm 12 in its `packageManager`
field. pnpm 12 ships as a native binary that its npm package unpacks in an
install script, and pnpm older than 11.10.0 provisions the pinned version
without running that script - leaving the package's placeholder text file
in place of the binary. `ghost update` then ran the placeholder and failed
with `Syntax error: ")" unexpected`, which gives no hint at what to do.

- the doctor check now fails before Ghost is downloaded when the installed
  pnpm is older than 11.10.0 and the target Ghost version pins pnpm 12
- if the placeholder is reached anyway (e.g. it was left behind by an
  earlier run), the shell parse error is translated into a system error
  that names the cause and the fix

Corepack is unaffected - it downloads pnpm 12's platform binary directly -
so the corepack fallback is left alone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Joya1LEPZhYpSftjhuM82