### PR TITLE
🐛 Fixed config field validation during explicit field setting

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -2,6 +2,11 @@
 const Command = require('../command');
 const options = require('../tasks/configure/options');
 
+// Maps a config path (e.g. `server.port`) to the option that manages it
+const optionsByConfigPath = new Map(
+    Object.entries(options).map(([name, option]) => [option.configPath || name, option])
+);
+
 class ConfigCommand extends Command {
     static configureSubcommands(commandName, commandArgs, extensions) {
         return commandArgs.command({
@@ -35,8 +40,10 @@ class ConfigCommand extends Command {
             return;
         } else if (key) {
             // setter
-            this.instance.config.set(key, value).save();
-            this.ui.log(`Successfully set '${key}' to '${value}'`, 'green');
+            const parsed = await this.parseValue(key, value);
+
+            this.instance.config.set(key, parsed).save();
+            this.ui.log(`Successfully set '${key}' to '${parsed}'`, 'green');
 
             // If the instance is running, we want to remind the user to restart
             // it so the new config can take effect. The isRunning check is only
@@ -57,6 +64,33 @@ class ConfigCommand extends Command {
 
         const configure = require('../tasks/configure');
         await configure(this.ui, this.instance.config, argv, this.system.environment, false);
+    }
+
+    async parseValue(key, value) {
+        const option = optionsByConfigPath.get(key);
+
+        if (!option) {
+            return value;
+        }
+
+        const parsed = option.transform ? option.transform(value) : value;
+
+        if (!option.validate) {
+            return parsed;
+        }
+
+        const result = await option.validate(parsed);
+
+        if (result !== true) {
+            const {ConfigError} = require('../errors');
+            throw new ConfigError({
+                config: {[key]: parsed},
+                message: result,
+                environment: this.system.environment
+            });
+        }
+
+        return parsed;
     }
 }
 

--- a/test/unit/commands/config-spec.js
+++ b/test/unit/commands/config-spec.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 
 const Config = require('../../../lib/utils/config');
+const errors = require('../../../lib/errors');
 
 const modulePath = '../../../lib/commands/config';
 
@@ -87,6 +88,87 @@ describe('Unit: Command > Config', function () {
             expect(saveStub.calledOnce).to.be.true;
             expect(setStub.args[0]).to.deep.equal(['url', 'http://localhost:2368']);
             expect(log.calledOnce).to.be.true;
+        });
+
+        it('transforms value before setting it', async function () {
+            const ConfigCommand = fake();
+            const checkEnvironment = sinon.stub();
+            const config = new Config('config.json');
+            const getInstance = sinon.stub().returns({checkEnvironment, config});
+            const setStub = sinon.stub(config, 'set').returns(config);
+            const saveStub = sinon.stub(config, 'save');
+            const log = sinon.stub();
+
+            const cmd = new ConfigCommand({log}, {getInstance});
+
+            await cmd.run({key: 'url', value: 'LoveGhost.com'});
+            expect(setStub.args[0]).to.deep.equal(['url', 'https://loveghost.com']);
+            expect(saveStub.calledOnce).to.be.true;
+            expect(log.args[0][0]).to.contain('https://loveghost.com');
+        });
+
+        it('validates value before setting it', async function () {
+            const ConfigCommand = fake();
+            const checkEnvironment = sinon.stub();
+            const config = new Config('config.json');
+            const getInstance = sinon.stub().returns({checkEnvironment, config});
+            const setStub = sinon.stub(config, 'set').returns(config);
+            const saveStub = sinon.stub(config, 'save');
+            const log = sinon.stub();
+
+            const cmd = new ConfigCommand({log}, {getInstance, environment: 'testing'});
+
+            try {
+                await cmd.run({key: 'url', value: 'not-a-url'});
+                expect.fail('run should have errored');
+            } catch (error) {
+                expect(error).to.be.an.instanceof(errors.ConfigError);
+                expect(error.options.config).to.deep.equal({url: 'https://not-a-url'});
+                expect(error.options.environment).to.equal('testing');
+            }
+
+            expect(setStub.called).to.be.false;
+            expect(saveStub.called).to.be.false;
+            expect(log.called).to.be.false;
+        });
+
+        it('validates using the option matching the config path', async function () {
+            const ConfigCommand = fake();
+            const checkEnvironment = sinon.stub();
+            const config = new Config('config.json');
+            const getInstance = sinon.stub().returns({checkEnvironment, config});
+            const setStub = sinon.stub(config, 'set').returns(config);
+            const saveStub = sinon.stub(config, 'save');
+            const log = sinon.stub();
+
+            const cmd = new ConfigCommand({log}, {getInstance, environment: 'testing'});
+
+            try {
+                await cmd.run({key: 'database.client', value: 'postgres'});
+                expect.fail('run should have errored');
+            } catch (error) {
+                expect(error).to.be.an.instanceof(errors.ConfigError);
+                expect(error.options.message).to.equal('Invalid database type. Supported types are mysql and sqlite3');
+            }
+
+            expect(setStub.called).to.be.false;
+            expect(saveStub.called).to.be.false;
+        });
+
+        it('doesn\'t validate keys without a matching option', async function () {
+            const ConfigCommand = fake();
+            const checkEnvironment = sinon.stub();
+            const config = new Config('config.json');
+            const getInstance = sinon.stub().returns({checkEnvironment, config});
+            const setStub = sinon.stub(config, 'set').returns(config);
+            const saveStub = sinon.stub(config, 'save');
+            const log = sinon.stub();
+
+            const cmd = new ConfigCommand({log}, {getInstance});
+
+            await cmd.run({key: 'paths.contentPath', value: '/var/www/ghost/content'});
+            expect(setStub.args[0]).to.deep.equal(['paths.contentPath', '/var/www/ghost/content']);
+            expect(saveStub.calledOnce).to.be.true;
         });
 
         it('calls configure if key and value aren\'t provided', async function () {


### PR DESCRIPTION
no ref
- validate/transform values when running `ghost config set <key> <value>`, just like we do during the normal prompt/argv-driven config command